### PR TITLE
#394 [IE 11] [Tab/Carousel] clicking on Tab title, Carousel indicator makes page jump to the top

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -424,8 +424,8 @@
          * @param {HTMLElement} element Element to focus
          */
         function focusWithoutScroll(element) {
-            var x = window.scrollX;
-            var y = window.scrollY;
+            var x = window.scrollX || window.pageXOffset;
+            var y = window.scrollY || window.pageYOffset;
             element.focus();
             window.scrollTo(x, y);
         }

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
@@ -239,8 +239,8 @@
          * @param {HTMLElement} element Element to focus
          */
         function focusWithoutScroll(element) {
-            var x = window.scrollX;
-            var y = window.scrollY;
+            var x = window.scrollX || window.pageXOffset;
+            var y = window.scrollY || window.pageYOffset;
             element.focus();
             window.scrollTo(x, y);
         }


### PR DESCRIPTION
- fallback for unsupported `window.scrollX`, `window.scrollY` on IE11

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #394 ` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | 
| Documentation Provided   |  (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
