### PR TITLE
avoid removing extension bundles from install folder

### DIFF
--- a/all/src/content/META-INF/vault/filter.xml
+++ b/all/src/content/META-INF/vault/filter.xml
@@ -15,5 +15,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <workspaceFilter version="1.0">
-    <filter root="/apps/core/wcm/install"/>
+    <filter root="/apps/core/wcm/install">
+        <exclude pattern="/apps/core/wcm/install/core\.wcm\.components\.extension\..*" />
+    </filter>
 </workspaceFilter>


### PR DESCRIPTION
 when (re)installing all package after extension package was installed.

steps to reproduce the problem:
1. Install "all" package from core components
2. Install "extension" package
3. Install "all" package again

expected: both core components bundle and content fragment extension bundle should be deployed in OSGi
actual: the content fragment extension bundle that was deployed with step 2 was deleted from repository in step 3

this PR adds an filter exclusion rule to avoid this.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | n/a
| Documentation Provided   | n/a
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0


