### PR TITLE
Issue #212 [Title] Add support for anchors.

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TitleImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TitleImpl.java
@@ -75,6 +75,9 @@ public class TitleImpl implements Title {
     @ValueMapValue(optional = true)
     private String linkURL;
 
+    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    private String id;
+
     /**
      * The {@link com.adobe.cq.wcm.core.components.internal.Utils.Heading} object for the type of this title.
      */
@@ -84,6 +87,13 @@ public class TitleImpl implements Title {
     private void initModel() {
         if (StringUtils.isBlank(title)) {
             title = StringUtils.defaultIfEmpty(currentPage.getPageTitle(), currentPage.getTitle());
+        }
+
+        if (StringUtils.isBlank(id) && title != null) {
+            id = title + "-" + String.valueOf(Math.abs(resource.getPath().hashCode() - 1));
+        }
+        if (id != null) {
+            id = id.replaceAll("\\s", "").replaceAll("\\u00a0", "");
         }
 
         if (heading == null) {
@@ -125,6 +135,11 @@ public class TitleImpl implements Title {
     @Override
     public boolean isLinkDisabled() {
         return linkDisabled;
+    }
+
+    @Override
+    public String getId() {
+        return id;
     }
 
     @Nonnull

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Title.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Title.java
@@ -86,6 +86,16 @@ public interface Title extends ComponentExporter {
     }
 
     /**
+     * Returns an unique identifier for this field, if one was not set, else returns set ID.
+     *
+     * @return an unique identifier/manual ID for the field
+     * @since com.adobe.cq.wcm.core.components.models 12.4.0
+     */
+    default String getId() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * @see ComponentExporter#getExportedType()
      * @since com.adobe.cq.wcm.core.components.models 12.2.0
      */

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TitleImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TitleImplTest.java
@@ -48,6 +48,7 @@ public class TitleImplTest {
     private static final String TITLE_WRONGTYPE = TEST_PAGE + "/jcr:content/par/title-wrongtype";
     private static final String TITLE_RESOURCE_JCR_TITLE_V2 = TEST_PAGE + "/jcr:content/par/title-jcr-title-v2";
     private static final String TITLE_RESOURCE_JCR_TITLE_LINK_V2 = TEST_PAGE + "/jcr:content/par/title-jcr-title-link-v2";
+    private static final String TITLE_RESOURCE_JCR_TITLE_ID_V2 = TEST_PAGE + "/jcr:content/par/title-jcr-title-id-v2";
 
     @ClassRule
     public static final AemContext CONTEXT = CoreComponentTestContext.createContext(TEST_BASE, TEST_PAGE);
@@ -112,6 +113,13 @@ public class TitleImplTest {
         }}));
         Title title = getTitleUnderTest(TITLE_RESOURCE_JCR_TITLE_LINK_V2, mockStyle);
         Utils.testJSONExport(title, Utils.getTestExporterJSONPath(TEST_BASE, "title-linkdisabled"));
+    }
+
+    @Test
+    public void testGetId() {
+        Title title = getTitleUnderTest(TITLE_RESOURCE_JCR_TITLE_ID_V2);
+        assertEquals("HelloWorld", title.getId());
+        Utils.testJSONExport(title, Utils.getTestExporterJSONPath(TEST_BASE, TITLE_RESOURCE_JCR_TITLE_ID_V2));
     }
 
     private Title getTitleUnderTest(String resourcePath) {

--- a/bundles/core/src/test/resources/title/exporter-title-jcr-title-id-v2.json
+++ b/bundles/core/src/test/resources/title/exporter-title-jcr-title-id-v2.json
@@ -1,6 +1,5 @@
 {
-    "text": "Hello World",
-    "id": "HelloWorld-259658182",
+    "id": "HelloWorld",
     "linkDisabled": false,
     ":type": "core/wcm/components/title/v2/title"
 }

--- a/bundles/core/src/test/resources/title/exporter-title-jcr-title-type.json
+++ b/bundles/core/src/test/resources/title/exporter-title-jcr-title-type.json
@@ -1,6 +1,7 @@
 {
     "type": "h2",
     "text": "Hello World",
+    "id": "HelloWorld-423396552",
     "linkDisabled": false,
     ":type": "core/wcm/components/title/v1/title"
 }

--- a/bundles/core/src/test/resources/title/exporter-title-jcr-title.json
+++ b/bundles/core/src/test/resources/title/exporter-title-jcr-title.json
@@ -1,5 +1,6 @@
 {
     "text": "Hello World",
+    "id": "HelloWorld-1969785453",
     "linkDisabled": false,
     ":type": "core/wcm/components/title/v1/title"
 }

--- a/bundles/core/src/test/resources/title/test-content.json
+++ b/bundles/core/src/test/resources/title/test-content.json
@@ -65,6 +65,15 @@
                 "jcr:created"       : "Wed Jan 13 2016 15:58:25 GMT+0100",
                 "jcr:lastModified"  : "Wed Jan 13 2016 16:14:51 GMT+0100",
                 "sling:resourceType": "core/wcm/components/title/v2/title"
+            },
+            "title-jcr-title-id-v2"     : {
+                "jcr:primaryType"   : "nt:unstructured",
+                "jcr:createdBy"     : "admin",
+                "id"                : "Hello World",
+                "jcr:lastModifiedBy": "admin",
+                "jcr:created"       : "Wed Jan 13 2016 15:58:25 GMT+0100",
+                "jcr:lastModified"  : "Wed Jan 13 2016 16:14:51 GMT+0100",
+                "sling:resourceType": "core/wcm/components/title/v2/title"
             }
         }
     }

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_dialog/.content.xml
@@ -107,6 +107,12 @@
                                                     sling:resourceType="granite/ui/components/foundation/renderconditions/simple"
                                                     expression="${!cqDesign.linkDisabled}"/>
                                             </linkURL>
