### PR TITLE
@refactor - adds JSON anchor link for scraping content for static export

### DIFF
--- a/examples/content/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/scripts/demo.js
+++ b/examples/content/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/scripts/demo.js
@@ -21,6 +21,7 @@
         self: '[data-cmp-examples-is="demo"]',
         info: '[data-cmp-examples-hook-demo="info"]',
         json: '[data-cmp-examples-hook-demo="json"]',
+        jsonLink: '[data-cmp-examples-hook-demo="jsonLink"]',
         markup: '[data-cmp-examples-hook-demo="markup"]',
         hideCode: '[data-cmp-examples-hook-demo="hideCode"]',
         showCode: '[data-cmp-examples-hook-demo="showCode"]',
@@ -44,10 +45,22 @@
             var copyCode = demo.querySelector(selectors.copyCode);
             var info = demo.querySelector(selectors.info);
             var json = demo.querySelector(selectors.json);
+            var jsonLink = demo.querySelector(selectors.jsonLink);
+            var jsonSrc = "";
             var markup = demo.querySelector(selectors.markup);
 
+            if (jsonLink) {
+                jsonSrc = jsonLink.href;
+
+                // a link to the model JSON is presented initially in the markup so that the content
+                // can be scraped when exporting a static version of the library
+                if (jsonLink.parentNode) {
+                    jsonLink.parentNode.removeChild(jsonLink);
+                }
+            }
+
             if (json) {
-                deferreds.push($.getJSON(json.dataset.cmpSrc + '.model.json', function(data) {
+                deferreds.push($.getJSON(jsonSrc, function(data) {
                     json.innerText = JSON.stringify(data, null, 2);
                 }));
             }

--- a/examples/content/src/content/jcr_root/apps/core-components-examples/components/demo/component/component.html
+++ b/examples/content/src/content/jcr_root/apps/core-components-examples/components/demo/component/component.html
@@ -19,7 +19,7 @@
      data-sly-unwrap="${!editMode || hasChildren}">
     <sly
         data-sly-test="${hasChildren}"
-        data-sly-resource="${resource.children[0] @ wcmmode=editMode?'edit':'disabled'}">
+        data-sly-resource="${resource.children[0] @ wcmmode=editMode ? 'edit': 'disabled'}">
     </sly>
     <sly
         data-sly-test="${editMode && !hasChildren}"

--- a/examples/content/src/content/jcr_root/apps/core-components-examples/components/demo/component/json.html
+++ b/examples/content/src/content/jcr_root/apps/core-components-examples/components/demo/component/json.html
@@ -15,4 +15,6 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */-->
-<code data-cmp-examples-hook-demo="json" class="language-json" data-sly-repeat="${resource.listChildren}" data-cmp-src="${item.path}"></code>
+<code data-sly-repeat="${resource.listChildren}" data-cmp-examples-hook-demo="json">
+    <a data-cmp-examples-hook-demo="jsonLink" href="${item.path}.model.json">JSON</a>
+</code>


### PR DESCRIPTION
Adds links to the component model JSON such that when the library is exported, the JSON resources are also scraped. The anchor hrefs are read for reference and removed on the client.