### PR TITLE
[Style System] Dialog style tab

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:icon="brush"
+    jcr:primaryType="cq:Component"
+    jcr:title="Dialog Style Selector (v1)"
+    jcr:description="Makes style system options for a component available in the component dialog"
+    componentGroup=".core-wcm-dialog"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/README.md
@@ -1,0 +1,41 @@
+<!--
+Copyright 2017 Adobe Systems Incorporated
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+Dialog Style Selector (v1)
+====
+Component for TouchUI authoring dialogs written in HTL that adds the style system options from a component's policy to the component dialog.
+
+## Features
+* Consolidates authoring options
+* Checkboxes for multiple-selection styles
+* Radio buttons for single-selection styles
+
+### Use Object
+The Image component uses the `com.adobe.cq.wcm.core.components.models.Image` Sling Model as its Use-object.
+
+## Client Libraries
+The component provides a `core.wcm.components.image.v1` client library category that contains a recommended base
+CSS styling. It should be added to a relevant site client library using the `embed` property.
+
+It also provides a `core.wcm.components.image.v1.editor` editor client library category that includes
+JavaScript handling for dialog interaction. It is already included by its edit dialog.
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v1
+* **Compatibility**: AEM 6.3
+* **Status**: production-ready
+* **Documentation**: [https://www.adobe.com/go/aem\_cmp\_image\_v1](https://www.adobe.com/go/aem_cmp_image_v1)
+

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/README.md
@@ -23,19 +23,55 @@ Component for TouchUI authoring dialogs written in HTL that adds the style syste
 * Radio buttons for single-selection styles
 
 ### Use Object
-The Image component uses the `com.adobe.cq.wcm.core.components.models.Image` Sling Model as its Use-object.
+The Dialog Style Selector component uses the `com.adobe.cq.editor.model.StyleSelector` Sling Model as its Use-object.
+
+## Dialog Usage
+The component can be included in in a dialog by referencing its resource type. An example dialog:
+```
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" 
+          xmlns:jcr="http://www.jcp.org/jcr/1.0" 
+          xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:primaryType="nt:unstructured"
+          jcr:title="Some Component"
+          sling:resourceType="cq/gui/components/authoring/dialog">
+    <content
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <tabs
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/tabs">
+                <items jcr:primaryType="nt:unstructured">
+                    <styles
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Styles"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <style
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="core/wcm/components/dialog/style/v1/style"/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </styles>
+                </items>
+            </tabs>
+        </items>
+    </content>
+</jcr:root>
+```
 
 ## Client Libraries
-The component provides a `core.wcm.components.image.v1` client library category that contains a recommended base
-CSS styling. It should be added to a relevant site client library using the `embed` property.
-
-It also provides a `core.wcm.components.image.v1.editor` editor client library category that includes
-JavaScript handling for dialog interaction. It is already included by its edit dialog.
-
-## Information
-* **Vendor**: Adobe
-* **Version**: v1
-* **Compatibility**: AEM 6.3
-* **Status**: production-ready
-* **Documentation**: [https://www.adobe.com/go/aem\_cmp\_image\_v1](https://www.adobe.com/go/aem_cmp_image_v1)
-
+The component extends the `cq.authoring.dialog` client library category. 

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/clientlibs/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/clientlibs/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/clientlibs/editor/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/clientlibs/editor/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[cq.authoring.dialog]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/clientlibs/editor/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/clientlibs/editor/js.txt
@@ -1,0 +1,2 @@
+#base=js
+dialog.js

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/clientlibs/editor/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/clientlibs/editor/js.txt
@@ -1,2 +1,18 @@
+###############################################################################
+# Copyright 2018 Adobe Systems Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
 #base=js
 dialog.js

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/clientlibs/editor/js/dialog.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/clientlibs/editor/js/dialog.js
@@ -1,0 +1,14 @@
+(function(document, $, Coral) {
+    "use strict";
+
+    $(document).on("click", ".cq-dialog-submit", function(e) {
+    	$(".dialog-style-system__hidden").empty();
+        $(".dialog-style-system__item input:checked").each(function(i, element){
+        	var parent = element.parentNode;
+        	var styleId = parent.id;
+			var styleIdInput = $('<input/>').attr({type: 'hidden', name: './cq:styleIds', value: styleId});
+			$(".dialog-style-system__hidden").append(styleIdInput);
+        });
+    });
+
+})(document, Granite.$, Coral);

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/clientlibs/editor/js/dialog.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/clientlibs/editor/js/dialog.js
@@ -1,13 +1,28 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2017 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 (function(document, $, Coral) {
     "use strict";
 
     $(document).on("click", ".cq-dialog-submit", function(e) {
-    	$(".dialog-style-system__hidden").empty();
-        $(".dialog-style-system__item input:checked").each(function(i, element){
-        	var parent = element.parentNode;
-        	var styleId = parent.id;
-			var styleIdInput = $('<input/>').attr({type: 'hidden', name: './cq:styleIds', value: styleId});
-			$(".dialog-style-system__hidden").append(styleIdInput);
+        $(".dialog-style-system__hidden").empty();
+        $(".dialog-style-system__item input:checked").each(function(i, element) {
+            var parent = element.parentNode;
+            var styleId = parent.id;
+            var styleIdInput = $("<input/>").attr({ type: "hidden", name: "./cq:styleIds", value: styleId });
+            $(".dialog-style-system__hidden").append(styleIdInput);
         });
     });
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/style.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/style.html
@@ -1,5 +1,4 @@
-<div data-sly-use.styles="${'com.adobe.cq.editor.model.StyleSelector' @ path=request.requestPathInfo.suffix}"
-     data-editor-styleselector-item-id="${styles.path}" class="dialog-style-system">
+<div data-sly-use.styles="${'com.adobe.cq.editor.model.StyleSelector' @ path=request.requestPathInfo.suffix}" class="dialog-style-system">
     <div data-sly-list.group="${styles.styleGroups}">
         <section class="coral-Form-fieldset">
             <div class="coral-Form-fieldwrapper">

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/style.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/style.html
@@ -1,3 +1,18 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2016 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.styles="${'com.adobe.cq.editor.model.StyleSelector' @ path=request.requestPathInfo.suffix}" class="dialog-style-system">
     <div data-sly-list.group="${styles.styleGroups}">
         <section class="coral-Form-fieldset">

--- a/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/style.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/dialog/style/v1/style/style.html
@@ -1,0 +1,38 @@
+<div data-sly-use.styles="${'com.adobe.cq.editor.model.StyleSelector' @ path=request.requestPathInfo.suffix}"
+     data-editor-styleselector-item-id="${styles.path}" class="dialog-style-system">
+    <div data-sly-list.group="${styles.styleGroups}">
+        <section class="coral-Form-fieldset">
+            <div class="coral-Form-fieldwrapper">
+                <label class="coral-Form-fieldlabel" id="${groupList.index}-group">
+                    ${group.label}
+                </label>
+                <div class="coral-Form-field coral-CheckboxGroup coral-CheckboxGroup--vertical" data-sly-test.multiple="${group.multiple}" data-sly-list.style="${group.styles}">
+                    <coral-checkbox class="coral-Form-field dialog-style-system__item" id="${style.id}" checked="${style.selected}" labelledby="${groupList.index}-group">
+                        ${style.label}
+                    </coral-checkbox>
+                </div>
+                <sly data-sly-test="${!multiple}">
+                    <div class="coral-Form-field coral-RadioGroup coral-RadioGroup--vertical">
+                        <coral-radio class="coral-Form-field" name="${groupList.index}-group-radio" id="${groupList.index}-group-none" labelledby="${groupList.index}-group">
+                            None
+                        </coral-radio>
+                        <sly data-sly-list.style="${group.styles}">
+                            <coral-radio class="coral-Form-field dialog-style-system__item" name="${groupList.index}-group-radio" id="${style.id}" checked="${style.selected}" labelledby="${groupList.index}-group">
+                                ${style.label}
+                            </coral-radio>
+                        </sly>
+                    </div>
+                </sly>
+            </div>
+        </section>
+    </div>
+
+    <div display="none" class="dialog-style-system__hidden">
+        <input data-sly-repeat.style="${styles.appliedStyles}" type="hidden" name="./cq:styleIds" value="${style.id}" data-editor-styleselector-id-input="true"/>
+    </div>
+
+    <input type="hidden" name="./cq:styleIds@Delete"/>
+    <input type="hidden" name="./cq:styleIds@TypeHint" value="String[]"/>
+    <input type="hidden" name="./jcr:lastModified"/>
+    <input type="hidden" name="./jcr:lastModifiedBy"/>
+</div>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | N/A (no new model class)
| Documentation Provided   | Yes (README.md)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Added a component for use in touch ui authoring dialogs that brings the existing style system menu into the dialog. This differs a bit from everything else that exists in the repo currently (is an authoring component rather than an end-user one, relies on an external model from com.adobe.cq.editor.model) and I wasn't entirely sure where to put it.