### PR TITLE
Making the import of the commerce bundle optional

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -63,6 +63,10 @@
                         <_dsannotations>*</_dsannotations>
                         <!-- Enable processing of OSGI metatype annotations -->
                         <_metatypeannotations>*</_metatypeannotations>
+                        <Import-Package>
+                            com.adobe.cq.commerce.*;resolution:=optional,
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
                 <dependencies>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/SocialMediaHelperImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/SocialMediaHelperImpl.java
@@ -221,20 +221,24 @@ public class SocialMediaHelperImpl implements SocialMediaHelper {
      * Instantiates the suitable metadata provider based on the contents of the current page.
      */
     private WebsiteMetadata createMetadataProvider() {
-        Product product = CommerceHelper.findCurrentProduct(currentPage);
-        ExperienceFragmentSocialVariation smVariant = findExperienceFragmentSocialVariation();
-        if (product == null) {
-            if (smVariant == null) {
-                return new WebsiteMetadataProvider();
+        try {
+            Product product = CommerceHelper.findCurrentProduct(currentPage);
+            ExperienceFragmentSocialVariation smVariant = findExperienceFragmentSocialVariation();
+            if (product == null) {
+                if (smVariant == null) {
+                    return new WebsiteMetadataProvider();
+                } else {
+                    return new ExperienceFragmentWebsiteMetadataProvider(smVariant);
+                }
             } else {
-                return new ExperienceFragmentWebsiteMetadataProvider(smVariant);
+                if (smVariant == null) {
+                    return new ProductMetadataProvider(product);
+                } else {
+                    return new ExperienceFragmentProductMetadataProvider(product, smVariant);
+                }
             }
-        } else {
-            if (smVariant == null) {
-                return new ProductMetadataProvider(product);
-            } else {
-                return new ExperienceFragmentProductMetadataProvider(product, smVariant);
-            }
+        } catch (NoClassDefFoundError e) {
+            return new WebsiteMetadataProvider();
         }
     }
 


### PR DESCRIPTION
- making the import of the commerce bundle optional
- catching NoClassDefFoundError in SocialMediaHelper in case the commerce API is not available and return the default page metadata in this case

fixes #423