### PR TITLE
#389 [Content Fragment] 1.0.8 unresolved dependencies with AEM 6.3.3.0

### DIFF
--- a/extension/contentfragment/bundle/src/main/java/com/adobe/cq/wcm/core/components/extension/contentfragment/internal/models/v1/ContentFragmentImpl.java
+++ b/extension/contentfragment/bundle/src/main/java/com/adobe/cq/wcm/core/components/extension/contentfragment/internal/models/v1/ContentFragmentImpl.java
@@ -453,7 +453,7 @@ public class ContentFragmentImpl implements ContentFragment {
             String [] values = getData().getValue(String[].class);
             String value = null;
             if (values != null) {
-                value = org.apache.commons.lang.StringUtils.join(values, ", ");
+                value = StringUtils.join(values, ", ");
             }
             if ("text/html".equals(contentType)) {
                 // return HTML as is


### PR DESCRIPTION
- moves `org.apache.commons.lang.*` reference to `org.apache.commons.lang3.*`

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #389` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | 
| Documentation Provided   | (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
