### PR TITLE
#326 #327 #361 [Carousel] Pause/play enhancements

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/CarouselImpl.java
@@ -67,6 +67,8 @@ public class CarouselImpl extends AbstractContainerImpl implements Carousel {
     }
 
     @Override
-    public boolean getAutopauseDisabled() { return autopauseDisabled; }
+    public boolean getAutopauseDisabled() {
+        return autopauseDisabled;
+    }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/CarouselImpl.java
@@ -47,11 +47,13 @@ public class CarouselImpl extends AbstractContainerImpl implements Carousel {
 
     protected boolean autoplay;
     protected Long delay;
+    protected boolean autopauseDisabled;
 
     @PostConstruct
     protected void initModel() {
         autoplay = properties.get(PN_AUTOPLAY, currentStyle.get(PN_AUTOPLAY, false));
         delay = properties.get(PN_DELAY, currentStyle.get(PN_DELAY, DEFAULT_DELAY));
+        autopauseDisabled = properties.get(PN_AUTOPAUSE_DISABLED, currentStyle.get(PN_AUTOPAUSE_DISABLED, false));
     }
 
     @Override
@@ -63,5 +65,8 @@ public class CarouselImpl extends AbstractContainerImpl implements Carousel {
     public Long getDelay() {
         return delay;
     }
+
+    @Override
+    public boolean getAutopauseDisabled() { return autopauseDisabled; }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
@@ -40,6 +40,13 @@ public interface Carousel extends Container {
     String PN_DELAY = "delay";
 
     /**
+     * Name of the resource property that indicates whether automatic pause on hovering the carousel is disabled, or not.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.6.0
+     */
+    String PN_AUTOPAUSE_DISABLED = "autopauseDisabled";
+
+    /**
      * Indicates whether the carousel should automatically transition between slides or not.
      *
      * @return {@code true} if the carousel should automatically transition slides; {@code false} otherwise
@@ -56,6 +63,16 @@ public interface Carousel extends Container {
      * @since com.adobe.cq.wcm.core.components.models 12.5.0
      */
     default Long getDelay() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Indicates whether automatic pause on hovering the carousel is disabled, or not.
+     *
+     * @return {@code true} if automatic pause on hovering the carousel should be disabled; {@code false} otherwise
+     * @since com.adobe.cq.wcm.core.components.models 12.6.0
+     */
+    default boolean getAutopauseDisabled() {
         throw new UnsupportedOperationException();
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.5.0")
+@Version("12.6.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/CarouselImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/CarouselImplTest.java
@@ -79,6 +79,7 @@ public class CarouselImplTest {
         Carousel carousel = getCarouselUnderTest(CAROUSEL_1);
         assertTrue(carousel.getAutoplay());
         assertEquals(new Long(7000), carousel.getDelay());
+        assertTrue(carousel.getAutopauseDisabled());
     }
 
     private Carousel getCarouselUnderTest(String resourcePath) {

--- a/bundles/core/src/test/resources/carousel/test-content.json
+++ b/bundles/core/src/test/resources/carousel/test-content.json
@@ -18,6 +18,7 @@
                         "sling:resourceType": "core/wcm/components/carousel/v1/carousel",
                         "autoplay"          : "true",
                         "delay"             : "7000",
+                        "autopauseDisabled" : "true",
                         "item_1": {
                             "jcr:primaryType"   : "nt:unstructured",
                             "jcr:title"         : "Teaser 1",

--- a/content/.stylelintrc.yaml
+++ b/content/.stylelintrc.yaml
@@ -38,7 +38,6 @@ rules:
 
     # property
     property-blacklist: null
-    property-no-vendor-prefix: true
     property-whitelist: null
 
     # declaration

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
@@ -22,7 +22,11 @@ Carousel component written in HTL.
 * Allows addition of Carousel item components of varying resource type.
 * Allowed components can be configured through policy configuration.
 * Carousel navigation via next/previous and position indicators.
-* Carousel autoplay with configurable delay and pause/play buttons.
+* Carousel autoplay with: 
+  * Configurable delay.
+  * Ability to disable automatic pause on hover.
+  * Pause/play buttons.
+  * Automatic pausing when the document is hidden, making use of the [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API).
 * Editing features for items (adding, removing, editing, re-ordering).
 
 ### Use Object

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
@@ -22,7 +22,7 @@ Carousel component written in HTL.
 * Allows addition of Carousel item components of varying resource type.
 * Allowed components can be configured through policy configuration.
 * Carousel navigation via next/previous and position indicators.
-* Carousel autoplay with configurable delay.
+* Carousel autoplay with configurable delay and pause/play buttons.
 * Editing features for items (adding, removing, editing, re-ordering).
 
 ### Use Object

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
@@ -56,6 +56,8 @@ BLOCK cmp-carousel
     ELEMENT cmp-carousel__action
         MOD cmp-carousel__action--previous
         MOD cmp-carousel__action--next
+        MOD cmp-carousel__action--pause
+        MOD cmp-carousel__action--play
     ELEMENT cmp-carousel__action-icon
     ELEMENT cmp-carousel__action-text
     ELEMENT cmp-carousel__indicators
@@ -76,6 +78,8 @@ A hook attribute from the following should be added to the corresponding element
 data-cmp-hook-carousel="item"
 data-cmp-hook-carousel="previous"
 data-cmp-hook-carousel="next"
+data-cmp-hook-carousel="pause"
+data-cmp-hook-carousel="play"
 data-cmp-hook-carousel="indicators"
 data-cmp-hook-carousel="indicator"
 ```

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
@@ -76,7 +76,7 @@ The following attributes can be added to the same element to provide options:
 
 1. `data-cmp-autoplay` - if the attribute is present, indicates that the carousel should automatically transition between slides.
 2. `data-cmp-delay` - the delay (in milliseconds) when automatically transitioning between slides.
-3. `data-cmp-autopause-disabled` - whether or not to disable automatically pausing the carousel on hover, when autoplay is enabled. 
+3. `data-cmp-autopause-disabled` - if the attribute is present, indicates that automatically pausing the carousel on hover, is disabled. 
 
 A hook attribute from the following should be added to the corresponding element so that the JavaScript is able to target it:
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
@@ -54,6 +54,7 @@ BLOCK cmp-carousel
     ELEMENT cmp-carousel__content
     ELEMENT cmp-carousel__item
     ELEMENT cmp-carousel__action
+        MOD cmp-carousel__action--disabled
         MOD cmp-carousel__action--previous
         MOD cmp-carousel__action--next
         MOD cmp-carousel__action--pause

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
@@ -72,6 +72,7 @@ The following attributes can be added to the same element to provide options:
 
 1. `data-cmp-autoplay` - if the attribute is present, indicates that the carousel should automatically transition between slides.
 2. `data-cmp-delay` - the delay (in milliseconds) when automatically transitioning between slides.
+3. `data-cmp-autopause-disabled` - whether or not to disable automatically pausing the carousel on hover, when autoplay is enabled. 
 
 A hook attribute from the following should be added to the corresponding element so that the JavaScript is able to target it:
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
@@ -24,7 +24,8 @@
     helpPath="https://www.adobe.com/go/aem_cmp_carousel_v1">
     <content
         jcr:primaryType="nt:unstructured"
-        sling:resourceType="granite/ui/components/coral/foundation/container">
+        sling:resourceType="granite/ui/components/coral/foundation/container"
+        granite:class="cmp-carousel__editor">
         <items jcr:primaryType="nt:unstructured">
             <tabs
                 jcr:primaryType="nt:unstructured"
@@ -45,26 +46,47 @@
                                 name="./autoplay"
                                 text="Automatically transition slides"
                                 uncheckedValue="false"
-                                value="true"/>
-                            <delay
+                                value="true">
+                                <granite:data
+                                    jcr:primaryType="nt:unstructured"
+                                    cmp-carousel-v1-dialog-hook="autoplay"/>
+                            </autoplay>
+                            <autoplayGroup
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
-                                fieldDescription="The delay (in milliseconds) before automatically transitioning to the next slide."
-                                fieldLabel="Transition Delay (milliseconds)"
-                                min="0"
-                                max="600000"
-                                name="./delay"
-                                step="100"
-                                value="5000"/>
-                            <autopauseDisabled
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                checked="false"
-                                fieldDescription="If checked, automatic pause on hovering the carousel is disabled."
-                                name="./autopauseDisabled"
-                                text="Disable automatic pause on hover"
-                                uncheckedValue="false"
-                                value="true"/>
+                                sling:resourceType="granite/ui/components/coral/foundation/well">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <delay
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                        fieldDescription="The delay (in milliseconds) before automatically transitioning to the next slide."
+                                        fieldLabel="Transition Delay (milliseconds)"
+                                        min="0"
+                                        max="600000"
+                                        name="./delay"
+                                        step="100"
+                                        value="5000">
+                                        <granite:data
+                                            jcr:primaryType="nt:unstructured"
+                                            cmp-carousel-v1-dialog-hook="delay"/>
+                                    </delay>
+                                    <autopauseDisabled
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                        checked="false"
+                                        fieldDescription="If checked, automatic pause when hovering the carousel is disabled."
+                                        name="./autopauseDisabled"
+                                        text="Disable automatic pause on hover"
+                                        uncheckedValue="false"
+                                        value="true">
+                                        <granite:data
+                                            jcr:primaryType="nt:unstructured"
+                                            cmp-carousel-v1-dialog-hook="autopauseDisabled"/>
+                                    </autopauseDisabled>
+                                </items>
+                                <granite:data
+                                    jcr:primaryType="nt:unstructured"
+                                    cmp-carousel-v1-dialog-hook="autoplayGroup"/>
+                            </autoplayGroup>
                         </items>
                     </properties>
                     <allowedcomponents

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
@@ -40,6 +40,7 @@
                             <autoplay
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                checked="false"
                                 fieldDescription="If checked, automatically transition between carousel slides."
                                 name="./autoplay"
                                 text="Automatically transition slides"
@@ -55,6 +56,15 @@
                                 name="./delay"
                                 step="100"
                                 value="5000"/>
+                            <autopauseDisabled
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                checked="false"
+                                fieldDescription="If checked, automatic pause on hovering the carousel is disabled."
+                                name="./autopauseDisabled"
+                                text="Disable automatic pause on hover"
+                                uncheckedValue="false"
+                                value="true"/>
                         </items>
                     </properties>
                     <allowedcomponents

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -79,26 +79,47 @@
                                                 name="./autoplay"
                                                 text="Automatically transition slides"
                                                 uncheckedValue="false"
-                                                value="true"/>
-                                            <delay
+                                                value="true">
+                                                <granite:data
+                                                    jcr:primaryType="nt:unstructured"
+                                                    cmp-carousel-v1-dialog-hook="autoplay"/>
+                                            </autoplay>
+                                            <autoplayGroup
                                                 jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
-                                                fieldDescription="The delay (in milliseconds) before automatically transitioning to the next slide."
-                                                fieldLabel="Transition Delay (milliseconds)"
-                                                min="0"
-                                                max="600000"
-                                                name="./delay"
-                                                step="100"
-                                                value="${not empty cqDesign.delay ? cqDesign.delay : 5000}"/>
-                                            <autopauseDisabled
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                                checked="${not empty cqDesign.autopauseDisabled ? cqDesign.autopauseDisabled : false}"
-                                                fieldDescription="If checked, automatic pause on hovering the carousel is disabled."
-                                                name="./autopauseDisabled"
-                                                text="Disable automatic pause on hover"
-                                                uncheckedValue="false"
-                                                value="true"/>
+                                                sling:resourceType="granite/ui/components/coral/foundation/well">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <delay
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                                        fieldDescription="The delay (in milliseconds) before automatically transitioning to the next slide."
+                                                        fieldLabel="Transition Delay (milliseconds)"
+                                                        min="0"
+                                                        max="600000"
+                                                        name="./delay"
+                                                        step="100"
+                                                        value="${not empty cqDesign.delay ? cqDesign.delay : 5000}">
+                                                        <granite:data
+                                                            jcr:primaryType="nt:unstructured"
+                                                            cmp-carousel-v1-dialog-hook="delay"/>
+                                                    </delay>
+                                                    <autopauseDisabled
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                        checked="${not empty cqDesign.autopauseDisabled ? cqDesign.autopauseDisabled : false}"
+                                                        fieldDescription="If checked, automatic pause when hovering the carousel is disabled."
+                                                        name="./autopauseDisabled"
+                                                        text="Disable automatic pause on hover"
+                                                        uncheckedValue="false"
+                                                        value="true">
+                                                        <granite:data
+                                                            jcr:primaryType="nt:unstructured"
+                                                            cmp-carousel-v1-dialog-hook="autopauseDisabled"/>
+                                                    </autopauseDisabled>
+                                                </items>
+                                                <granite:data
+                                                    jcr:primaryType="nt:unstructured"
+                                                    cmp-carousel-v1-dialog-hook="autoplayGroup"/>
+                                            </autoplayGroup>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -90,6 +90,15 @@
                                                 name="./delay"
                                                 step="100"
                                                 value="${not empty cqDesign.delay ? cqDesign.delay : 5000}"/>
+                                            <autopauseDisabled
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                checked="${not empty cqDesign.autopauseDisabled ? cqDesign.autopauseDisabled : false}"
+                                                fieldDescription="If checked, automatic pause on hovering the carousel is disabled."
+                                                name="./autopauseDisabled"
+                                                text="Disable automatic pause on hover"
+                                                uncheckedValue="false"
+                                                value="true"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -92,7 +92,7 @@
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/alert"
                                                         size="S"
-                                                        text="Automatic transitioning can be previewed via the 'View as published' page action."
+                                                        text="Automatic transitions are previewed with the 'View as published' page action."
                                                         variant="info">
                                                     </alert>
                                                     <delay

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -88,6 +88,13 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/well">
                                                 <items jcr:primaryType="nt:unstructured">
+                                                    <alert
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/alert"
+                                                        size="S"
+                                                        text="Automatic transitioning can be previewed via the 'View as published' page action."
+                                                        variant="info">
+                                                    </alert>
                                                     <delay
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -38,14 +38,14 @@
             <span class="cmp-carousel__action-icon"></span>
             <span class="cmp-carousel__action-text">${'Next' @ i18n}</span>
         </button>
-        <button data-sly-test="carousel.autoplay"
+        <button data-sly-test="${carousel.autoplay}"
                 role="button"
                 class="cmp-carousel__action cmp-carousel__action--pause"
                 data-cmp-hook-carousel="pause">
             <span class="cmp-carousel__action-icon"></span>
             <span class="cmp-carousel__action-text">${'Pause' @ i18n}</span>
         </button>
-        <button data-sly-test="carousel.autoplay"
+        <button data-sly-test="${carousel.autoplay}"
                 role="button"
                 class="cmp-carousel__action cmp-carousel__action--play"
                 data-cmp-hook-carousel="play">

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -25,13 +25,31 @@
              role="tabpanel"
              class="cmp-carousel__item${itemList.first ? ' cmp-carousel__item--active' : ''}"
              data-cmp-hook-carousel="item"></div>
-        <button role="button" class="cmp-carousel__action cmp-carousel__action--previous" data-cmp-hook-carousel="previous">
+        <button role="button"
+                class="cmp-carousel__action cmp-carousel__action--previous"
+                data-cmp-hook-carousel="previous">
             <span class="cmp-carousel__action-icon"></span>
             <span class="cmp-carousel__action-text">${'Previous' @ i18n}</span>
         </button>
-        <button role="button" class="cmp-carousel__action cmp-carousel__action--next" data-cmp-hook-carousel="next">
+        <button role="button"
+                class="cmp-carousel__action cmp-carousel__action--next"
+                data-cmp-hook-carousel="next">
             <span class="cmp-carousel__action-icon"></span>
             <span class="cmp-carousel__action-text">${'Next' @ i18n}</span>
+        </button>
+        <button data-sly-test="carousel.autoplay"
+                role="button"
+                class="cmp-carousel__action cmp-carousel__action--pause"
+                data-cmp-hook-carousel="pause">
+            <span class="cmp-carousel__action-icon"></span>
+            <span class="cmp-carousel__action-text">${'Pause' @ i18n}</span>
+        </button>
+        <button data-sly-test="carousel.autoplay"
+                role="button"
+                class="cmp-carousel__action cmp-carousel__action--play"
+                data-cmp-hook-carousel="play">
+            <span class="cmp-carousel__action-icon"></span>
+            <span class="cmp-carousel__action-text">${'Play' @ i18n}</span>
         </button>
         <ol role="tablist" class="cmp-carousel__indicators" data-cmp-hook-carousel="indicators">
             <li data-sly-repeat.item="${carousel.items}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -18,7 +18,8 @@
      class="cmp-carousel"
      data-cmp-is="carousel"
      data-cmp-autoplay="${(wcmmode.edit || wcmmode.preview) ? '' : carousel.autoplay}"
-     data-cmp-delay="${carousel.delay}">
+     data-cmp-delay="${carousel.delay}"
+     data-cmp-autopause-disabled="${carousel.autopauseDisabled}">
     <div class="cmp-carousel__content" data-sly-test="${carousel.items && carousel.items.size > 0}" >
         <div data-sly-repeat.item="${carousel.items}"
              data-sly-resource="${item.path @ decorationTagName='div'}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/editor/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/editor/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[core.wcm.components.carousel.v1.editor]"
+    dependencies="[jquery]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/editor/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/editor/js.txt
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright 2018 Adobe Systems Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=js
+
+carousel.js

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/editor/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/editor/js/carousel.js
@@ -1,0 +1,79 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2018 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+/* global jQuery, Coral */
+(function($) {
+    "use strict";
+
+    var selectors = {
+        dialogContent: ".cmp-carousel__editor",
+        autoplay: "[data-cmp-carousel-v1-dialog-hook='autoplay']",
+        autoplayGroup: "[data-cmp-carousel-v1-dialog-hook='autoplayGroup']",
+        delay: "[data-cmp-carousel-v1-dialog-hook='delay']",
+        autopauseDisabled: "[data-cmp-carousel-v1-dialog-hook='autopauseDisabled']"
+    };
+
+    var autoplay;
+    var autoplayGroup;
+    var delay;
+    var autopauseDisabled;
+
+    $(document).on("dialog-loaded", function(event) {
+        var $dialog = event.dialog;
+
+        if ($dialog.length) {
+            var dialogContent = $dialog[0].querySelector(selectors.dialogContent);
+
+            if (dialogContent) {
+                autoplay = dialogContent.querySelector(selectors.autoplay);
+                autoplayGroup = dialogContent.querySelector(selectors.autoplayGroup);
+                delay = dialogContent.querySelector(selectors.delay);
+                autopauseDisabled = dialogContent.querySelector(selectors.autopauseDisabled);
+
+                if (autoplay) {
+                    Coral.commons.ready(autoplay, function() {
+                        autoplay.on("change", onAutoplayChange);
+                        onAutoplayChange();
+                    });
+                }
+            }
+        }
+    });
+
+    /**
+     * Handles a change in the autoplay checkbox state.
+     * Conditionally toggles hidden state of the related autoplay group which contains
+     * additional fields that are only relevant when autoplay is enabled.
+     *
+     * @private
+     */
+    function onAutoplayChange() {
+        if (autoplay && autoplayGroup && delay && autopauseDisabled) {
+            var delayField = $(delay).adaptTo("foundation-field");
+            var autopauseDisabledField = $(autopauseDisabled).adaptTo("foundation-field");
+
+            if (!autoplay.checked) {
+                autoplayGroup.setAttribute("hidden", true);
+                delayField.setDisabled(true);
+                autopauseDisabledField.setDisabled(true);
+            } else {
+                delayField.setDisabled(false);
+                autopauseDisabledField.setDisabled(false);
+                autoplayGroup.removeAttribute("hidden");
+            }
+        }
+    }
+
+})(jQuery);

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/css/carousel.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/css/carousel.less
@@ -61,6 +61,8 @@
 }
 
 .cmp-carousel__action--previous {
+    left: 0;
+
     .cmp-carousel__action-icon {
         background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 8 8'%3E%3Cpath d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3E%3C/svg%3E");
     }

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/css/carousel.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/css/carousel.less
@@ -15,6 +15,7 @@
  */
 
 @cmp-carousel-indicator-size: 10px;
+@cmp-carousel-indicator-gap: 14px;
 
 .cmp-carousel__content {
     position: relative;
@@ -29,105 +30,19 @@
 }
 
 .cmp-carousel__action {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    border: 0;
-
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 15%;
-
-    text-align: center;
-    opacity: 0;
-    background-color: rgba(255, 255, 255, .1);
-    transition: opacity .2s;
-    outline: none;
-}
-
-.cmp-carousel:hover {
-    .cmp-carousel__action {
-        opacity: 1;
-    }
-}
-
-.cmp-carousel__action-icon {
-    display: inline-block;
-    width: 20px;
-    height: 20px;
-    background: transparent no-repeat center center;
-    background-size: 100% 100%;
-}
-
-.cmp-carousel__action--previous {
-    left: 0;
-
-    .cmp-carousel__action-icon {
-        background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 8 8'%3E%3Cpath d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3E%3C/svg%3E");
-    }
-}
-
-.cmp-carousel__action--next {
-    right: 0;
-
-    .cmp-carousel__action-icon {
-        background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 8 8'%3E%3Cpath d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3E%3C/svg%3E");
-    }
-}
-
-.cmp-carousel__action--pause, .cmp-carousel__action--play {
-    left: ~"calc(50% - 44px - 5px)";
-    top: auto;
-    bottom: @cmp-carousel-indicator-size + 20px;
-
-    display: inline-block;
-    width: 44px;
-    height: 44px;
-    padding: 12px;
-}
-
-.cmp-carousel__action--play {
-    left: ~"calc(50% + 5px)";
-
-    .cmp-carousel__action-icon {
-        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='8' fill='%23fff' viewBox='0 0 8 8' width='8'%3E%3Cg transform='matrix(7.01443e-17,1.14554,-1.14554,7.01443e-17,9.35844,-1.06667)'%3E%3Cpath d='M4.423,2.17L6.931,7.186L1.915,7.186L4.423,2.17Z'/%3E%3C/g%3E%3C/svg%3E");
-    }
-}
-
-.cmp-carousel__action--pause {
-    .cmp-carousel__action-icon {
-        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='8' fill='%23fff' viewBox='0 0 8 8' width='8'%3E%3Crect height='8' rx='0.2' ry='0.2' width='2.5' x='1' y='0' /%3E%3Crect height='8' rx='0.2' ry='0.2' width='2.5' x='5' y='0' /%3E%3C/svg%3E");
-    }
-}
-
-.cmp-carousel__action-text {
-    position: absolute;
-
-    width: 1px;
-    height: 1px;
-    border: 0;
-    padding: 0;
-    overflow: hidden;
-    white-space: nowrap;
-    clip: rect(0, 0, 0, 0);
-    clip-path: inset(50%);
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
 }
 
 .cmp-carousel__indicators {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-
     display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     margin: 0;
     padding: 0;
 
-    justify-content: center;
-
     list-style: none;
-    background-color: rgba(0, 0, 0, .3);
 }
 
 .cmp-carousel__indicator {
@@ -136,15 +51,15 @@
     flex: 0 1 auto;
     width: @cmp-carousel-indicator-size;
     height: @cmp-carousel-indicator-size;
-    margin: 6px 4px;
+    margin: 0 @cmp-carousel-indicator-gap/2;
     border-radius: 50%;
 
     font-size: 0;
     text-indent: -3000px;
 
-    background-color: rgba(255, 255, 255, .5);
+    background-color: rgba(0, 0, 0, .5);
 
     &--active {
-        background-color: rgba(255, 255, 255, .9);
+        background-color: rgba(0, 0, 0, .8);
     }
 }

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/css/carousel.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/css/carousel.less
@@ -15,7 +15,6 @@
  */
 
 @cmp-carousel-indicator-size: 10px;
-@cmp-carousel-action-icon-size: 24px;
 
 .cmp-carousel__content {
     position: relative;
@@ -62,8 +61,6 @@
 }
 
 .cmp-carousel__action--previous {
-    left: 0;
-
     .cmp-carousel__action-icon {
         background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 8 8'%3E%3Cpath d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3E%3C/svg%3E");
     }
@@ -74,6 +71,31 @@
 
     .cmp-carousel__action-icon {
         background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 8 8'%3E%3Cpath d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3E%3C/svg%3E");
+    }
+}
+
+.cmp-carousel__action--pause, .cmp-carousel__action--play {
+    left: ~"calc(50% - 44px - 5px)";
+    top: auto;
+    bottom: @cmp-carousel-indicator-size + 20px;
+
+    display: inline-block;
+    width: 44px;
+    height: 44px;
+    padding: 12px;
+}
+
+.cmp-carousel__action--play {
+    left: ~"calc(50% + 5px)";
+
+    .cmp-carousel__action-icon {
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='8' fill='%23fff' viewBox='0 0 8 8' width='8'%3E%3Cg transform='matrix(7.01443e-17,1.14554,-1.14554,7.01443e-17,9.35844,-1.06667)'%3E%3Cpath d='M4.423,2.17L6.931,7.186L1.915,7.186L4.423,2.17Z'/%3E%3C/g%3E%3C/svg%3E");
+    }
+}
+
+.cmp-carousel__action--pause {
+    .cmp-carousel__action-icon {
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='8' fill='%23fff' viewBox='0 0 8 8' width='8'%3E%3Crect height='8' rx='0.2' ry='0.2' width='2.5' x='1' y='0' /%3E%3Crect height='8' rx='0.2' ry='0.2' width='2.5' x='5' y='0' /%3E%3C/svg%3E");
     }
 }
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -225,20 +225,18 @@
                 }
             }
 
-            var pause = that._elements["pause"];
-            if (pause) {
+            if (that._elements["pause"]) {
                 if (that._properties.autoplay) {
-                    pause.addEventListener("click", onPauseClick);
+                    that._elements["pause"].addEventListener("click", onPauseClick);
                 } else {
-                    setActionDisabled(pause);
+                    setActionDisabled(that._elements["pause"]);
                 }
             }
 
-            var play = that._elements["play"];
-            if (play) {
-                setActionDisabled(play);
+            if (that._elements["play"]) {
+                setActionDisabled(that._elements["play"]);
                 if (that._properties.autoplay) {
-                    play.addEventListener("click", onPlayClick);
+                    that._elements["play"].addEventListener("click", onPlayClick);
                 }
             }
 
@@ -345,16 +343,7 @@
         function pause() {
             that._paused = true;
             clearAutoplayInterval();
-
-            var pause = that._elements["pause"];
-            if (pause) {
-                setActionDisabled(pause);
-            }
-
-            var play = that._elements["play"];
-            if (play) {
-                setActionDisabled(play, false);
-            }
+            refreshPlayPauseActions();
         }
 
         /**
@@ -372,15 +361,17 @@
                 resetAutoplayInterval();
             }
 
-            var pause = that._elements["pause"];
-            if (pause) {
-                setActionDisabled(pause, false);
-            }
+            refreshPlayPauseActions();
+        }
 
-            var play = that._elements["play"];
-            if (play) {
-                setActionDisabled(play);
-            }
+        /**
+         * Refreshes the play/pause action markup based on the {@code Carousel#_paused} state
+         *
+         * @private
+         */
+        function refreshPlayPauseActions() {
+            setActionDisabled(that._elements["pause"], that._paused);
+            setActionDisabled(that._elements["play"], !that._paused);
         }
 
         /**
@@ -515,13 +506,16 @@
         }
 
         /**
-         * Sets the disabled state for an action
+         * Sets the disabled state for an action and toggles the appropriate CSS classes
          *
          * @private
          * @param {HTMLElement} action Action to disable
-         * @param {Boolean} [disable] false to enable
+         * @param {Boolean} [disable] {@code true} to disable, {@code false} to enable
          */
         function setActionDisabled(action, disable) {
+            if (!action) {
+                return;
+            }
             if (disable !== false) {
                 action.disabled = true;
                 action.classList.add("cmp-carousel__action--disabled");

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -20,6 +20,7 @@
     var IS = "carousel";
 
     var keyCodes = {
+        SPACE: 32,
         END: 35,
         HOME: 36,
         ARROW_LEFT: 37,
@@ -281,6 +282,14 @@
                 case keyCodes.END:
                     event.preventDefault();
                     navigateAndFocusIndicator(lastIndex);
+                    break;
+                case keyCodes.SPACE:
+                    event.preventDefault();
+                    if (!that._paused) {
+                        pause();
+                    } else {
+                        play();
+                    }
                     break;
                 default:
                     return;

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -211,6 +211,23 @@
                 }
             }
 
+            var pause = that._elements["pause"];
+            if (pause) {
+                if (that._properties.autoplay) {
+                    pause.addEventListener("click", onPauseClick);
+                } else {
+                    setActionDisabled(pause);
+                }
+            }
+
+            var play = that._elements["play"];
+            if (play) {
+                setActionDisabled(play);
+                if (that._properties.autoplay) {
+                    play.addEventListener("click", onPlayClick);
+                }
+            }
+
             that._elements.self.addEventListener("keydown", onKeyDown);
             that._elements.self.addEventListener("mouseenter", onMouseEnter);
             that._elements.self.addEventListener("mouseleave", onMouseLeave);
@@ -272,6 +289,68 @@
          */
         function onMouseLeave(event) {
             resetAutoplayInterval();
+        }
+
+        /**
+         * Handles pause element click events
+         *
+         * @private
+         * @param {Object} event The click event
+         */
+        function onPauseClick(event) {
+            pause();
+        }
+
+        /**
+         * Handles play element click events
+         *
+         * @private
+         * @param {Object} event The click event
+         */
+        function onPlayClick() {
+            play();
+        }
+
+        /**
+         * Pauses the playing of the Carousel. Sets {@code Carousel#_paused} marker.
+         * Only relevant when autoplay is enabled
+         *
+         * @private
+         */
+        function pause() {
+            that._paused = true;
+            clearAutoplayInterval();
+
+            var pause = that._elements["pause"];
+            if (pause) {
+                setActionDisabled(pause);
+            }
+
+            var play = that._elements["play"];
+            if (play) {
+                setActionDisabled(play, false);
+            }
+        }
+
+        /**
+         * Enables the playing of the Carousel. Sets {@code Carousel#_paused} marker.
+         * Only relevant when autoplay is enabled
+         *
+         * @private
+         */
+        function play() {
+            that._paused = false;
+            resetAutoplayInterval();
+
+            var pause = that._elements["pause"];
+            if (pause) {
+                setActionDisabled(pause, false);
+            }
+
+            var play = that._elements["play"];
+            if (play) {
+                setActionDisabled(play);
+            }
         }
 
         /**
@@ -377,7 +456,7 @@
          * @private
          */
         function resetAutoplayInterval() {
-            if (!that._properties.autoplay) {
+            if (that._paused || !that._properties.autoplay) {
                 return;
             }
             clearAutoplayInterval();
@@ -400,6 +479,23 @@
         function clearAutoplayInterval() {
             window.clearInterval(that._autoplayIntervalId);
             that._autoplayIntervalId = null;
+        }
+
+        /**
+         * Sets the disabled state for an action
+         *
+         * @private
+         * @param {HTMLElement} action Action to disable
+         * @param {Boolean} [disable] false to enable
+         */
+        function setActionDisabled(action, disable) {
+            if (disable !== false) {
+                action.disabled = true;
+                action.classList.add("cmp-carousel__action--disabled");
+            } else {
+                action.disabled = false;
+                action.classList.remove("cmp-carousel__action--disabled");
+            }
         }
     }
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -59,6 +59,19 @@
                 value = parseFloat(value);
                 return !isNaN(value) ? value : null;
             }
+        },
+        /**
+         * Determines whether automatic pause on hovering the carousel is disabled
+         *
+         * @memberof Carousel
+         * @type {Boolean}
+         * @default false
+         */
+        "autopauseDisabled": {
+            "default": false,
+            "transform": function(value) {
+                return !(value === null || typeof value === "undefined");
+            }
         }
     };
 
@@ -229,8 +242,11 @@
             }
 
             that._elements.self.addEventListener("keydown", onKeyDown);
-            that._elements.self.addEventListener("mouseenter", onMouseEnter);
-            that._elements.self.addEventListener("mouseleave", onMouseLeave);
+
+            if (!that._properties.autopauseDisabled) {
+                that._elements.self.addEventListener("mouseenter", onMouseEnter);
+                that._elements.self.addEventListener("mouseleave", onMouseLeave);
+            }
         }
 
         /**
@@ -340,7 +356,12 @@
          */
         function play() {
             that._paused = false;
-            resetAutoplayInterval();
+
+            // If the Carousel is hovered, don't begin auto transitioning until the next mouse leave event
+            var hovered = that._elements.self.parentElement.querySelector(":hover") === that._elements.self;
+            if (that._properties.autopauseDisabled || !hovered) {
+                resetAutoplayInterval();
+            }
 
             var pause = that._elements["pause"];
             if (pause) {

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -282,13 +282,19 @@
                     navigateAndFocusIndicator(lastIndex);
                     break;
                 case keyCodes.SPACE:
-                    if (that._properties.autoplay) {
+                    if (that._properties.autoplay && (event.target !== that._elements["previous"] && event.target !== that._elements["next"])) {
                         event.preventDefault();
                         if (!that._paused) {
                             pause();
                         } else {
                             play();
                         }
+                    }
+                    if (event.target === that._elements["pause"]) {
+                        that._elements["play"].focus();
+                    }
+                    if (event.target === that._elements["play"]) {
+                        that._elements["pause"].focus();
                     }
                     break;
                 default:
@@ -324,6 +330,7 @@
          */
         function onPauseClick(event) {
             pause();
+            that._elements["play"].focus();
         }
 
         /**
@@ -334,6 +341,7 @@
          */
         function onPlayClick() {
             play();
+            that._elements["pause"].focus();
         }
 
         /**

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -284,17 +284,20 @@
                 case keyCodes.SPACE:
                     if (that._properties.autoplay && (event.target !== that._elements["previous"] && event.target !== that._elements["next"])) {
                         event.preventDefault();
+
+                        if (event.target === that._elements["pause"]) {
+                            that._elements["play"].focus();
+                        }
+
+                        if (event.target === that._elements["play"]) {
+                            that._elements["pause"].focus();
+                        }
+
                         if (!that._paused) {
                             pause();
                         } else {
                             play();
                         }
-                    }
-                    if (event.target === that._elements["pause"]) {
-                        that._elements["play"].focus();
-                    }
-                    if (event.target === that._elements["play"]) {
-                        that._elements["pause"].focus();
                     }
                     break;
                 default:

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -282,11 +282,13 @@
                     navigateAndFocusIndicator(lastIndex);
                     break;
                 case keyCodes.SPACE:
-                    event.preventDefault();
-                    if (!that._paused) {
-                        pause();
-                    } else {
-                        play();
+                    if (that._properties.autoplay) {
+                        event.preventDefault();
+                        if (!that._paused) {
+                            pause();
+                        } else {
+                            play();
+                        }
                     }
                     break;
                 default:

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -482,6 +482,9 @@
             }
             clearAutoplayInterval();
             that._autoplayIntervalId = window.setInterval(function() {
+                if (document.visibilityState && document.hidden) {
+                    return;
+                }
                 var indicators = that._elements["indicators"];
                 if (indicators !== document.activeElement && indicators.contains(document.activeElement)) {
                     // if an indicator has focus, ensure we switch focus following navigation

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -284,20 +284,17 @@
                 case keyCodes.SPACE:
                     if (that._properties.autoplay && (event.target !== that._elements["previous"] && event.target !== that._elements["next"])) {
                         event.preventDefault();
-
-                        if (event.target === that._elements["pause"]) {
-                            that._elements["play"].focus();
-                        }
-
-                        if (event.target === that._elements["play"]) {
-                            that._elements["pause"].focus();
-                        }
-
                         if (!that._paused) {
                             pause();
                         } else {
                             play();
                         }
+                    }
+                    if (event.target === that._elements["pause"]) {
+                        that._elements["play"].focus();
+                    }
+                    if (event.target === that._elements["play"]) {
+                        that._elements["pause"].focus();
                     }
                     break;
                 default:

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -110,12 +110,15 @@
 
             setupProperties(config.options);
             cacheElements(config.element);
+
             that._active = 0;
+            that._paused = false;
 
             if (that._elements.item) {
                 refreshActive();
                 bindEvents();
                 resetAutoplayInterval();
+                refreshPlayPauseActions();
             }
 
             if (window.Granite && window.Granite.author && window.Granite.author.MessageChannel) {
@@ -228,13 +231,10 @@
             if (that._elements["pause"]) {
                 if (that._properties.autoplay) {
                     that._elements["pause"].addEventListener("click", onPauseClick);
-                } else {
-                    setActionDisabled(that._elements["pause"]);
                 }
             }
 
             if (that._elements["play"]) {
-                setActionDisabled(that._elements["play"]);
                 if (that._properties.autoplay) {
                     that._elements["play"].addEventListener("click", onPlayClick);
                 }

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-cases/Carousel/v1/Carousel.js
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-cases/Carousel/v1/Carousel.js
@@ -229,6 +229,46 @@
     };
 
     /**
+     * Test: Autoplay group toggle
+     */
+    carousel.tcAutoplayGroup = function(tcExecuteBeforeTest, tcExecuteAfterTest, selectors) {
+        return new h.TestCase("Edit Dialog : Autoplay group", {
+            execBefore: tcExecuteBeforeTest,
+            execAfter: tcExecuteAfterTest
+        })
+            // create new items with titles
+            .execTestCase(carousel.tcCreateItems(selectors))
+
+            // open the edit dialog
+            .execTestCase(c.tcOpenConfigureDialog("cmpPath"))
+
+            // switch to the properties tab
+            .click(selectors.editDialog.tabs.properties)
+
+            // verify autoplay isn't initially enabled
+            .assert.exist(selectors.editDialog.autoplay + ":checked", false)
+
+            // verify the autoplay group isn't show initially
+            .asserts.visible(selectors.editDialog.autoplayGroup, false)
+
+            // check the autoplay checkbox
+            .click(selectors.editDialog.autoplay)
+
+            // verify the autoplay group is now visible and its related fields are not disabled
+            .asserts.visible(selectors.editDialog.autoplayGroup, true)
+            .assert.exists(selectors.editDialog.delay + "[disabled]", false)
+            .assert.exists(selectors.editDialog.autopauseDisabled + "[disabled]", false)
+
+            // uncheck the autoplay checkbox
+            .click(selectors.editDialog.autoplay)
+
+            // verify the autoplay group is hidden again and its related fields are disabled
+            .asserts.visible(selectors.editDialog.autoplayGroup, false)
+            .assert.exists(selectors.editDialog.delay + "[disabled]", true)
+            .assert.exists(selectors.editDialog.autopauseDisabled + "[disabled]", true);
+    };
+
+    /**
      * Test: Panel Select
      */
     carousel.tcPanelSelect = function(tcExecuteBeforeTest, tcExecuteAfterTest, selectors) {

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-suites/Carousel/v1/Carousel.js
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-suites/Carousel/v1/Carousel.js
@@ -32,7 +32,15 @@
                     input: "[data-cmp-hook-childreneditor='itemTitle']",
                     hiddenInput: "[data-cmp-hook-childreneditor='itemResourceType']"
                 }
-            }
+            },
+            tabs: {
+                items: ".cmp-carousel__editor coral-tab:eq(0)",
+                properties: ".cmp-carousel__editor coral-tab:eq(1)"
+            },
+            autoplay: "[data-cmp-carousel-v1-dialog-hook='autoplay']",
+            autoplayGroup: "[data-cmp-carousel-v1-dialog-hook='autoplayGroup']",
+            delay: "[data-cmp-carousel-v1-dialog-hook='delay']",
+            autopauseDisabled: "[data-cmp-carousel-v1-dialog-hook='autopauseDisabled']"
         },
         insertComponentDialog: {
             self: ".InsertComponentDialog",
@@ -78,6 +86,7 @@
         .addTestCase(carousel.tcAddItems(tcExecuteBeforeTest, tcExecuteAfterTest, selectors))
         .addTestCase(carousel.tcRemoveItems(tcExecuteBeforeTest, tcExecuteAfterTest, selectors))
         .addTestCase(carousel.tcReorderItems(tcExecuteBeforeTest, tcExecuteAfterTest, selectors))
+        .addTestCase(carousel.tcAutoplayGroup(tcExecuteBeforeTest, tcExecuteAfterTest, selectors))
         .addTestCase(carousel.tcPanelSelect(tcExecuteBeforeTest, tcExecuteAfterTest, selectors))
         .addTestCase(carousel.tcAllowedComponents(tcExecuteBeforeTest, tcExecuteAfterTest, selectors, "/carousel", "core-component/components",
             c.policyPath, c.policyAssignmentPath, "core/wcm/tests/components/test-page-v2", c.rtCarousel_v1))


### PR DESCRIPTION
This pull request addresses issues #326 #327 and #361 which are closely related to the autoplay and pause/play bug/features we would like to address for the [2.2.2 milestone](https://github.com/adobe/aem-core-wcm-components/milestone/9).

**General**
- documentation updates
- test case addition and updates

#326 Provide pause/play button when autoplay is enabled
- adds pause and play button markup
- adds JS handling for playing / pausing
- simplifies default site CSS
- adds ability to configure auto-pause on hover via the edit and policy dialogs. It may be a valid use-case for example to disable auto-pause on hover for a full screen Carousel.

#327 Pause carousel autoplay when carousel document is hidden
- uses the page visibility API (https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) to only continue autoplay if the document isn't hidden (background tabs, minimised window, OS lock).

#361 Disable and hide autoplay related fields if autoplay isn't enabled
- adds a well in dialog content to group the autoplay fields (delay and auto-pause disabled).
- hides the well if autoplay isn't enabled.
- disables "delay" and "auto-pause disabled" fields if autoplay isn't enabled.

![autoplay-group-toggle](https://user-images.githubusercontent.com/25616660/47808125-ff411900-dd3d-11e8-9fed-b02a6c731abc.gif)

