### PR TITLE
#364 [Image] Alt text stays mandatory field even when 'decorative' flag is set on first save

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/editor/js/image.js
@@ -19,6 +19,7 @@
 
     var dialogContentSelector = ".cmp-image__editor";
     var CheckboxTextfieldTuple = window.CQ.CoreComponents.CheckboxTextfieldTuple.v1;
+    var isDecorative;
     var altTuple;
     var captionTuple;
     var $altGroup;
@@ -33,7 +34,7 @@
         var $dialogContent = $dialog.find(dialogContentSelector);
         var dialogContent  = $dialogContent.length > 0 ? $dialogContent[0] : undefined;
         if (dialogContent) {
-            var isDecorative   = dialogContent.querySelector('coral-checkbox[name="./isDecorative"]');
+            isDecorative      = dialogContent.querySelector('coral-checkbox[name="./isDecorative"]');
             altTuple          =
                 new CheckboxTextfieldTuple(dialogContent, 'coral-checkbox[name="./altValueFromDAM"]', 'input[name="./alt"]');
             $altGroup         = $dialogContent.find(".cmp-image__editor-alt");
@@ -54,6 +55,7 @@
                             captionTuple.hideCheckbox(false);
                             altTuple.reinitCheckbox();
                             captionTuple.reinitCheckbox();
+                            toggleAlternativeFieldsAndLink(isDecorative);
                         }
                     );
                 });
@@ -83,7 +85,7 @@
                     captionTuple.hideCheckbox(true);
                 }
             }
-            toggleAlternativeFieldsAndLink(dialogContent.querySelector('coral-checkbox[name="./isDecorative"]'));
+            toggleAlternativeFieldsAndLink(isDecorative);
         }
     });
 
@@ -130,6 +132,7 @@
                     }
                     altTuple.seedTextValue(description);
                     altTuple.update();
+                    toggleAlternativeFieldsAndLink(isDecorative);
                 }
                 if (captionTuple) {
                     var title = data["dc:title"];


### PR DESCRIPTION
`altTuple.update()`, `altTuple.reinitCheckbox()` cause a change in the disabled state of fields related to the tuple. These are called when we update the DAM file reference for the image in the dialog.

Here, we ensure we refresh the state of the alt fields following calls to these functions based on the `isDecorative` state.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #364` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Todo
| Documentation Provided   | N/A (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
