### PR TITLE
#372 [Carousel] Saving dialog with autoplay unchecked, removes delay and disable on pause defaults

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/editor/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/editor/js/carousel.js
@@ -20,15 +20,11 @@
     var selectors = {
         dialogContent: ".cmp-carousel__editor",
         autoplay: "[data-cmp-carousel-v1-dialog-hook='autoplay']",
-        autoplayGroup: "[data-cmp-carousel-v1-dialog-hook='autoplayGroup']",
-        delay: "[data-cmp-carousel-v1-dialog-hook='delay']",
-        autopauseDisabled: "[data-cmp-carousel-v1-dialog-hook='autopauseDisabled']"
+        autoplayGroup: "[data-cmp-carousel-v1-dialog-hook='autoplayGroup']"
     };
 
     var autoplay;
     var autoplayGroup;
-    var delay;
-    var autopauseDisabled;
 
     $(document).on("dialog-loaded", function(event) {
         var $dialog = event.dialog;
@@ -39,8 +35,6 @@
             if (dialogContent) {
                 autoplay = dialogContent.querySelector(selectors.autoplay);
                 autoplayGroup = dialogContent.querySelector(selectors.autoplayGroup);
-                delay = dialogContent.querySelector(selectors.delay);
-                autopauseDisabled = dialogContent.querySelector(selectors.autopauseDisabled);
 
                 if (autoplay) {
                     Coral.commons.ready(autoplay, function() {
@@ -60,17 +54,10 @@
      * @private
      */
     function onAutoplayChange() {
-        if (autoplay && autoplayGroup && delay && autopauseDisabled) {
-            var delayField = $(delay).adaptTo("foundation-field");
-            var autopauseDisabledField = $(autopauseDisabled).adaptTo("foundation-field");
-
+        if (autoplay && autoplayGroup) {
             if (!autoplay.checked) {
                 autoplayGroup.setAttribute("hidden", true);
-                delayField.setDisabled(true);
-                autopauseDisabledField.setDisabled(true);
             } else {
-                delayField.setDisabled(false);
-                autopauseDisabledField.setDisabled(false);
                 autoplayGroup.removeAttribute("hidden");
             }
         }


### PR DESCRIPTION
Due to the default behaviour of the Granite `com.adobe.granite.ui.components.Value.val()` [0] method if the form isn't fresh, default values are ignored if a property isn't set. As we disable the autoplay fields (delay + disable autopause), they don't have a value set the first time and for subsequent dialog load they therefore aren't provided with a default.

Here we don't disable these so that their default is persisted and available on subsequent load.

[0] - https://helpx.adobe.com/experience-manager/6-4/sites/developing/using/reference-materials/javadoc/com/adobe/granite/ui/components/Value.html

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #372` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      |
| Documentation Provided   | (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
