### PR TITLE
@releng - align separator BEM naming with other components

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/README.md
@@ -24,7 +24,7 @@ Separator component written in HTL.
 ## BEM Description
 ```
 BLOCK cmp-separator
-    ELEMENT cmp-separator__horizontalRule
+    ELEMENT cmp-separator__horizontal-rule
 ```
 
 ## Information

--- a/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/separator.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/separator.html
@@ -14,5 +14,5 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div class="cmp-separator">
-    <hr class="cmp-separator__horizontalRule"/>
+    <hr class="cmp-separator__horizontal-rule"/>
 </div>


### PR DESCRIPTION
Ensures the separator BEM classes are aligned with the pattern used elsewhere.