### PR TITLE
#369 [Tabs] Tab focus behaviour too invasive

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
@@ -151,7 +151,7 @@
                 for (var i = 0; i < tabs.length; i++) {
                     (function(index) {
                         tabs[i].addEventListener("click", function(event) {
-                            navigate(index);
+                            navigateAndFocusTab(index);
                         });
                         tabs[i].addEventListener("keydown", function(event) {
                             onKeyDown(event);
@@ -176,23 +176,23 @@
                 case keyCodes.ARROW_UP:
                     event.preventDefault();
                     if (index > 0) {
-                        navigate(index - 1);
+                        navigateAndFocusTab(index - 1);
                     }
                     break;
                 case keyCodes.ARROW_RIGHT:
                 case keyCodes.ARROW_DOWN:
                     event.preventDefault();
                     if (index < lastIndex) {
-                        navigate(index + 1);
+                        navigateAndFocusTab(index + 1);
                     }
                     break;
                 case keyCodes.HOME:
                     event.preventDefault();
-                    navigate(0);
+                    navigateAndFocusTab(0);
                     break;
                 case keyCodes.END:
                     event.preventDefault();
-                    navigate(lastIndex);
+                    navigateAndFocusTab(lastIndex);
                     break;
                 default:
                     return;
@@ -217,7 +217,6 @@
                             tabs[i].classList.add(selectors.active.tab);
                             tabs[i].setAttribute("aria-selected", true);
                             tabs[i].setAttribute("tabindex", "0");
-                            focusWithoutScroll(tabs[i]);
                         } else {
                             tabpanels[i].classList.remove(selectors.active.tabpanel);
                             tabpanels[i].setAttribute("aria-hidden", true);
@@ -255,6 +254,17 @@
         function navigate(index) {
             that._active = index;
             refreshActive();
+        }
+
+        /**
+         * Navigates to the item at the provided index and ensures the active tab gains focus
+         *
+         * @private
+         * @param {Number} index The index of the item to navigate to
+         */
+        function navigateAndFocusTab(index) {
+            navigate(index);
+            focusWithoutScroll(that._elements["tab"][index]);
         }
     }
 


### PR DESCRIPTION
- only shift tab focus on click and keyboard event handling

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #369` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      |
| Documentation Provided   | (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
