### PR TITLE
#163 [Image] Errors when using Design Importer with image (v1 and v2)

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
@@ -168,9 +168,9 @@ public class ImageImpl implements Image {
                 hasContent = false;
                 return;
             }
-            // The jcr:mimeType property may contain a charset prefix (image/jpeg;charset=UTF-8).
-            // For example if a binary was written with jcrUtils#putFile and an optional charset was provided.
-            // Check for the prefix and remove as necessary.
+            // The jcr:mimeType property may contain a charset suffix (image/jpeg;charset=UTF-8).
+            // For example if a file was written with jcrUtils#putFile and an optional charset was provided.
+            // Check for the suffix and remove as necessary.
             mimeType = mimeType.split(";")[0];
             extension = mimeTypeService.getExtension(mimeType);
             ValueMap properties = resource.getValueMap();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
@@ -168,6 +168,10 @@ public class ImageImpl implements Image {
                 hasContent = false;
                 return;
             }
+            // The jcr:mimeType property may contain a charset prefix (image/jpeg;charset=UTF-8).
+            // For example if a binary was written with jcrUtils#putFile and an optional charset was provided.
+            // Check for the prefix and remove as necessary.
+            mimeType = mimeType.split(";")[0];
             extension = mimeTypeService.getExtension(mimeType);
             ValueMap properties = resource.getValueMap();
             Calendar lastModified = properties.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class);


### PR DESCRIPTION
- removes potential charset information from `jcr:mimeType` property
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #163` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      |
| Documentation Provided   | (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
