### PR TITLE
[security] Remove jackson-databind security warning

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -545,19 +545,19 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.9.7</version>
+                <version>2.9.5</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.7</version>
+                <version>2.9.5</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.9.7</version>
+                <version>2.9.5</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -545,19 +545,19 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.8.4</version>
+                <version>2.9.7</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.8.4</version>
+                <version>2.9.7</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.8.4</version>
+                <version>2.9.7</version>
                 <scope>provided</scope>
             </dependency>
 


### PR DESCRIPTION
- update to latest version of the jackson artifacts that are available in CQ

Warning: don't merge this PR until the updated Jackson artifacts (2.9.5) are available in CQ 6.4 (NPR-27169)

Note: the updated Jackson artifacts (2.9.5) are available in CQ 6.3 and 6.5