+                                            <id
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="Leave empty to use a auto generated ID. Spaces are automatically removed in manually entered IDs."
+                                                fieldLabel="ID"
+                                                name="./id"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/title.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/title.html
@@ -17,7 +17,7 @@
      data-sly-use.title="com.adobe.cq.wcm.core.components.models.Title"
      data-sly-use.template="core/wcm/components/commons/v1/templates.html"
      data-sly-test.text="${title.text}">
-    <h1 class="cmp-title__text" data-sly-element="${title.type}">
+    <h1 class="cmp-title__text" id="${title.id}" data-sly-element="${title.type}">
         <a data-sly-unwrap="${!title.linkURL || title.linkDisabled}" class="cmp-title__link" href="${title.linkURL}">${text}</a>
     </h1>
 </div>

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-cases/Title/v1/Title.js
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-cases/Title/v1/Title.js
@@ -267,4 +267,54 @@ window.CQ.CoreComponentsIT.Title.v1 = window.CQ.CoreComponentsIT.Title.v1 || {}
         ;
     };
 
+    /**
+     * Test: Check if the format of auto generated id is correct.
+     */
+    title.tcCheckAutoId = function(tcExecuteBeforeTest, tcExecuteAfterTest) {
+        return new h.TestCase("Check if automatic id is generated correctly", {
+            execBefore: tcExecuteBeforeTest,
+            execAfter: tcExecuteAfterTest })
+
+            // open the configuration dialog
+            .execTestCase(c.tcOpenConfigureDialog("cmpPath"))
+            // add some example text
+            .fillInput("[name='./jcr:title']", "Content name")
+            // close the dialog
+            .execTestCase(c.tcSaveConfigureDialog)
+            // switch to content frame
+            .config.changeContext(c.getContentFrame)
+
+            // check if id is rendered correctly
+            .assert.isTrue(function() {
+                var selector = "h1.cmp-title__text";
+                return h.find(selector).attr("id").startsWith("Contentname");
+            })
+        ;
+    };
+
+    /**
+     * Test: Check manually entered id.
+     */
+    title.tcCheckManualId = function(tcExecuteBeforeTest, tcExecuteAfterTest) {
+        return new h.TestCase("Check the manually entered id", {
+            execBefore: tcExecuteBeforeTest,
+            execAfter: tcExecuteAfterTest })
+
+            // open the configuration dialog
+            .execTestCase(c.tcOpenConfigureDialog("cmpPath"))
+            // add some example text
+            .fillInput("[name='./id']", "Content name")
+            // close the dialog
+            .execTestCase(c.tcSaveConfigureDialog)
+            // switch to content frame
+            .config.changeContext(c.getContentFrame)
+
+            // check if id is rendered correctly
+            .assert.isTrue(function() {
+                var selector = "h1.cmp-title__text";
+                return h.find(selector).attr("id") === "Contentname";
+            })
+        ;
+    };
+
 }(hobs, jQuery));

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-suites/Title/v2/Title.js
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-suites/Title/v2/Title.js
@@ -45,6 +45,8 @@
         .addTestCase(titleV1.tcCheckExistenceOfTypesUsingPolicy(tcExecuteBeforeTest, tcExecuteAfterTest, "/title", "core-component/components",
             c.policyPath, c.policyAssignmentPath))
         .addTestCase(titleV1.tcCheckExistenceOfOneTypeUsingPolicy(tcExecuteBeforeTest, tcExecuteAfterTest, "/title", "core-component/components",
-            c.policyPath, c.policyAssignmentPath));
+            c.policyPath, c.policyAssignmentPath))
+        .addTestCase(titleV1.tcCheckAutoId(tcExecuteBeforeTest, tcExecuteAfterTest))
+        .addTestCase(titleV1.tcCheckManualId(tcExecuteBeforeTest, tcExecuteAfterTest));
 
 }(hobs, jQuery));


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #212 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      | Yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
* User can manually enter an ID, spaces will automatically be removed.
* If ID field is empty, ID is generated as follows- *"Title's Text without spaces"* + *"-hash of component's unique path"*. I think this improves human readability.
* IDs are automatically updated if the component is moved to a new path.
* Didn't provide an option in Design Dialog to disable IDs (would do so if required).