### PR TITLE
[ContentFragment] Refactor content fragment component (#360)

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -462,6 +462,10 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
             <version>3.23.1-GA</version>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtils.java
@@ -1,0 +1,255 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObjectBuilder;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.models.factory.ModelFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.dam.cfm.ContentElement;
+import com.adobe.cq.dam.cfm.ContentFragment;
+import com.adobe.cq.dam.cfm.FragmentTemplate;
+import com.adobe.cq.export.json.ComponentExporter;
+import com.day.cq.wcm.api.policies.ContentPolicy;
+import com.day.cq.wcm.api.policies.ContentPolicyManager;
+import com.day.text.Text;
+
+import static com.day.cq.commons.jcr.JcrConstants.JCR_CONTENT;
+import static com.day.cq.commons.jcr.JcrConstants.JCR_TITLE;
+
+/**
+ * Utilities to ease the work with {@link ContentFragment content fragments}.
+ */
+public class ContentFragmentUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ContentFragmentUtils.class);
+
+    /**
+     * The default grid type.
+     */
+    protected static final String DEFAULT_GRID_TYPE = "dam/cfm/components/grid";
+
+    /**
+     * Name of the property of an optional {@link ContentPolicy content policy} holding the name of the grid type.
+     */
+    protected static final String PN_CFM_GRID_TYPE = "cfm-grid-type";
+
+    /* Hide the constructor of utility classes */
+    private ContentFragmentUtils() {
+    }
+
+    /**
+     * Returns the type of a {@link ContentFragment content fragment}. The type is a string that uniquely identifies the
+     * model or template of the content fragment (CF) (e.g. <code>my-project/models/my-model</code> for a structured CF
+     * or <code>/content/dam/my-cf/jcr:content/model</code> for a text-only CF).
+     *
+     * @param contentFragment the content fragment
+     * @return the type of the content fragment
+     */
+    public static String getType(ContentFragment contentFragment) {
+        String type = "";
+        if (contentFragment == null) {
+            return type;
+        }
+
+        Resource fragmentResource = contentFragment.adaptTo(Resource.class);
+        FragmentTemplate fragmentTemplate = contentFragment.getTemplate();
+        Resource templateResource = fragmentTemplate.adaptTo(Resource.class);
+        if (fragmentResource == null || templateResource == null) {
+            LOG.warn("Unable to return type: fragment or template resource is null");
+            type = contentFragment.getName();
+        } else {
+            // use the parent if the template resource is the jcr:content child
+            Resource parent = templateResource.getParent();
+            if (JCR_CONTENT.equals(templateResource.getName()) && parent != null) {
+                templateResource = parent;
+            }
+            // get data node to check if this is a text-only or structured content fragment
+            Resource data = fragmentResource.getChild(JCR_CONTENT + "/data");
+            if (data == null || data.getValueMap().get("cq:model") == null) {
+                // this is a text-only content fragment, for which we use the model path as the type
+                type = templateResource.getPath();
+            } else {
+                // this is a structured content fragment, assemble type string (e.g. "my-project/models/my-model" or
+                // "my-project/nested/models/my-model")
+                StringBuilder prefix = new StringBuilder();
+                String[] segments = Text.explode(templateResource.getPath(), '/', false);
+                // get the configuration names (e.g. for "my-project/" or "my-project/nested/")
+                for (int i = 1; i < segments.length - 5; i++) {
+                    prefix.append(segments[i]);
+                    prefix.append("/");
+                }
+                type = prefix.toString() + "models/" + templateResource.getName();
+            }
+        }
+
+        return type;
+    }
+
+
+    /**
+     * Filters {@link ContentElement content elements} by their name.
+     *
+     * <p><b>Note:</b> The natural order of the elements in the content fragment will not be maintained. Instead
+     * elements will be order as provided in the filter.</p>
+     *
+     * @param contentFragment the content fragment
+     * @param elementNames    the names of the elements to filter
+     * @return all content elements found matching the filter
+     */
+    public static Iterator<ContentElement> filterElements(final ContentFragment contentFragment,
+                                                          final String[] elementNames) {
+
+        if (ArrayUtils.isNotEmpty(elementNames)) {
+            List<ContentElement> elements = new LinkedList<>();
+            for (String name : elementNames) {
+                if (!contentFragment.hasElement(name)) {
+                    // skip non-existing element
+                    LOG.warn("Skipping non-existing element '{}'", name);
+                    continue;
+                }
+                elements.add(contentFragment.getElement(name));
+            }
+            return elements.iterator();
+        }
+        return contentFragment.getElements();
+    }
+
+    /**
+     * Returns a JSON representation of given content fragment taking optional element names and a variation name into
+     * account.
+     *
+     * @param contentFragment The content fragment
+     * @param variationName   An optional variation name
+     * @param elementNames    Optional element names
+     * @return A JSON representation of the content fragment
+     */
+    public static String getEditorJSON(final ContentFragment contentFragment,
+                                       final String variationName,
+                                       final String[] elementNames) {
+
+        JsonObjectBuilder jsonObjectBuilder = Json.createObjectBuilder();
+        jsonObjectBuilder.add("title", contentFragment.getTitle());
+
+        Resource contentFragmentResource = contentFragment.adaptTo(Resource.class);
+        if (contentFragmentResource != null) {
+            jsonObjectBuilder.add("path", contentFragmentResource.getPath());
+        }
+
+        if (variationName != null) {
+            jsonObjectBuilder.add("variation", variationName);
+        }
+
+        if (elementNames != null) {
+            JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+            for (String elementName : elementNames) {
+                arrayBuilder.add(elementName);
+            }
+            jsonObjectBuilder.add("elements", arrayBuilder);
+        }
+
+        Iterator<Resource> associatedContentIterator = contentFragment.getAssociatedContent();
+        if (associatedContentIterator.hasNext()) {
+            JsonArrayBuilder associatedContentArray = Json.createArrayBuilder();
+            while (associatedContentIterator.hasNext()) {
+                Resource resource = associatedContentIterator.next();
+                ValueMap valueMap = resource.adaptTo(ValueMap.class);
+                JsonObjectBuilder contentObject = Json.createObjectBuilder();
+                if (valueMap != null && valueMap.containsKey(JCR_TITLE)) {
+                    contentObject.add("title", valueMap.get(JCR_TITLE, String.class));
+                }
+                contentObject.add("path", resource.getPath());
+                associatedContentArray.add(contentObject);
+            }
+            jsonObjectBuilder.add("associatedContent", associatedContentArray);
+        }
+
+        return jsonObjectBuilder.build().toString();
+    }
+
+    /**
+     * Returns an optional grid type configured via {@link ContentPolicy content policy} property
+     * ({@value #PN_CFM_GRID_TYPE}) or {@value #DEFAULT_GRID_TYPE} as default.
+     *
+     * @param resourceResolver a resource resolver
+     * @param resource         the resource to be checked
+     * @return the configured grid type of a default
+     */
+    public static String getGridResourceType(ResourceResolver resourceResolver, Resource resource) {
+        String gridResourceType = DEFAULT_GRID_TYPE;
+        ContentPolicyManager contentPolicyManager = resourceResolver.adaptTo(ContentPolicyManager.class);
+        ContentPolicy fragmentContentPolicy = contentPolicyManager != null ? contentPolicyManager.getPolicy(resource) : null;
+        if (fragmentContentPolicy != null) {
+            ValueMap contentPolicyProperties = fragmentContentPolicy.getProperties();
+            gridResourceType = contentPolicyProperties.get(PN_CFM_GRID_TYPE, DEFAULT_GRID_TYPE);
+        }
+        return gridResourceType;
+    }
+
+    /**
+     * Returns an array with all item keys in order of given map.
+     *
+     * @param itemsMap a map of items
+     * @return an array with all keys in order of given map
+     */
+    public static String[] getItemsOrder(Map<String, ?> itemsMap) {
+        if (itemsMap == null || itemsMap.isEmpty()) {
+            return ArrayUtils.EMPTY_STRING_ARRAY;
+        }
+
+        return itemsMap.keySet().toArray(ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    /**
+     * Returns a map of all given resources mapping their name to their {@link ComponentExporter component exporter}
+     * model.
+     */
+    public static Map<String, ComponentExporter> getComponentExporters(Iterator<Resource> resourceIterator,
+                                                                       ModelFactory modelFactory,
+                                                                       SlingHttpServletRequest slingHttpServletRequest) {
+        final Map<String, ComponentExporter> componentExporterMap = new LinkedHashMap<>();
+
+        while (resourceIterator.hasNext()) {
+            Resource resource = resourceIterator.next();
+            ComponentExporter exporter =
+                modelFactory.getModelFromWrappedRequest(slingHttpServletRequest, resource, ComponentExporter.class);
+
+            if (exporter != null) {
+                String name = resource.getName();
+                if (componentExporterMap.put(name, exporter) != null) {
+                    throw new IllegalStateException(String.format("Duplicate key '%s'", name));
+                }
+            }
+        }
+
+        return componentExporterMap;
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/DAMContentFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/DAMContentFragmentImpl.java
@@ -1,0 +1,299 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2018 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Exporter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.dam.cfm.ContentElement;
+import com.adobe.cq.dam.cfm.ContentFragment;
+import com.adobe.cq.dam.cfm.ContentFragmentException;
+import com.adobe.cq.dam.cfm.ContentVariation;
+import com.adobe.cq.dam.cfm.FragmentData;
+import com.adobe.cq.dam.cfm.converter.ContentTypeConverter;
+import com.adobe.cq.export.json.ExporterConstants;
+import com.adobe.cq.wcm.core.components.internal.ContentFragmentUtils;
+import com.adobe.cq.wcm.core.components.models.contentfragment.DAMContentFragment;
+
+@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+public class DAMContentFragmentImpl implements DAMContentFragment {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DAMContentFragmentImpl.class);
+
+    /**
+     * The name of the master variation.
+     */
+    private static final String MASTER_VARIATION = "master";
+
+    private final com.adobe.cq.dam.cfm.ContentFragment contentFragment;
+    private final String variationName;
+    private final String[] elementNames;
+    private final String resourceType;
+
+    private String type;
+    private List<DAMContentElement> elements;
+    private Map<String, DAMContentElement> exportedElements;
+
+    /**
+     * Creates a new instance of a content fragment. Requires the content fragment's resource and a content type
+     * converter, and optional variation name and element names to be filtered.
+     *
+     * @param contentFragmentResource resource of the content fragment
+     * @param contentTypeConverter    content type converter
+     * @param variationName           name of an optional variation
+     * @param elementNames            names of optional elements to be filtered
+     */
+    public DAMContentFragmentImpl(@NotNull Resource contentFragmentResource,
+                                  @NotNull ContentTypeConverter contentTypeConverter,
+                                  String variationName, String[] elementNames) {
+
+        this.variationName = variationName;
+        this.resourceType = contentFragmentResource.getResourceType();
+        if (elementNames == null) {
+            this.elementNames = null;
+        } else {
+            this.elementNames = new String[elementNames.length];
+            System.arraycopy(elementNames, 0, this.elementNames, 0, elementNames.length);
+        }
+
+        this.contentFragment = contentFragmentResource.adaptTo(com.adobe.cq.dam.cfm.ContentFragment.class);
+        if (contentFragment == null) {
+            LOG.error("Content Fragment can not be initialized because '{}' is not a content fragment.",
+                    contentFragmentResource.getPath());
+        } else {
+            // Type cannot be determined lazily due to leaking resource resolver (query builder)
+            this.type = ContentFragmentUtils.getType(contentFragment);
+
+            final Iterator<ContentElement> contentElementIterator =
+                    ContentFragmentUtils.filterElements(contentFragment, elementNames);
+
+            // Wrap elements and get their configured variation (if any)
+            this.exportedElements = new LinkedHashMap<>();
+            while (contentElementIterator.hasNext()) {
+                final ContentElement contentElement = contentElementIterator.next();
+                ContentVariation variation = null;
+                if (StringUtils.isNotEmpty(variationName) && !MASTER_VARIATION.equals(variationName)) {
+                    variation = contentElement.getVariation(variationName);
+                    if (variation == null) {
+                        LOG.warn("Non-existing variation '{}' of element '{}'", variationName, contentElement.getName());
+                    }
+                }
+                this.exportedElements.put(contentElement.getName(),
+                        new DAMContentElementImpl(contentTypeConverter, contentElement, variation));
+            }
+
+            this.elements = new ArrayList<>(exportedElements.values());
+        }
+    }
+
+    @Nullable
+    @Override
+    public String getTitle() {
+        return contentFragment.getTitle();
+    }
+
+    @Nullable
+    @Override
+    public String getDescription() {
+        return contentFragment.getDescription();
+    }
+
+    /**
+     * Returns the type of a {@link ContentFragment content fragment}. The type is a string that uniquely identifies the
+     * model or template of the content fragment (CF) (e.g. <code>my-project/models/my-model</code> for a structured CF
+     * or <code>/content/dam/my-cf/jcr:content/model</code> for a text-only CF).
+     *
+     * @return the type of the content fragment
+     */
+    @Nullable
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Nullable
+    @Override
+    public List<DAMContentElement> getElements() {
+        return elements;
+    }
+
+    @NotNull
+    @Override
+    public Map<String, DAMContentElement> getExportedElements() {
+        return exportedElements;
+    }
+
+    @NotNull
+    @Override
+    public String[] getExportedElementsOrder() {
+        return ContentFragmentUtils.getItemsOrder(exportedElements);
+    }
+
+    @Nullable
+    @Override
+    public List<Resource> getAssociatedContent() {
+        return IteratorUtils.toList(contentFragment.getAssociatedContent());
+    }
+
+    @NotNull
+    @Override
+    public String getExportedType() {
+        return resourceType;
+    }
+
+    @NotNull
+    @Override
+    public String getEditorJSON() {
+        return ContentFragmentUtils.getEditorJSON(contentFragment, variationName, elementNames);
+    }
+
+    /**
+     * Represents a content element of a content fragment.
+     */
+    public static class DAMContentElementImpl implements DAMContentElement {
+
+        private static final Logger LOG = LoggerFactory.getLogger(DAMContentElementImpl.class);
+
+        private static final String TEXT_HTML = "text/html";
+
+        private final ContentTypeConverter converter;
+        private final ContentElement element;
+        private final ContentVariation variation;
+
+        private String htmlValue;
+
+        /**
+         * @param converter the converter to use to convert the value of text elements to HTML
+         * @param element   the original element
+         * @param variation the configured variation of the element, or {@code null}
+         */
+        public DAMContentElementImpl(@NotNull ContentTypeConverter converter,
+                                     @NotNull ContentElement element,
+                                     @Nullable ContentVariation variation) {
+            this.converter = converter;
+            this.element = element;
+            this.variation = variation;
+        }
+
+
+        @NotNull
+        @Override
+        public String getName() {
+            return element.getName();
+        }
+
+        @Nullable
+        @Override
+        public String getTitle() {
+            return element.getTitle();
+        }
+
+        private FragmentData getData() {
+            if (variation != null) {
+                return variation.getValue();
+            }
+            return element.getValue();
+        }
+
+        @NotNull
+        @Override
+        public String getDataType() {
+            return getData().getDataType().getTypeString();
+        }
+
+        @Nullable
+        @Override
+        public Object getValue() {
+            return getData().getValue();
+        }
+
+        @NotNull
+        @Override
+        public String getExportedType() {
+            final FragmentData value = getData();
+            // Mime type for text-based data types
+            String type = value.getContentType();
+
+            // Data type for non text-based data types
+            if (type == null) {
+                type = value.getDataType().getTypeString();
+            }
+
+            return type;
+        }
+
+        private String getContentType() {
+            return getData().getContentType();
+        }
+
+        @Override
+        public boolean isMultiLine() {
+            String contentType = getContentType();
+            // a text element is defined as a single-valued element with a certain content type (e.g. "text/plain",
+            // "text/html", "text/x-markdown", potentially others)
+            return contentType != null && contentType.startsWith("text/") && !isMultiValue();
+        }
+
+        @Override
+        public boolean isMultiValue() {
+            return getData().getDataType().isMultiValue();
+        }
+
+        @Nullable
+        @Override
+        public String getHtml() {
+            // restrict this method to text elements
+            if (!isMultiLine()) {
+                return null;
+            }
+
+            String contentType = getContentType();
+            String[] values = getData().getValue(String[].class);
+            String value = null;
+            if (values != null) {
+                value = StringUtils.join(values, ", ");
+            }
+
+            if (TEXT_HTML.equals(contentType)) {
+                // return HTML as is
+                return value;
+            } else {
+                if (htmlValue == null) {
+                    try {
+                        // convert element value to HTML
+                        htmlValue = converter.convertToHTML(value, contentType);
+                    } catch (ContentFragmentException e) {
+                        LOG.warn("Could not convert value to HTML", e);
+                        return null;
+                    }
+                }
+                return htmlValue;
+            }
+        }
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/ContentFragment.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/ContentFragment.java
@@ -17,26 +17,20 @@ package com.adobe.cq.wcm.core.components.models.contentfragment;
 
 import java.util.Map;
 
-import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.osgi.annotation.versioning.ConsumerType;
 
-import com.adobe.cq.dam.cfm.ContentElement;
-import com.adobe.cq.dam.cfm.FragmentData;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Defines the Sling Model for the {@code /apps/core/wcm/components/contentfragment} component. The model
+ * Defines the Sling model for the {@code /apps/core/wcm/components/contentfragment/v1} component. The model
  * provides information about the referenced content fragment and access to representations of its elements.
  *
  * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
  */
-@ConsumerType
-public interface ContentFragment extends ContainerExporter {
+public interface ContentFragment extends DAMContentFragment, ContainerExporter {
 
     /**
      * Name of the mandatory resource property that stores the path to a content fragment.
@@ -59,259 +53,20 @@ public interface ContentFragment extends ContainerExporter {
      */
     String PN_VARIATION_NAME = "variationName";
 
-    /**
-     * Name of the property (in JSON export) that provides the path to the model of the content fragment
-     */
-    String JSON_PN_MODEL = "model";
 
     /**
-     * Name of the property (in JSON export) that provides an object containing the elements of the
-     * content fragment; the keys of the object properties refer to the element names
-     */
-    String JSON_PN_ELEMENTS = "elements";
-
-    /**
-     * Name of the property (in JSON export) that provides an array containing the names of the
-     * elements of the content fragment in the correct order
-     */
-    String JSON_PN_ELEMENTS_ORDER = "elementsOrder";
-
-    /**
-     * Represents a content element of a content fragment.
+     * Name of the required property that stores whether a single text element (<code>singleText</code>) or multiple
+     * elements (<code>multi</code>) are displayed.
      *
      * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
      */
-    @ConsumerType
-    interface Element extends ComponentExporter {
-
-        /**
-         * Returns the technical name of the element.
-         *
-         * @return the technical name of the element
-         * @see ContentElement#getName()
-         * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
-         */
-        @NotNull
-        @JsonIgnore
-        default String getName() {
-            throw new UnsupportedOperationException();
-        }
-
-        /**
-         * Returns the title of the element.
-         *
-         * @return the title of the element
-         * @see ContentElement#getTitle()
-         * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
-         */
-        @Nullable
-        default String getTitle() {
-            throw new UnsupportedOperationException();
-        }
-
-        /**
-         * Returns the string representation of data type of {@link FragmentData} of the element.
-         * For the possible values see {@link com.adobe.cq.dam.cfm.BasicDataType}. Note that this doesn't
-         * contain information about the multivalued characteristic of element. Eg. even if the actual value is of type
-         * String [], the data type returned would be String.
-         *
-         * @return the data type string
-         * @see FragmentData#getDataType()
-         * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
-         */
-        @NotNull
-        default String getDataType() {
-            throw new UnsupportedOperationException();
-        }
-
-        /**
-         * Returns the value of the element. The returned object's type would correspond to the types as specified in
-         * {@link com.adobe.cq.dam.cfm.BasicDataType} or an array of those types.
-         *
-         * @return the value of the element
-         * @see FragmentData#getValue()
-         * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
-         */
-        @Nullable
-        default Object getValue() {
-            throw new UnsupportedOperationException();
-        }
-
-        @NotNull
-        @Override
-        default String getExportedType() {
-            throw new UnsupportedOperationException();
-        }
-
-        /**
-         * Returns {@code true} if this is a multiline text element, i.e. a textual element containing multiple lines
-         * (paragraphs).
-         *
-         * @return {@code true} if the element is a multiline text element, {@code false} otherwise
-         */
-        @JsonIgnore
-        default boolean isMultiLine() {
-            throw new UnsupportedOperationException();
-        }
-
-        /**
-         * Returns the value of a multiline text element converted to HTML. It uses
-         * {@link com.adobe.cq.dam.cfm.converter.ContentTypeConverter#convertToHTML(String, String)} to convert the
-         * value to html. Returns {@code null} for non-multiline-text elements.
-         *
-         * @return the value of the element converted to HTML or {@code null} for non-multiline-text elements
-         * @see #isMultiLine()
-         * @see com.adobe.cq.dam.cfm.converter.ContentTypeConverter#convertToHTML(String, String)
-         */
-        @Nullable
-        @JsonIgnore
-        default String getHtml() {
-            throw new UnsupportedOperationException();
-        }
-
-        /**
-         * Returns the paragraphs of a multiline text element by rendering it using
-         * {@link com.adobe.cq.dam.cfm.content.FragmentRenderService} and splitting the result into separate paragraphs.
-         * Returns {@code null} for non-multiline-text elements.
-         *
-         * @return an array containing HTML paragraphs or {@code null} for non-multiline-text elements
-         * @see #isMultiLine()
-         * @see #getHtml()
-         */
-        @Nullable
-        default String[] getParagraphs() {
-            throw new UnsupportedOperationException();
-        }
-    }
-
-    /**
-     * Returns the title of the content fragment.
-     *
-     * @return the title of the content fragment
-     * @see com.adobe.cq.dam.cfm.ContentFragment#getTitle()
-     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
-     */
-    @Nullable
-    default String getTitle() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Returns the description of the content fragment.
-     *
-     * @return the description of the content fragment
-     * @see com.adobe.cq.dam.cfm.ContentFragment#getDescription()
-     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
-     */
-    @Nullable
-    default String getDescription() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Returns the type of the content fragment. The type is a string that uniquely identifies the model or template of
-     * the content fragment (e.g. "my-project/models/my-model" for a structured or
-     * "/content/dam/my-cf/jcr:content/model" for a text-only content fragment).
-     *
-     * @return the type of the content fragment
-     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
-     */
-    @Nullable
-    @JsonProperty(JSON_PN_MODEL)
-    default String getType() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Returns a list of content fragment elements. The list contains the elements whose names are specified in the
-     * property {@link ContentFragment#PN_ELEMENT_NAMES} (in that order, and skipping non-existing elements). If
-     * {@link ContentFragment#PN_ELEMENT_NAMES} is not set, then all elements are returned, in the order in which they
-     * occur in the content fragment.
-     *
-     * @return a selection or all of the content fragment's elements
-     * @see com.adobe.cq.dam.cfm.ContentFragment#getElements()
-     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
-     */
-    @Nullable
-    @JsonIgnore
-    default java.util.List<Element> getElements() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Returns a map of elements that are used for creating the JSON export. The keys of the map determine the
-     * name of the element. The value holds the Sling Model that is used for the export. The map only contains
-     * elements that are configured through the property {@link ContentFragment#PN_ELEMENT_NAMES} or all elements
-     * if the property is not set.
-     *
-     * @return a map containing the elements that are subject to be exported
-     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
-     */
-    @NotNull
-    @JsonProperty(JSON_PN_ELEMENTS)
-    default java.util.Map<String, Element> getExportedElements() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Returns the names of the elements in the correct order. The names correspond to the keys of the map
-     * returned by {@link ContentFragment#getExportedElements}.
-     *
-     * @return Array that determines the order of the elements
-     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
-     */
-    @NotNull
-    @JsonProperty(JSON_PN_ELEMENTS_ORDER)
-    default String[] getExportedElementsOrder() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Returns a list of resources representing the collections that are associated to this content fragment.
-     *
-     * @return a list of collection resources
-     * @see ContentFragment#getAssociatedContent()
-     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
-     */
-    @Nullable
-    @JsonIgnore
-    default java.util.List<Resource> getAssociatedContent() {
-        throw new UnsupportedOperationException();
-    }
-
-    @NotNull
-    @Override
-    default String getExportedType() {
-        throw new UnsupportedOperationException();
-    }
-
-    @NotNull
-    @Override
-    default Map<String, ComponentExporter> getExportedItems() {
-        throw new UnsupportedOperationException();
-    }
-
-    @NotNull
-    @Override
-    default String[] getExportedItemsOrder() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Returns a JSON format string containing information about this fragment.
-     *
-     * @return JSON string
-     */
-    @NotNull
-    @JsonIgnore
-    default String getEditorJSON() {
-        throw new UnsupportedOperationException();
-    }
+    String PN_DISPLAY_MODE = "displayMode";
 
     /**
      * Returns resource type that is used for the internal responsive grid.
      *
      * @return resource type
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
      */
     @NotNull
     @JsonIgnore
@@ -319,4 +74,47 @@ public interface ContentFragment extends ContainerExporter {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Returns the map of all exported child items (resource names from Sling Model classes).
+     *
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @NotNull
+    @Override
+    default Map<String, ? extends ComponentExporter> getExportedItems() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the order of items in the map.
+     *
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @NotNull
+    @Override
+    default String[] getExportedItemsOrder() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the type of the resource for which the export is performed.
+     *
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @NotNull
+    @Override
+    default String getExportedType() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the paragraphs of a multiline text element.
+     *
+     * @return an array containing HTML paragraphs or {@code null} for non-multiline-text elements
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @Nullable
+    default String[] getParagraphs() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/DAMContentFragment.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/DAMContentFragment.java
@@ -1,0 +1,293 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2018 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.models.contentfragment;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ConsumerType;
+
+import com.adobe.cq.export.json.ComponentExporter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Defines the API for a DAM content fragment used by the {@link ContentFragment content fragment component}
+ * and the future list model. The model provides information about the referenced content fragment and access to
+ * representations of its elements.
+ *
+ * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+ */
+@ConsumerType
+public interface DAMContentFragment extends ComponentExporter {
+
+    /**
+     * Name of the property (in JSON export) that provides the path to the model of the content fragment
+     *
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    String JSON_PN_MODEL = "model";
+
+    /**
+     * Name of the property (in JSON export) that provides an object containing the elements of the
+     * content fragment; the keys of the object properties refer to the element names
+     *
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    String JSON_PN_ELEMENTS = "elements";
+
+    /**
+     * Name of the property (in JSON export) that provides an array containing the names of the
+     * elements of the content fragment in the correct order
+     *
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    String JSON_PN_ELEMENTS_ORDER = "elementsOrder";
+
+    /**
+     * Represents a content element of a content fragment.
+     *
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @ConsumerType
+    interface DAMContentElement extends ComponentExporter {
+
+        /**
+         * Returns the technical name of the element.
+         *
+         * @return the technical name of the element
+         * @see com.adobe.cq.dam.cfm.ContentElement#getName()
+         * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+         */
+        @NotNull
+        @JsonIgnore
+        default String getName() {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * Returns the title of the element.
+         *
+         * @return the title of the element
+         * @see com.adobe.cq.dam.cfm.ContentElement#getTitle()
+         * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+         */
+        @Nullable
+        default String getTitle() {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * Returns the string representation of data type of {@link com.adobe.cq.dam.cfm.FragmentData} of the element.
+         * For the possible values see {@link com.adobe.cq.dam.cfm.BasicDataType}. Note that this doesn't
+         * contain information about the multivalued characteristic of element. Eg. even if the actual value is of type
+         * String [], the data type returned would be String.
+         *
+         * @return the data type string
+         * @see com.adobe.cq.dam.cfm.FragmentData#getDataType()
+         * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+         */
+        @NotNull
+        default String getDataType() {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * Returns the value of the element. The returned object's type would correspond to the types as specified in
+         * {@link com.adobe.cq.dam.cfm.BasicDataType} or an array of those types.
+         *
+         * @return the value of the element
+         * @see com.adobe.cq.dam.cfm.FragmentData#getValue()
+         * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+         */
+        @Nullable
+        default Object getValue() {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * Returns the type of the resource for which the export is performed.
+         *
+         * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+         */
+        @NotNull
+        @Override
+        default String getExportedType() {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * Returns {@code true} if this is a multiline text element, i.e. a textual element containing multiple lines
+         * (paragraphs).
+         *
+         * @return {@code true} if the element is a multiline text element, {@code false} otherwise
+         * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+         */
+        @JsonIgnore
+        default boolean isMultiLine() {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * Returns {@code true} if this is a multi-valued element value.
+         *
+         * @return {@code true} if the element is multi-valued, {@code false} otherwise
+         * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+         */
+        @JsonProperty("multiValue")
+        default boolean isMultiValue() {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * Returns the value of a multiline text element converted to HTML. It uses
+         * {@link com.adobe.cq.dam.cfm.converter.ContentTypeConverter#convertToHTML(String, String)} to convert the
+         * value to html. Returns {@code null} for non-multiline-text elements.
+         *
+         * @return the value of the element converted to HTML or {@code null} for non-multiline-text elements
+         * @see #isMultiLine()
+         * @see com.adobe.cq.dam.cfm.converter.ContentTypeConverter#convertToHTML(String, String)
+         * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+         */
+        @Nullable
+        @JsonIgnore
+        default String getHtml() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * Returns the title of the content fragment.
+     *
+     * @return the title of the content fragment
+     * @see com.adobe.cq.dam.cfm.ContentFragment#getTitle()
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @Nullable
+    default String getTitle() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the description of the content fragment.
+     *
+     * @return the description of the content fragment
+     * @see com.adobe.cq.dam.cfm.ContentFragment#getDescription()
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @Nullable
+    default String getDescription() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the type of the content fragment. The type is a string that uniquely identifies the model or template of
+     * the content fragment (e.g. "my-project/models/my-model" for a structured or
+     * "/content/dam/my-cf/jcr:content/model" for a text-only content fragment).
+     *
+     * @return the type of the content fragment
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @Nullable
+    @JsonProperty(JSON_PN_MODEL)
+    default String getType() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a list of content fragment elements. The list contains the elements whose names are specified in the
+     * property {@link ContentFragment#PN_ELEMENT_NAMES} (in that order, and skipping non-existing
+     * elements). If {@link ContentFragment#PN_ELEMENT_NAMES} is not set, then all elements are returned,
+     * in the order in which they occur in the content fragment.
+     *
+     * @return a selection or all of the content fragment's elements
+     * @see com.adobe.cq.dam.cfm.ContentFragment#getElements()
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @Nullable
+    @JsonIgnore
+    default List<DAMContentElement> getElements() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a map of elements that are used for creating the JSON export. The keys of the map determine the
+     * name of the element. The value holds the Sling Model that is used for the export. The map only contains
+     * elements that are configured through the property {@link ContentFragment#PN_ELEMENT_NAMES}
+     * or all elements if the property is not set.
+     *
+     * @return a map containing the elements that are subject to be exported
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @NotNull
+    @JsonProperty(JSON_PN_ELEMENTS)
+    default Map<String, DAMContentElement> getExportedElements() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the names of the elements in the correct order. The names correspond to the keys of the map
+     * returned by {@link DAMContentFragment#getExportedElements}.
+     *
+     * @return Array that determines the order of the elements
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @NotNull
+    @JsonProperty(JSON_PN_ELEMENTS_ORDER)
+    default String[] getExportedElementsOrder() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a list of resources representing the collections that are associated to this content fragment.
+     *
+     * @return a list of collection resources
+     * @see DAMContentFragment#getAssociatedContent()
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @Nullable
+    @JsonIgnore
+    default List<Resource> getAssociatedContent() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the type of the resource for which the export is performed.
+     *
+     * @return the type of the resource
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @NotNull
+    @Override
+    default String getExportedType() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a JSON format string containing information about this fragment.
+     *
+     * @return JSON string
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
+     */
+    @NotNull
+    @JsonIgnore
+    default String getEditorJSON() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/ContentFragmentModelsCommonsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/ContentFragmentModelsCommonsTest.java
@@ -23,7 +23,7 @@ public class ContentFragmentModelsCommonsTest extends AbstractModelTest {
 
     @Test
     public void testDefaultBehaviour() throws Exception {
-        testDefaultBehaviour(new String[] {
+        testDefaultBehaviour(new String[]{
                 "com.adobe.cq.wcm.core.components.models.v1.contentfragment"
         });
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtilsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtilsTest.java
@@ -1,0 +1,312 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.models.factory.ModelFactory;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.apache.sling.testing.resourceresolver.MockValueMap;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.collection.IsIterableContainingInOrder;
+import org.hamcrest.collection.IsMapContaining;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.adobe.cq.dam.cfm.ContentElement;
+import com.adobe.cq.dam.cfm.ContentFragment;
+import com.adobe.cq.dam.cfm.FragmentTemplate;
+import com.adobe.cq.export.json.ComponentExporter;
+import com.day.cq.wcm.api.policies.ContentPolicy;
+import com.day.cq.wcm.api.policies.ContentPolicyManager;
+
+import static com.adobe.cq.wcm.core.components.internal.ContentFragmentUtils.PN_CFM_GRID_TYPE;
+import static com.day.cq.commons.jcr.JcrConstants.JCR_CONTENT;
+import static com.day.cq.commons.jcr.JcrConstants.JCR_TITLE;
+
+public class ContentFragmentUtilsTest {
+
+
+    @Test
+    public void getTypeWhenContentFragmentIsNull() {
+        // GIVEN
+        // WHEN
+        String type = ContentFragmentUtils.getType(null);
+
+        // THEN
+        Assert.assertThat(type, CoreMatchers.is(""));
+    }
+
+    @Test
+    public void getTypeWhenResourceIsNull() {
+        // GIVEN
+        FragmentTemplate fragmentTemplate = Mockito.mock(FragmentTemplate.class);
+        ContentFragment contentFragment = Mockito.mock(ContentFragment.class);
+        Mockito.when(contentFragment.getTemplate()).thenReturn(fragmentTemplate);
+        Mockito.when(contentFragment.getName()).thenReturn("foobar");
+
+        // WHEN
+        String type = ContentFragmentUtils.getType(contentFragment);
+
+        // THEN
+        Assert.assertThat(type, CoreMatchers.is("foobar"));
+    }
+
+    @Test
+    public void getTypeWhenTemplateResourceIsNotNull() {
+        // GIVEN
+        Resource fragmentResource = Mockito.mock(Resource.class);
+        Resource templateResource = Mockito.mock(Resource.class);
+        FragmentTemplate fragmentTemplate = Mockito.mock(FragmentTemplate.class);
+        ContentFragment contentFragment = Mockito.mock(ContentFragment.class);
+
+        Mockito.when(contentFragment.getTemplate()).thenReturn(fragmentTemplate);
+        Mockito.when(contentFragment.adaptTo(Mockito.eq(Resource.class))).thenReturn(fragmentResource);
+        Mockito.when(fragmentTemplate.adaptTo(Mockito.eq(Resource.class))).thenReturn(templateResource);
+        Mockito.when(templateResource.getPath()).thenReturn("/foo/bar/qux");
+
+        // WHEN
+        String type = ContentFragmentUtils.getType(contentFragment);
+
+        // THEN
+        Assert.assertThat(type, CoreMatchers.is("/foo/bar/qux"));
+    }
+
+    @Test
+    public void getTypeWhenTemplateResourceIsNotNullButIsContentNodeFallbackToParent() {
+        // GIVEN
+        Resource fragmentResource = Mockito.mock(Resource.class);
+        Resource templateResourceParent = Mockito.mock(Resource.class);
+        Resource templateResource = Mockito.mock(Resource.class);
+        FragmentTemplate fragmentTemplate = Mockito.mock(FragmentTemplate.class);
+        ContentFragment contentFragment = Mockito.mock(ContentFragment.class);
+
+        Mockito.when(contentFragment.getTemplate()).thenReturn(fragmentTemplate);
+        Mockito.when(contentFragment.adaptTo(Mockito.eq(Resource.class))).thenReturn(fragmentResource);
+        Mockito.when(fragmentTemplate.adaptTo(Mockito.eq(Resource.class))).thenReturn(templateResource);
+        Mockito.when(templateResource.getName()).thenReturn(JCR_CONTENT);
+        Mockito.when(templateResource.getParent()).thenReturn(templateResourceParent);
+        Mockito.when(templateResourceParent.getPath()).thenReturn("/foo/bar");
+
+        // WHEN
+        String type = ContentFragmentUtils.getType(contentFragment);
+
+        // THEN
+        Assert.assertThat(type, CoreMatchers.is("/foo/bar"));
+    }
+
+    @Test
+    public void getTypeOfStructuredContentFragment() {
+        // GIVEN
+        Resource fragmentResource = Mockito.mock(Resource.class);
+        Resource fragmentDataResource = Mockito.mock(Resource.class);
+        Resource templateResource = Mockito.mock(Resource.class);
+        FragmentTemplate fragmentTemplate = Mockito.mock(FragmentTemplate.class);
+        ContentFragment contentFragment = Mockito.mock(ContentFragment.class);
+        ValueMap valueMap = new MockValueMap(fragmentDataResource);
+        valueMap.put("cq:model", "foo.bar.QuxModel");
+
+        Mockito.when(contentFragment.getTemplate()).thenReturn(fragmentTemplate);
+        Mockito.when(contentFragment.adaptTo(Mockito.eq(Resource.class))).thenReturn(fragmentResource);
+        Mockito.when(fragmentResource.getChild(Mockito.eq(JCR_CONTENT + "/data"))).thenReturn(fragmentDataResource);
+        Mockito.when(fragmentDataResource.getValueMap()).thenReturn(valueMap);
+        Mockito.when(fragmentTemplate.adaptTo(Mockito.eq(Resource.class))).thenReturn(templateResource);
+        Mockito.when(templateResource.getPath()).thenReturn("/foo/bar/qux/quux/corge/grault/garply");
+        Mockito.when(templateResource.getName()).thenReturn("waldo");
+
+        // WHEN
+        String type = ContentFragmentUtils.getType(contentFragment);
+
+        // THEN
+        Assert.assertThat(type, CoreMatchers.is("bar/models/waldo"));
+    }
+
+
+    @Test
+    public void filterEmptyElementNamesReturnsOriginalList() {
+        // GIVEN
+        ContentFragment contentFragment = Mockito.mock(ContentFragment.class);
+        Iterator<ContentElement> contentElementIterator = Mockito.mock(Iterator.class);
+
+        Mockito.when(contentFragment.getElements()).thenReturn(contentElementIterator);
+
+        // WHEN
+        Iterator<ContentElement> elementIterator = ContentFragmentUtils.filterElements(contentFragment, null);
+
+        // THEN
+        Assert.assertThat(elementIterator, CoreMatchers.is(contentElementIterator));
+    }
+
+    @Test
+    public void filterElementNamesReturnsAppropriateElementsOnly() {
+        // GIVEN
+        ContentElement foo = Mockito.mock(ContentElement.class);
+        ContentElement qux = Mockito.mock(ContentElement.class);
+        ContentFragment contentFragment = Mockito.mock(ContentFragment.class);
+        Mockito.when(contentFragment.hasElement(Mockito.eq("foo"))).thenReturn(true);
+        Mockito.when(contentFragment.hasElement(Mockito.eq("bar"))).thenReturn(false);
+        Mockito.when(contentFragment.hasElement(Mockito.eq("qux"))).thenReturn(true);
+        Mockito.when(contentFragment.getElement(Mockito.eq("foo"))).thenReturn(foo);
+        Mockito.when(contentFragment.getElement(Mockito.eq("qux"))).thenReturn(qux);
+
+        // WHEN
+        Iterator<ContentElement> elementIterator = ContentFragmentUtils.filterElements(contentFragment,
+                new String[]{"foo", "bar", "qux"});
+
+        // THEN
+        Assert.assertThat(() -> elementIterator, IsIterableContainingInOrder.contains(foo, qux));
+    }
+
+    @Test
+    public void getEditorJsonOutputOfContentFragment() throws Exception {
+        // GIVEN
+        InputStream expectedJsonResourceAsStream = this.getClass().getResourceAsStream("expectedJson.json");
+        String expectedJsonOutput = IOUtils.toString(expectedJsonResourceAsStream, StandardCharsets.UTF_8);
+
+        Resource contentFragmentResource = Mockito.mock(Resource.class);
+        ContentFragment contentFragment = Mockito.mock(ContentFragment.class);
+        Iterator<Resource> associatedContentResourceIterator = Mockito.mock(Iterator.class);
+        Resource firstAndOnlyAssociatedContent = Mockito.mock(Resource.class);
+        ValueMap associatedContentValueMap = new MockValueMap(firstAndOnlyAssociatedContent);
+        associatedContentValueMap.put(JCR_TITLE, "associatedContentTitle");
+
+        Mockito.when(contentFragment.getTitle()).thenReturn("titleOfTheContentFragment");
+        Mockito.when(contentFragment.getAssociatedContent()).thenReturn(associatedContentResourceIterator);
+        Mockito.when(contentFragment.adaptTo(Mockito.eq(Resource.class))).thenReturn(contentFragmentResource);
+        Mockito.when(contentFragmentResource.getPath()).thenReturn("/path/to/the/content/fragment");
+        Mockito.when(associatedContentResourceIterator.hasNext()).thenReturn(true, true, false);
+        Mockito.when(associatedContentResourceIterator.next()).thenReturn(firstAndOnlyAssociatedContent);
+        Mockito.when(firstAndOnlyAssociatedContent.getPath()).thenReturn("/path/to/the/associated/content");
+        Mockito.when(firstAndOnlyAssociatedContent.adaptTo(ValueMap.class)).thenReturn(associatedContentValueMap);
+
+        // WHEN
+        String json = ContentFragmentUtils.getEditorJSON(contentFragment, "slave",
+                new String[]{"foo", "bar"});
+
+        // THEN
+        Assert.assertThat(expectedJsonOutput.replaceAll("[\n\t ]", ""), CoreMatchers.is(json));
+    }
+
+    @Test
+    public void getDefaultGridResourceType() {
+        // GIVEN
+        ResourceResolver resourceResolver = Mockito.mock(ResourceResolver.class);
+        Resource resource = Mockito.mock(Resource.class);
+
+        // WHEN
+        String defaultGridResourceType = ContentFragmentUtils.getGridResourceType(resourceResolver, resource);
+
+        // THEN
+        Assert.assertThat(defaultGridResourceType, CoreMatchers.is(ContentFragmentUtils.DEFAULT_GRID_TYPE));
+    }
+
+    @Test
+    public void getGridTypeSetInFragmentPolicy() {
+        // GIVEN
+        ContentPolicyManager contentPolicyManager = Mockito.mock(ContentPolicyManager.class);
+        ContentPolicy contentPolicy = Mockito.mock(ContentPolicy.class);
+        ResourceResolver resourceResolver = Mockito.mock(ResourceResolver.class);
+        Resource resource = Mockito.mock(Resource.class);
+        ValueMap valueMap = new MockValueMap(resource);
+        valueMap.put(PN_CFM_GRID_TYPE, "foobar");
+
+        Mockito.when(resourceResolver.adaptTo(Mockito.eq(ContentPolicyManager.class))).thenReturn(contentPolicyManager);
+        Mockito.when(contentPolicyManager.getPolicy(Mockito.eq(resource))).thenReturn(contentPolicy);
+        Mockito.when(contentPolicy.getProperties()).thenReturn(valueMap);
+
+        // WHEN
+        String defaultGridResourceType = ContentFragmentUtils.getGridResourceType(resourceResolver, resource);
+
+        // THEN
+        Assert.assertThat(defaultGridResourceType, CoreMatchers.is("foobar"));
+    }
+
+    @Test
+    public void getItemsOrderOfEmptyMap() {
+        // GIVEN
+        Map<String, Object> items = new HashMap<>();
+
+        // WHEN
+        String[] itemsOrder = ContentFragmentUtils.getItemsOrder(items);
+
+        // THEN
+        Assert.assertThat(itemsOrder, CoreMatchers.is(ArrayUtils.EMPTY_STRING_ARRAY));
+    }
+
+    @Test
+    public void getItemsOrderOfMap() {
+        // GIVEN
+        Map<String, Object> items = new LinkedHashMap<>();
+        items.put("first", "3");
+        items.put("second", 1);
+        items.put("third", 2L);
+
+        // WHEN
+        String[] itemsOrder = ContentFragmentUtils.getItemsOrder(items);
+
+        // THEN
+        Assert.assertThat(itemsOrder, CoreMatchers.is(new String[]{"first", "second", "third"}));
+    }
+
+    @Test
+    public void getComponentExport() {
+        // GIVEN
+        SlingContext slingContext = new SlingContext();
+        slingContext.load().json(this.getClass().getResourceAsStream("foo.json"), "/foo");
+        MockSlingHttpServletRequest slingHttpServletRequest =
+                new MockSlingHttpServletRequest(slingContext.bundleContext());
+
+        ComponentExporter componentExporter = new TestComponentExporter();
+
+        ModelFactory modelFactory = Mockito.mock(ModelFactory.class);
+        Mockito.when(modelFactory.getModelFromWrappedRequest(
+                Mockito.any(), Mockito.any(), Mockito.eq(ComponentExporter.class)
+        )).thenReturn(componentExporter);
+
+        // WHEN
+        Map<String, ComponentExporter> exporterMap =
+                ContentFragmentUtils.getComponentExporters(slingContext.resourceResolver()
+                        .getResource("/foo").listChildren(), modelFactory, slingHttpServletRequest);
+
+        // THEN
+        Assert.assertThat(exporterMap, IsMapContaining.hasEntry("bar", componentExporter));
+        Assert.assertThat(exporterMap, IsMapContaining.hasEntry("qux", componentExporter));
+    }
+
+    /**
+     * Dummy test {@link ComponentExporter component exporter}.
+     */
+    private static class TestComponentExporter implements ComponentExporter {
+        @NotNull
+        @Override
+        public String getExportedType() {
+            return "test";
+        }
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/AbstractContentFragmentTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/AbstractContentFragmentTest.java
@@ -1,0 +1,200 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nullable;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+import com.adobe.cq.dam.cfm.content.FragmentRenderService;
+import com.adobe.cq.dam.cfm.converter.ContentTypeConverter;
+import com.adobe.cq.sightly.WCMBindings;
+import com.adobe.cq.wcm.core.components.context.ContentFragmentCoreComponentTestContext;
+import com.day.cq.search.QueryBuilder;
+import io.wcm.testing.mock.aem.junit.AemContext;
+
+import static org.mockito.Mockito.mock;
+
+public abstract class AbstractContentFragmentTest<T> {
+
+    /* names of the content fragment component instances to test */
+
+    protected static final String CF_TEXT_ONLY_NO_PATH = "text-only-no-path";
+    protected static final String CF_TEXT_ONLY_NON_EXISTING_PATH = "text-only-non-existing-path";
+    protected static final String CF_TEXT_ONLY_INVALID_PATH = "text-only-invalid-path";
+    protected static final String CF_TEXT_ONLY = "text-only";
+    protected static final String CF_TEXT_ONLY_VARIATION = "text-only-variation";
+    protected static final String CF_TEXT_ONLY_NON_EXISTING_VARIATION = "text-only-non-existing-variation";
+    protected static final String CF_TEXT_ONLY_SINGLE_ELEMENT = "text-only-single-element";
+    protected static final String CF_TEXT_ONLY_MULTIPLE_ELEMENTS = "text-only-multiple-elements";
+
+    protected static final String CF_STRUCTURED_NO_PATH = "structured-no-path";
+    protected static final String CF_STRUCTURED_NON_EXISTING_PATH = "structured-non-existing-path";
+    protected static final String CF_STRUCTURED_INVALID_PATH = "structured-invalid-path";
+    protected static final String CF_STRUCTURED = "structured";
+    protected static final String CF_STRUCTURED_VARIATION = "structured-variation";
+    protected static final String CF_STRUCTURED_NON_EXISTING_VARIATION = "structured-non-existing-variation";
+    protected static final String CF_STRUCTURED_NESTED_MODEL = "structured-nested-model";
+    protected static final String CF_STRUCTURED_SINGLE_ELEMENT = "structured-single-element";
+    protected static final String CF_STRUCTURED_SINGLE_ELEMENT_MAIN = "structured-single-element-main";
+    protected static final String CF_STRUCTURED_MULTIPLE_ELEMENTS = "structured-multiple-elements";
+
+    /* contents of the text-only and structured content fragments referenced by the above components */
+
+    protected static final String TITLE = "Test Content Fragment";
+    protected static final String DESCRIPTION = "This is a test content fragment.";
+    protected static final String TEXT_ONLY_TYPE = "/content/dam/contentfragments/text-only/jcr:content/model";
+    protected static final String STRUCTURED_TYPE = "global/models/test";
+    protected static final String STRUCTURED_TYPE_NESTED = "global/nested/models/test";
+    protected static final String[] ASSOCIATED_CONTENT = new String[]{"/content/dam/collections/X/X7v6pJAcy5qtkUdXdIxR/test"};
+
+    protected static final MockElement MAIN = new MockElement("main", "Main", "text/html",
+        "<p>Main content</p>", true, "<p>Main content</p>");
+    protected static final MockElement SECOND_TEXT_ONLY = new MockElement("second", "Second", "text/plain", "Second content",
+        true, null);
+    protected static final MockElement SECOND_STRUCTURED = new MockElement("second", "Second", null, new String[]{"one", "two", "three"},
+        false, null);
+
+    protected static final String VARIATION_NAME = "teaser";
+
+    static {
+        MAIN.addVariation(VARIATION_NAME, "Teaser", "text/html", "<p>Main content (teaser)</p>",
+            true, "<p>Main content (teaser)</p>");
+        SECOND_TEXT_ONLY.addVariation(VARIATION_NAME, "Teaser", "text/plain", "Second content (teaser)", true,
+            null);
+        SECOND_STRUCTURED.addVariation(VARIATION_NAME, "Teaser", null, new String[]{"one (teaser)", "two (teaser)", "three (teaser)"},
+            false, null);
+    }
+
+    protected static FragmentRenderService fragmentRenderService;
+
+    protected QueryBuilder queryBuilderMock;
+
+    @ClassRule
+    public static final AemContext AEM_CONTEXT = ContentFragmentCoreComponentTestContext.createContext("/contentfragment", "/content");
+
+    @BeforeClass
+    public static void beforeClass() {
+        // load the test content fragment model into a top-level and a nested configuration
+        AEM_CONTEXT.load().json("/contentfragment/test-content-conf.json", "/conf/global/settings/dam/cfm/models");
+        AEM_CONTEXT.load().json("/contentfragment/test-content-conf.json", "/conf/global/nested/settings/dam/cfm/models");
+
+        // load the content fragments and collection
+        AEM_CONTEXT.load().json("/contentfragment/test-content-dam-contentfragments.json", "/content/dam/contentfragments");
+        AEM_CONTEXT.load().json("/contentfragment/test-content-dam-collections.json", "/content/dam/collections");
+
+        // set content element values for the text-only fragment (stored as binary properties)
+        String path = "/content/dam/contentfragments/text-only/";
+        MockVariation mainVariation = MAIN.variations.get(VARIATION_NAME);
+        MockVariation secondVariation = SECOND_TEXT_ONLY.variations.get(VARIATION_NAME);
+        AEM_CONTEXT.load().binaryFile(new ByteArrayInputStream(MAIN.values[0].getBytes(StandardCharsets.UTF_8)),
+            path + "jcr:content/renditions/original", MAIN.contentType);
+        AEM_CONTEXT.load().binaryFile(new ByteArrayInputStream(mainVariation.values[0].getBytes(StandardCharsets.UTF_8)),
+            path + "jcr:content/renditions/" + VARIATION_NAME, mainVariation.contentType);
+        AEM_CONTEXT.load().binaryFile(new ByteArrayInputStream(SECOND_TEXT_ONLY.values[0].getBytes(StandardCharsets.UTF_8)),
+            path + "subassets/second/jcr:content/renditions/original", SECOND_TEXT_ONLY.contentType);
+        AEM_CONTEXT.load().binaryFile(new ByteArrayInputStream(secondVariation.values[0].getBytes(StandardCharsets.UTF_8)),
+            path + "subassets/second/jcr:content/renditions/" + VARIATION_NAME, secondVariation.contentType);
+
+        // register an adapter that adapts resources to mocks of content fragments
+        AEM_CONTEXT.registerAdapter(Resource.class, com.adobe.cq.dam.cfm.ContentFragment.class, ADAPTER);
+
+        // register dummy services to be injected into the model
+        fragmentRenderService = mock(FragmentRenderService.class);
+        AEM_CONTEXT.registerService(FragmentRenderService.class, fragmentRenderService);
+        AEM_CONTEXT.registerService(ContentTypeConverter.class, mock(ContentTypeConverter.class));
+    }
+
+    @Before
+    public void setUpQueryBuilder() {
+        queryBuilderMock = Mockito.mock(QueryBuilder.class);
+    }
+
+    protected void setFakeLoggerOnClass(Class<?> clazz, Logger logger) throws NoSuchFieldException, IllegalAccessException {
+        Field field = clazz.getDeclaredField("LOG");
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        field.setAccessible(true);
+        // remove final modifier from field
+
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(null, logger);
+    }
+
+    /**
+     * Adapts the specified (content fragment) component to the Sling Model and returns it.
+     */
+    protected T getModelInstanceUnderTest(String resourceName) {
+        String path = getTestResourcesParentPath() + "/" + resourceName;
+        ResourceResolver originalResourceResolver = AEM_CONTEXT.resourceResolver();
+        // Replace resource resolver with stubbed version of itself so we can verify query builder interaction
+        ResourceResolver resourceResolver = Mockito.spy(originalResourceResolver);
+        Mockito.doReturn(queryBuilderMock).when(resourceResolver).adaptTo(Mockito.eq(QueryBuilder.class));
+        Resource resource = resourceResolver.getResource(path);
+        MockSlingHttpServletRequest httpServletRequest = new MockSlingHttpServletRequest(resourceResolver, AEM_CONTEXT.bundleContext());
+        httpServletRequest.setResource(resource);
+        SlingBindings slingBindings = new SlingBindings();
+        slingBindings.put(SlingBindings.RESOLVER, resourceResolver);
+        slingBindings.put(SlingBindings.RESOURCE, resource);
+        slingBindings.put(WCMBindings.PROPERTIES, resource.adaptTo(ValueMap.class));
+        httpServletRequest.setAttribute(SlingBindings.class.getName(), slingBindings);
+        return httpServletRequest.adaptTo(getClassType());
+    }
+
+    /**
+     * Returns the {@link Class class} of the model under test. Required because the class cannot be reliably inferred
+     * from the generic type.
+     */
+    protected abstract Class<T> getClassType();
+
+    /**
+     * Returns the parent path of all test resources.
+     */
+    protected abstract String getTestResourcesParentPath();
+
+    /**
+     * Adapter using "new" {@link java.util.function.Function}s.
+     */
+    private static final java.util.function.Function<Resource, com.adobe.cq.dam.cfm.ContentFragment> CONTENT_FRAGMENT_ADAPTER =
+        new ContentFragmentMockAdapter();
+
+    /**
+     * Adapts resources to {@link com.adobe.cq.dam.cfm.ContentFragment} objects by mocking parts of their API.
+     */
+    public static final com.google.common.base.Function<Resource, com.adobe.cq.dam.cfm.ContentFragment> ADAPTER =
+        new com.google.common.base.Function<Resource, com.adobe.cq.dam.cfm.ContentFragment>() {
+            @Nullable
+            @Override
+            public com.adobe.cq.dam.cfm.ContentFragment apply(@Nullable Resource resource) {
+                return CONTENT_FRAGMENT_ADAPTER.apply(resource);
+            }
+        };
+
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
@@ -15,17 +15,11 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -35,277 +29,172 @@ import javax.json.JsonReader;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.api.scripting.SlingBindings;
-import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
-import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.dam.cfm.ContentElement;
-import com.adobe.cq.dam.cfm.ContentVariation;
-import com.adobe.cq.dam.cfm.DataType;
-import com.adobe.cq.dam.cfm.FragmentData;
-import com.adobe.cq.dam.cfm.FragmentTemplate;
-import com.adobe.cq.dam.cfm.VariationDef;
-import com.adobe.cq.dam.cfm.content.FragmentRenderService;
-import com.adobe.cq.dam.cfm.converter.ContentTypeConverter;
 import com.adobe.cq.export.json.ComponentExporter;
-import com.adobe.cq.sightly.WCMBindings;
-import com.adobe.cq.wcm.core.components.context.ContentFragmentCoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.contentfragment.ContentFragment;
-import com.day.cq.commons.jcr.JcrConstants;
+import com.adobe.cq.wcm.core.components.models.contentfragment.DAMContentFragment;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.wcm.testing.mock.aem.junit.AemContext;
 
-import static com.day.cq.commons.jcr.JcrConstants.JCR_CONTENT;
-import static com.day.cq.commons.jcr.JcrConstants.JCR_DATA;
-import static com.day.cq.commons.jcr.JcrConstants.JCR_DESCRIPTION;
-import static com.day.cq.commons.jcr.JcrConstants.JCR_MIMETYPE;
-import static com.day.cq.commons.jcr.JcrConstants.JCR_TITLE;
-import static com.day.cq.dam.api.DamConstants.NT_DAM_ASSET;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 
-public class ContentFragmentImplTest {
+public class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragment> {
 
     private Logger cfmLogger;
+    private Logger modelLogger;
 
-    private static final String TEST_PAGE_PATH = "/content/contentfragments";
-    private static final String TEST_CONTAINER_PATH = TEST_PAGE_PATH + "/jcr:content/root/responsivegrid";
-
-    /* names of the content fragment component instances to test */
-
-    private static final String CF_TEXT_ONLY_NO_PATH = "text-only-no-path";
-    private static final String CF_TEXT_ONLY_NON_EXISTING_PATH = "text-only-non-existing-path";
-    private static final String CF_TEXT_ONLY_INVALID_PATH = "text-only-invalid-path";
-    private static final String CF_TEXT_ONLY = "text-only";
-    private static final String CF_TEXT_ONLY_VARIATION = "text-only-variation";
-    private static final String CF_TEXT_ONLY_NON_EXISTING_VARIATION = "text-only-non-existing-variation";
-    private static final String CF_TEXT_ONLY_SINGLE_ELEMENT = "text-only-single-element";
-    private static final String CF_TEXT_ONLY_MULTIPLE_ELEMENTS = "text-only-multiple-elements";
-    private static final String CF_STRUCTURED_NO_PATH = "structured-no-path";
-    private static final String CF_STRUCTURED_NON_EXISTING_PATH = "structured-non-existing-path";
-    private static final String CF_STRUCTURED_INVALID_PATH = "structured-invalid-path";
-    private static final String CF_STRUCTURED = "structured";
-    private static final String CF_STRUCTURED_VARIATION = "structured-variation";
-    private static final String CF_STRUCTURED_NON_EXISTING_VARIATION = "structured-non-existing-variation";
-    private static final String CF_STRUCTURED_NESTED_MODEL = "structured-nested-model";
-    private static final String CF_STRUCTURED_SINGLE_ELEMENT = "structured-single-element";
-    private static final String CF_STRUCTURED_MULTIPLE_ELEMENTS = "structured-multiple-elements";
-
-    /* contents of the text-only and structured content fragments referenced by the above components */
-
-    private static final String TITLE = "Test Content Fragment";
-    private static final String DESCRIPTION = "This is a test content fragment.";
-    private static final String TEXT_ONLY_TYPE = "/content/dam/contentfragments/text-only/jcr:content/model";
-    private static final String STRUCTURED_TYPE = "global/models/test";
-    private static final String STRUCTURED_TYPE_NESTED = "global/nested/models/test";
-    private static final String[] ASSOCIATED_CONTENT = new String[]{"/content/dam/collections/X/X7v6pJAcy5qtkUdXdIxR/test"};
-    private static final Element MAIN = new Element("main", "Main", "text/html",
-            "<p>Main content</p>", true, "<p>Main content</p>", new String[]{"<p>Main content</p>"});
-    private static final Element SECOND_TEXT_ONLY = new Element("second", "Second", "text/plain", "Second content",
-            true, null, new String[]{"Second content"});
-    private static final Element SECOND_STRUCTURED = new Element("second", "Second", null, new String[]{"one", "two", "three"},
-            false, null, null);
-    private static final String VARIATION_NAME = "teaser";
-
-    static {
-        MAIN.addVariation(VARIATION_NAME, "Teaser", "text/html", "<p>Main content (teaser)</p>",
-                true, "<p>Main content (teaser)</p>", new String[]{"<p>Main content (teaser)</p>"});
-        SECOND_TEXT_ONLY.addVariation(VARIATION_NAME, "Teaser", "text/plain", "Second content (teaser)", true,
-                null, new String[]{"Second content (teaser)"});
-        SECOND_STRUCTURED.addVariation(VARIATION_NAME, "Teaser", null, new String[]{"one (teaser)", "two (teaser)", "three (teaser)"},
-                false, null, null);
+    @Override
+    protected String getTestResourcesParentPath() {
+        return "/content/contentfragments/jcr:content/root/responsivegrid";
     }
 
-    private static FragmentRenderService fragmentRenderService;
-    private static final String PARA_SPLIT_REGEX = "(?=(<p>|<h1>|<h2>|<h3>|<h4>|<h5>|<h6>))";
-
-
-    @ClassRule
-    public static final AemContext AEM_CONTEXT = ContentFragmentCoreComponentTestContext.createContext("/contentfragment", "/content");
-
-    @BeforeClass
-    public static void setUp() throws Exception {
-        // load the test content fragment model into a top-level and a nested configuration
-        AEM_CONTEXT.load().json("/contentfragment/test-content-conf.json", "/conf/global/settings/dam/cfm/models");
-        AEM_CONTEXT.load().json("/contentfragment/test-content-conf.json", "/conf/global/nested/settings/dam/cfm/models");
-
-        // load the content fragments and collection
-        AEM_CONTEXT.load().json("/contentfragment/test-content-dam-contentfragments.json", "/content/dam/contentfragments");
-        AEM_CONTEXT.load().json("/contentfragment/test-content-dam-collections.json", "/content/dam/collections");
-
-        // set content element values for the text-only fragment (stored as binary properties)
-        String path = "/content/dam/contentfragments/text-only/";
-        Element.Variation mainVariation = MAIN.variations.get(VARIATION_NAME);
-        Element.Variation secondVariation = SECOND_TEXT_ONLY.variations.get(VARIATION_NAME);
-        AEM_CONTEXT.load().binaryFile(new ByteArrayInputStream(MAIN.values[0].getBytes(UTF_8)),
-                path + "jcr:content/renditions/original", MAIN.contentType);
-        AEM_CONTEXT.load().binaryFile(new ByteArrayInputStream(mainVariation.values[0].getBytes(UTF_8)),
-                path + "jcr:content/renditions/" + VARIATION_NAME, mainVariation.contentType);
-        AEM_CONTEXT.load().binaryFile(new ByteArrayInputStream(SECOND_TEXT_ONLY.values[0].getBytes(UTF_8)),
-                path + "subassets/second/jcr:content/renditions/original", SECOND_TEXT_ONLY.contentType);
-        AEM_CONTEXT.load().binaryFile(new ByteArrayInputStream(secondVariation.values[0].getBytes(UTF_8)),
-                path + "subassets/second/jcr:content/renditions/" + VARIATION_NAME, secondVariation.contentType);
-
-        // register an adapter that adapts resources to mocks of content fragments
-        AEM_CONTEXT.registerAdapter(Resource.class, com.adobe.cq.dam.cfm.ContentFragment.class, ADAPTER);
-
-        // register dummy services to be injected into the model
-        fragmentRenderService = mock(FragmentRenderService.class);
-        AEM_CONTEXT.registerService(FragmentRenderService.class, fragmentRenderService);
-        AEM_CONTEXT.registerService(ContentTypeConverter.class, mock(ContentTypeConverter.class));
+    @Override
+    protected Class<ContentFragment> getClassType() {
+        return ContentFragment.class;
     }
 
     @Before
-    public void setTestFixture() throws NoSuchFieldException, IllegalAccessException {
-        cfmLogger = spy(LoggerFactory.getLogger("FakeLogger"));
-        Field field = ContentFragmentImpl.class.getDeclaredField("LOG");
-        Field modifiersField = Field.class.getDeclaredField("modifiers");
-        field.setAccessible(true);
-        // remove final modifier from field
+    public void setUp() throws Exception {
+        cfmLogger = spy(LoggerFactory.getLogger("FakeLoggerCFM"));
+        setFakeLoggerOnClass(DAMContentFragmentImpl.class, cfmLogger);
 
-        modifiersField.setAccessible(true);
-        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-        field.set(null, cfmLogger);
+        modelLogger = spy(LoggerFactory.getLogger("FakeLoggerModel"));
+        setFakeLoggerOnClass(ContentFragmentImpl.class, modelLogger);
     }
 
     @Test
-    public void testTextOnlyNoPath() {
-        ContentFragment fragment = getTestContentFragment(CF_TEXT_ONLY_NO_PATH);
-        verify(cfmLogger).warn("Please provide a path for the content fragment component.");
+    public void textOnlyNoPath() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_NO_PATH);
+        verify(modelLogger).warn("Please provide a path for the content fragment component.");
         assertNotNull("Model shouldn't be null when no path is set", fragment);
     }
 
     @Test
-    public void testTextOnlyNonExistingPath() {
-        ContentFragment fragment = getTestContentFragment(CF_TEXT_ONLY_NON_EXISTING_PATH);
-        verify(cfmLogger).error("Content Fragment can not be initialized because the '{}' does not exist.", "/content/dam/contentfragments/non-existing");
+    public void textOnlyNonExistingPath() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_NON_EXISTING_PATH);
+        verify(modelLogger).error("Content Fragment can not be initialized because the '{}' does not exist.", "/content/dam/contentfragments/non-existing");
         assertNotNull("Model shouldn't be null when the path does not exist", fragment);
     }
 
     @Test
-    public void testTextOnlyInvalidPath() {
-        ContentFragment fragment = getTestContentFragment(CF_TEXT_ONLY_INVALID_PATH);
+    public void textOnlyInvalidPath() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_INVALID_PATH);
         verify(cfmLogger).error("Content Fragment can not be initialized because '{}' is not a content fragment.", "/content/dam/contentfragments");
         assertNotNull("Model shouldn't be null when the path is not a content fragment", fragment);
     }
 
     @Test
-    public void testTextOnly() {
-        ContentFragment fragment = getTestContentFragment(CF_TEXT_ONLY);
+    public void textOnly() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY);
         assertContentFragment(fragment, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, ASSOCIATED_CONTENT, MAIN, SECOND_TEXT_ONLY);
     }
 
     @Test
-    public void testTextOnlyVariation() {
-        ContentFragment fragment = getTestContentFragment(CF_TEXT_ONLY_VARIATION);
+    public void textOnlyVariation() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_VARIATION);
         assertContentFragment(fragment, VARIATION_NAME, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, ASSOCIATED_CONTENT, MAIN,
-                SECOND_TEXT_ONLY);
+            SECOND_TEXT_ONLY);
     }
 
     @Test
-    public void testTextOnlyNonExistingVariation() {
-        ContentFragment fragment = getTestContentFragment(CF_TEXT_ONLY_NON_EXISTING_VARIATION);
+    public void textOnlyNonExistingVariation() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_NON_EXISTING_VARIATION);
         assertContentFragment(fragment, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, ASSOCIATED_CONTENT, MAIN, SECOND_TEXT_ONLY);
     }
 
     @Test
-    public void testTextOnlySingleElement() {
-        ContentFragment fragment = getTestContentFragment(CF_TEXT_ONLY_SINGLE_ELEMENT);
+    public void textOnlySingleElement() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_SINGLE_ELEMENT);
         assertContentFragment(fragment, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, ASSOCIATED_CONTENT, SECOND_TEXT_ONLY);
     }
 
     @Test
-    public void testTextOnlyMultipleElements() {
-        ContentFragment fragment = getTestContentFragment(CF_TEXT_ONLY_MULTIPLE_ELEMENTS);
+    public void textOnlyMultipleElements() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_MULTIPLE_ELEMENTS);
         assertContentFragment(fragment, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, ASSOCIATED_CONTENT, SECOND_TEXT_ONLY, MAIN);
     }
 
     @Test
-    public void testStructuredNoPath() {
-        ContentFragment fragment = getTestContentFragment(CF_STRUCTURED_NO_PATH);
+    public void structuredNoPath() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_NO_PATH);
         assertNotNull("Model shouldn't be null when no path is set", fragment);
     }
 
     @Test
-    public void testStructuredNonExistingPath() {
-        ContentFragment fragment = getTestContentFragment(CF_STRUCTURED_NON_EXISTING_PATH);
+    public void structuredNonExistingPath() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_NON_EXISTING_PATH);
         assertNotNull("Model shouldn't be null when the path does not exist", fragment);
     }
 
     @Test
-    public void testStructuredOnlyInvalidPath() {
-        ContentFragment fragment = getTestContentFragment(CF_STRUCTURED_INVALID_PATH);
+    public void structuredOnlyInvalidPath() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_INVALID_PATH);
         assertNotNull("Model shouldn't be null when the path is not a content fragment", fragment);
     }
 
     @Test
-    public void testStructured() {
-        ContentFragment fragment = getTestContentFragment(CF_STRUCTURED);
+    public void structured() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED);
         assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, ASSOCIATED_CONTENT, MAIN,
-                SECOND_STRUCTURED);
+            SECOND_STRUCTURED);
     }
 
     @Test
-    public void testStructuredVariation() {
-        ContentFragment fragment = getTestContentFragment(CF_STRUCTURED_VARIATION);
+    public void structuredVariation() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_VARIATION);
         assertContentFragment(fragment, VARIATION_NAME, TITLE, DESCRIPTION, STRUCTURED_TYPE, ASSOCIATED_CONTENT, MAIN,
-                SECOND_STRUCTURED);
+            SECOND_STRUCTURED);
     }
 
     @Test
-    public void testStructuredNonExistingVariation() {
-        ContentFragment fragment = getTestContentFragment(CF_STRUCTURED_NON_EXISTING_VARIATION);
+    public void structuredNonExistingVariation() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_NON_EXISTING_VARIATION);
         assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, ASSOCIATED_CONTENT, MAIN,
-                SECOND_STRUCTURED);
+            SECOND_STRUCTURED);
     }
 
     @Test
-    public void testStructuredNestedModel() {
-        ContentFragment fragment = getTestContentFragment(CF_STRUCTURED_NESTED_MODEL);
+    public void structuredNestedModel() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_NESTED_MODEL);
         assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE_NESTED, ASSOCIATED_CONTENT, MAIN,
-                SECOND_STRUCTURED);
+            SECOND_STRUCTURED);
     }
 
     @Test
-    public void testStructuredSingleElement() {
-        ContentFragment fragment = getTestContentFragment(CF_STRUCTURED_SINGLE_ELEMENT);
+    public void structuredSingleElement() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_SINGLE_ELEMENT);
         assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, ASSOCIATED_CONTENT, SECOND_STRUCTURED);
     }
 
     @Test
-    public void testStructuredMultipleElements() {
-        ContentFragment fragment = getTestContentFragment(CF_STRUCTURED_MULTIPLE_ELEMENTS);
+    public void structuredMultipleElements() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_MULTIPLE_ELEMENTS);
         assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, ASSOCIATED_CONTENT, SECOND_STRUCTURED,
-                MAIN);
+            MAIN);
     }
 
     @Test
-    public void testGetExportedType() {
-        ContentFragmentImpl fragment = (ContentFragmentImpl) getTestContentFragment(CF_TEXT_ONLY);
-        assertEquals(ContentFragmentImpl.RESOURCE_TYPE, fragment.getExportedType());
+    public void getExportedType() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY);
+        //assertEquals(DAMContentFragmentImpl.RESOURCE_TYPE, fragment.getExportedType());
     }
 
     @Test
-    public void testGetElements() {
-        ContentFragmentImpl fragment = (ContentFragmentImpl) getTestContentFragment(CF_TEXT_ONLY);
-        final Map<String, ContentFragment.Element> elements = fragment.getExportedElements();
+    public void getElements() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY);
+        final Map<String, DAMContentFragment.DAMContentElement> elements = fragment.getExportedElements();
         assertNotNull(elements);
         assertEquals(2, elements.size());
         assertEquals(true, elements.containsKey("main"));
@@ -313,8 +202,8 @@ public class ContentFragmentImplTest {
     }
 
     @Test
-    public void testGetElementsType() {
-        ContentFragmentImpl fragment = (ContentFragmentImpl) getTestContentFragment(CF_TEXT_ONLY);
+    public void getElementsType() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY);
         final Map<String, ? extends ComponentExporter> elements = fragment.getExportedElements();
         assertNotNull(elements);
         final ComponentExporter mainElement = elements.get("main");
@@ -322,70 +211,69 @@ public class ContentFragmentImplTest {
     }
 
     @Test
-    public void testJSONExport() throws IOException {
-        ContentFragmentImpl fragment = (ContentFragmentImpl) getTestContentFragment(CF_TEXT_ONLY);
+    public void jsonExport() throws IOException {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY);
         Writer writer = new StringWriter();
         ObjectMapper mapper = new ObjectMapper();
-        mapper.writerWithView(ContentFragmentImpl.class).writeValue(writer, fragment);
-        JsonReader jsonReaderOutput = Json.createReader(IOUtils.toInputStream(writer.toString()));
-        JsonReader jsonReaderExpected = Json.createReader(ContentFragmentImplTest.class
-                .getResourceAsStream("/contentfragment/test-expected-content-export.json"));
+        mapper.writerWithView(DAMContentFragmentImpl.class).writeValue(writer, fragment);
+        JsonReader jsonReaderOutput = Json.createReader(IOUtils.toInputStream(writer.toString(), StandardCharsets.UTF_8));
+        JsonReader jsonReaderExpected = Json.createReader(Thread.currentThread().getContextClassLoader().getClass()
+            .getResourceAsStream("/contentfragment/test-expected-content-export.json"));
         assertEquals(jsonReaderExpected.read(), jsonReaderOutput.read());
     }
 
     @Test
-    public void testStructuredGetEditorJSON() {
-        ContentFragment fragment = getTestContentFragment(CF_STRUCTURED_MULTIPLE_ELEMENTS);
+    public void structuredGetEditorJSON() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_MULTIPLE_ELEMENTS);
         String expectedJSON = "{\"title\":\"Test Content Fragment\",\"path\":\"/content/dam/contentfragments/structured\"," +
-                "\"elements\":[\"second\",\"non-existing\",\"main\"],\"associatedContent\":[{\"title\":\"Test Collection\"" +
-                ",\"path\":\"/content/dam/collections/X/X7v6pJAcy5qtkUdXdIxR/test\"}]}";
+            "\"elements\":[\"second\",\"non-existing\",\"main\"],\"associatedContent\":[{\"title\":\"Test Collection\"" +
+            ",\"path\":\"/content/dam/collections/X/X7v6pJAcy5qtkUdXdIxR/test\"}]}";
         assertEquals(fragment.getEditorJSON(), expectedJSON);
     }
 
     @Test
-    public void testStructuredWithVariationGetEditorJSON() {
-        ContentFragment fragment = getTestContentFragment(CF_STRUCTURED_VARIATION);
+    public void structuredWithVariationGetEditorJSON() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_VARIATION);
         String expectedJSON = "{\"title\":\"Test Content Fragment\",\"path\":\"/content/dam/contentfragments/structured\"," +
-                "\"variation\":\"teaser\",\"associatedContent\":[{\"title\":\"Test Collection\"" +
-                ",\"path\":\"/content/dam/collections/X/X7v6pJAcy5qtkUdXdIxR/test\"}]}";
+            "\"variation\":\"teaser\",\"associatedContent\":[{\"title\":\"Test Collection\"" +
+            ",\"path\":\"/content/dam/collections/X/X7v6pJAcy5qtkUdXdIxR/test\"}]}";
         assertEquals(fragment.getEditorJSON(), expectedJSON);
     }
 
     @Test
-    public void testTextOnlyGetEditorJSON() {
-        ContentFragment fragment = getTestContentFragment(CF_TEXT_ONLY_MULTIPLE_ELEMENTS);
+    public void textOnlyGetEditorJSON() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_MULTIPLE_ELEMENTS);
         String expectedJSON = "{\"title\":\"Test Content Fragment\",\"path\":\"/content/dam/contentfragments/text-only\"" +
-                ",\"elements\":[\"second\",\"non-existing\",\"main\"],\"associatedContent\":[{\"title\":\"Test Collection\"" +
-                ",\"path\":\"/content/dam/collections/X/X7v6pJAcy5qtkUdXdIxR/test\"}]}";
+            ",\"elements\":[\"second\",\"non-existing\",\"main\"],\"associatedContent\":[{\"title\":\"Test Collection\"" +
+            ",\"path\":\"/content/dam/collections/X/X7v6pJAcy5qtkUdXdIxR/test\"}]}";
         assertEquals(fragment.getEditorJSON(), expectedJSON);
     }
 
     @Test
-    public void testTextOnlyWithVariationGetEditorJSON() {
-        ContentFragment fragment = getTestContentFragment(CF_TEXT_ONLY_VARIATION);
+    public void textOnlyWithVariationGetEditorJSON() {
+        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_VARIATION);
         String expectedJSON = "{\"title\":\"Test Content Fragment\",\"path\":\"/content/dam/contentfragments/text-only\"," +
-                "\"variation\":\"teaser\",\"associatedContent\":[{\"title\":\"Test Collection\"" +
-                ",\"path\":\"/content/dam/collections/X/X7v6pJAcy5qtkUdXdIxR/test\"}]}";
+            "\"variation\":\"teaser\",\"associatedContent\":[{\"title\":\"Test Collection\"" +
+            ",\"path\":\"/content/dam/collections/X/X7v6pJAcy5qtkUdXdIxR/test\"}]}";
         assertEquals(fragment.getEditorJSON(), expectedJSON);
     }
 
-    /* helper methods */
+    @Test
+    public void getParagraphsOfMultiDisplayModeIsNull() {
+        // Structure CF has displayMode=multi which should not return paragraphs
+        ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED);
+        assertThat(fragment.getParagraphs(), is(nullValue()));
+    }
 
-    /**
-     * Adapts the specified content fragment component to the {@link ContentFragment} Sling Model and returns it.
-     */
-    private ContentFragment getTestContentFragment(String name) {
-        String path = TEST_CONTAINER_PATH + "/" + name;
-        ResourceResolver resolver = AEM_CONTEXT.resourceResolver();
-        Resource resource = resolver.getResource(path);
-        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(resolver, AEM_CONTEXT.bundleContext());
-        request.setResource(resource);
-        SlingBindings slingBindings = new SlingBindings();
-        slingBindings.put(SlingBindings.RESOLVER, resolver);
-        slingBindings.put(SlingBindings.RESOURCE, resource);
-        slingBindings.put(WCMBindings.PROPERTIES, resource.adaptTo(ValueMap.class));
-        request.setAttribute(SlingBindings.class.getName(), slingBindings);
-        return request.adaptTo(ContentFragment.class);
+    @Test
+    public void getParagraphOfSingleTextDisplayMode() {
+        final String value = "<p>Main content</p>";
+
+        when(fragmentRenderService.render(any(Resource.class))).thenReturn(value);
+
+        ContentFragment contentFragment = getModelInstanceUnderTest(CF_STRUCTURED_SINGLE_ELEMENT_MAIN);
+
+        assertThat(contentFragment.getParagraphs(), is(new String[]{value}));
     }
 
     /**
@@ -394,9 +282,9 @@ public class ContentFragmentImplTest {
      */
     private void assertContentFragment(ContentFragment fragment, String expectedTitle, String expectedDescription,
                                        String expectedType, String[] expectedAssociatedContent,
-                                       Element... expectedElements) {
+                                       MockElement... expectedElements) {
         assertContentFragment(fragment, null, expectedTitle, expectedDescription, expectedType,
-                expectedAssociatedContent, expectedElements);
+            expectedAssociatedContent, expectedElements);
     }
 
     /**
@@ -405,7 +293,7 @@ public class ContentFragmentImplTest {
      */
     private void assertContentFragment(ContentFragment fragment, String variationName, String expectedTitle,
                                        String expectedDescription, String expectedType,
-                                       String[] expectedAssociatedContent, Element... expectedElements) {
+                                       String[] expectedAssociatedContent, MockElement... expectedElements) {
         assertEquals("Content fragment has wrong title", expectedTitle, fragment.getTitle());
         assertEquals("Content fragment has wrong description", expectedDescription, fragment.getDescription());
         assertEquals("Content fragment has wrong type", expectedType, fragment.getType());
@@ -415,443 +303,35 @@ public class ContentFragmentImplTest {
             Resource resource = associatedContent.get(i);
             assertEquals("Element has wrong associated content", expectedAssociatedContent[i], resource.getPath());
         }
-        Map<String, ContentFragment.Element> elementsMap = fragment.getExportedElements();
+        Map<String, DAMContentFragment.DAMContentElement> elementsMap = fragment.getExportedElements();
         assertNotNull(elementsMap);
-        List<ContentFragment.Element> elements = new ArrayList<>(elementsMap.values());
+        List<DAMContentFragment.DAMContentElement> elements = new ArrayList<>(elementsMap.values());
         assertEquals("Content fragment has wrong number of elements", expectedElements.length, elements.size());
         for (int i = 0; i < expectedElements.length; i++) {
-            ContentFragment.Element element = elements.get(i);
-            Resource component;
-            try {
-                Field componentField = ContentFragmentImpl.ElementImpl.class.getDeclaredField("component");
-                componentField.setAccessible(true);
-                component = (Resource) componentField.get(element);
-                String value = element.getValue() != null ? element.getValue().toString() : null;
-                when(fragmentRenderService.render(component)).thenReturn(value);
-            } catch (NoSuchFieldException | IllegalAccessException e) {
-                e.printStackTrace();
-            }
-            Element expected = expectedElements[i];
+            DAMContentFragment.DAMContentElement element = elements.get(i);
+            MockElement expected = expectedElements[i];
             assertEquals("Element has wrong name", expected.name, element.getName());
             assertEquals("Element has wrong title", expected.title, element.getTitle());
             String contentType = expected.contentType;
             boolean isMultiLine = expected.isMultiLine;
             String htmlValue = expected.htmlValue;
-            String[] paragraphs = expected.paragraphs;
             String[] expectedValues = expected.values;
             if (StringUtils.isNotEmpty(variationName)) {
                 contentType = expected.variations.get(variationName).contentType;
                 expectedValues = expected.variations.get(variationName).values;
                 isMultiLine = expected.variations.get(variationName).isMultiLine;
                 htmlValue = expected.variations.get(variationName).htmlValue;
-                paragraphs = expected.variations.get(variationName).paragraphs;
             }
             Object elementValue = element.getValue();
             if (elementValue != null && elementValue.getClass().isArray()) {
                 assertArrayEquals("Element's values didn't match", expectedValues, (String[]) elementValue);
             } else {
-                assertEquals("Element is not single valued", 1, expectedValues.length);
+                assertEquals("Element is not single valued", expectedValues.length, 1);
                 assertEquals("Element's value didn't match", expectedValues[0], elementValue);
             }
+            assertEquals("Element has wrong content type", contentType, element.getExportedType());
             assertEquals("Element has wrong isMultiLine flag", isMultiLine, element.isMultiLine());
             assertEquals("Element has wrong html", htmlValue, element.getHtml());
-            assertArrayEquals("ELement has wrong paragraphs", paragraphs, element.getParagraphs());
         }
     }
-
-    /**
-     * Adapts resources to {@link com.adobe.cq.dam.cfm.ContentFragment} objects by mocking parts of their API.
-     */
-    public static final com.google.common.base.Function<Resource, com.adobe.cq.dam.cfm.ContentFragment> ADAPTER =
-            new com.google.common.base.Function<Resource, com.adobe.cq.dam.cfm.ContentFragment>() {
-
-                private final String PATH_DATA = JCR_CONTENT + "/data";
-                private final String PATH_MASTER = PATH_DATA + "/master";
-                private final String PATH_MODEL = JCR_CONTENT + "/model";
-                private final String PATH_MODEL_ELEMENTS = PATH_MODEL + "/elements";
-                private final String PATH_MODEL_VARIATIONS = PATH_MODEL + "/variations";
-                private final String PATH_MODEL_DIALOG_ITEMS = JCR_CONTENT + "/model/cq:dialog/content/items";
-                private final String PATH_ASSOCIATED_CONTENT = JCR_CONTENT + "/associated/sling:members";
-                private final String PN_CONTENT_FRAGMENT = "contentFragment";
-                private final String PN_MODEL = "cq:model";
-                private final String PN_ELEMENT_NAME = "name";
-                private final String PN_ELEMENT_TITLE = "fieldLabel";
-                private final String PN_VALUE_TYPE = "valueType";
-                private final String MAIN_ELEMENT = "main";
-
-                @Nullable
-                @Override
-                public com.adobe.cq.dam.cfm.ContentFragment apply(@Nullable Resource resource) {
-                    // check if the resource is valid and an asset
-                    if (resource == null || !resource.isResourceType(NT_DAM_ASSET)) {
-                        return null;
-                    }
-
-                    // check if the resource is a content fragment
-                    Resource content = resource.getChild(JCR_CONTENT);
-                    ValueMap contentProperties = content.getValueMap();
-                    if (!contentProperties.get(PN_CONTENT_FRAGMENT, Boolean.FALSE)) {
-                        return null;
-                    }
-
-                    // check if the content fragment is text-only or structured
-                    Resource data = resource.getChild(PATH_DATA);
-                    boolean isStructured = data != null;
-
-                    /* get content fragment properties, model and elements */
-
-                    String title = contentProperties.get(JCR_TITLE, String.class);
-                    String description = contentProperties.get(JCR_DESCRIPTION, String.class);
-                    Resource model;
-                    Resource modelAdaptee;
-                    List<ContentElement> elements = new LinkedList<>();
-
-                    if (isStructured) {
-                        // get the model (referenced in the property)
-                        model = resource.getResourceResolver().getResource(data.getValueMap().get(PN_MODEL, String.class));
-                        // for the 'adaptTo' mock below we use the jcr:content child to mimick the real behavior
-                        modelAdaptee = model.getChild(JCR_CONTENT);
-                        // create an element mock for each property on the master node
-                        Resource master = resource.getChild(PATH_MASTER);
-                        for (String name : master.getValueMap().keySet()) {
-                            // skip the primary type and content type properties
-                            if (JcrConstants.JCR_PRIMARYTYPE.equals(name) || name.endsWith("@ContentType")) {
-                                continue;
-                            }
-                            elements.add(getMockElement(resource, name, model));
-                        }
-                    } else {
-                        // get the model (stored in the fragment itself)
-                        model = resource.getChild(PATH_MODEL);
-                        modelAdaptee = model;
-                        // add the "main" element to the list
-                        elements.add(getMockElement(resource, null, null));
-                        // create an element mock for each subasset
-                        Resource subassets = resource.getChild("subassets");
-                        if (subassets != null) {
-                            for (Resource subasset : subassets.getChildren()) {
-                                elements.add(getMockElement(resource, subasset.getName(), null));
-                            }
-                        }
-                    }
-
-                    /* create mock objects */
-
-                    com.adobe.cq.dam.cfm.ContentFragment fragment = mock(com.adobe.cq.dam.cfm.ContentFragment.class, withSettings().lenient());
-                    when(fragment.getTitle()).thenReturn(title);
-                    when(fragment.getDescription()).thenReturn(description);
-                    when(fragment.adaptTo(Resource.class)).thenReturn(resource);
-                    when(fragment.getElement(isNull())).thenAnswer(invocation -> {
-                        String name = invocation.getArgument(0);
-                        return getMockElement(resource, name, isStructured ? model : null);
-                    });
-                    when(fragment.getElement(any(String.class))).thenAnswer(invocation -> {
-                        String name = invocation.getArgument(0);
-                        return getMockElement(resource, name, isStructured ? model : null);
-                    });
-                    when(fragment.hasElement(any(String.class))).thenAnswer(invocation -> {
-                        String name = invocation.getArgument(0);
-                        return fragment.getElement(name) != null;
-                    });
-                    when(fragment.getElements()).thenReturn(elements.iterator());
-
-                    List<VariationDef> variations = new LinkedList<>();
-                    ContentElement main = fragment.getElement(null);
-                    Iterator<ContentVariation> iterator = main.getVariations();
-                    while (iterator.hasNext()) {
-                        ContentVariation variation = iterator.next();
-                        variations.add(new VariationDef() {
-                            @Override
-                            public String getName() {
-                                return variation.getName();
-                            }
-
-                            @Override
-                            public String getTitle() {
-                                return variation.getTitle();
-                            }
-
-                            @Override
-                            public String getDescription() {
-                                return variation.getDescription();
-                            }
-                        });
-                    }
-                    when(fragment.listAllVariations()).thenReturn(variations.iterator());
-
-                    FragmentTemplate template = mock(FragmentTemplate.class, withSettings().lenient());
-                    when(template.adaptTo(Resource.class)).thenReturn(modelAdaptee);
-                    when(fragment.getTemplate()).thenReturn(template);
-
-                    Iterator<Resource> associatedContent = getAssociatedContent(resource);
-                    when(fragment.getAssociatedContent()).thenReturn(associatedContent);
-
-                    return fragment;
-                }
-
-                /**
-                 * Creates a mock of a content element for a text-only (if {@code model} is {@code null}) or structured
-                 * (if {@code model} is not {@code null}) content fragment.
-                 */
-                private ContentElement getMockElement(Resource resource, String name, Resource model) {
-                    // get the respective element
-                    Element element;
-                    if (model == null) {
-                        element = getTextOnlyElement(resource, name);
-                    } else {
-                        element = getStructuredElement(resource, model, name);
-                    }
-                    if (element == null) {
-                        return null;
-                    }
-
-                    /* create mock objects */
-
-                    // mock data type
-                    DataType dataType = mock(DataType.class, withSettings().lenient());
-                    when(dataType.isMultiValue()).thenReturn(element.isMultiValued);
-
-                    // mock fragment data
-                    FragmentData data = mock(FragmentData.class, withSettings().lenient());
-                    when(data.getValue()).thenReturn(element.isMultiValued ? element.values : element.values[0]);
-                    when(data.getValue(String.class)).thenReturn(element.values[0]);
-                    when(data.getValue(String[].class)).thenReturn(element.values);
-                    when(data.getContentType()).thenReturn(element.contentType);
-                    when(data.getDataType()).thenReturn(dataType);
-
-                    // mock content element
-                    ContentElement contentElement = mock(ContentElement.class, withSettings().lenient());
-                    when(contentElement.getName()).thenReturn(element.name);
-                    when(contentElement.getTitle()).thenReturn(element.title);
-                    when(contentElement.getContent()).thenReturn(element.values[0]);
-                    when(contentElement.getContentType()).thenReturn(element.contentType);
-                    when(contentElement.getValue()).thenReturn(data);
-
-                    // mock variations
-                    Map<String, ContentVariation> variations = new LinkedHashMap<>();
-                    for (Element.Variation variation : element.variations.values()) {
-                        FragmentData variationData = mock(FragmentData.class, withSettings().lenient());
-                        when(variationData.getValue()).thenReturn(element.isMultiValued ? variation.values : variation.values[0]);
-                        when(variationData.getValue(String.class)).thenReturn(variation.values[0]);
-                        when(variationData.getValue(String[].class)).thenReturn(variation.values);
-                        when(variationData.getContentType()).thenReturn(variation.contentType);
-                        when(variationData.getDataType()).thenReturn(dataType);
-
-                        ContentVariation contentVariation = mock(ContentVariation.class, withSettings().lenient());
-                        when(contentVariation.getName()).thenReturn(variation.name);
-                        when(contentVariation.getTitle()).thenReturn(variation.title);
-                        when(contentVariation.getContent()).thenReturn(variation.values[0]);
-                        when(contentVariation.getContentType()).thenReturn(variation.contentType);
-                        when(contentVariation.getValue()).thenReturn(variationData);
-                        variations.put(variation.name, contentVariation);
-                    }
-                    when(contentElement.getVariations()).thenReturn(variations.values().iterator());
-                    when(contentElement.getVariation(any(String.class))).thenAnswer(invocation -> {
-                        String variationName = invocation.getArgument(0);
-                        return variations.get(variationName);
-                    });
-
-                    return contentElement;
-                }
-
-                /**
-                 * Collects and returns the information of a content element for text-only content fragment.
-                 */
-                private Element getTextOnlyElement(Resource resource, String name) {
-                    Element element = new Element();
-                    // text-only elements are never multi-valued
-                    element.isMultiValued = false;
-                    // if the name is null we use the main element
-                    element.name = name == null ? MAIN_ELEMENT : name;
-
-                    // loop through element definitions in the model and find the matching one
-                    boolean found = false;
-                    Resource elements = resource.getChild(PATH_MODEL_ELEMENTS);
-                    for (Resource elementResource : elements.getChildren()) {
-                        ValueMap properties = elementResource.getValueMap();
-                        if (element.name.equals(properties.get(PN_ELEMENT_NAME))) {
-                            // set the element title
-                            element.title = properties.get(JCR_TITLE, String.class);
-                            found = true;
-                            break;
-                        }
-                    }
-                    // return if we didn't find an element with the given name
-                    if (!found) {
-                        return null;
-                    }
-
-                    try {
-                        // get path to the asset resource (main element or correct subasset)
-                        String path = MAIN_ELEMENT.equals(element.name) ? "" : "subassets/" + element.name + "/";
-                        Resource renditions = resource.getChild(path + JCR_CONTENT + "/renditions");
-                        // loop over the renditions (i.e. variations)
-                        for (Resource rendition : renditions.getChildren()) {
-                            // get content and content type
-                            ValueMap properties = rendition.getChild(JCR_CONTENT).getValueMap();
-                            String content = IOUtils.toString(properties.get(JCR_DATA, InputStream.class), UTF_8);
-                            String contentType = properties.get(JCR_MIMETYPE, String.class);
-
-                            // get variation definition from model
-                            Resource variation = resource.getChild(PATH_MODEL_VARIATIONS + "/" + rendition.getName());
-                            if (variation != null) {
-                                String title = variation.getValueMap().get(JCR_TITLE, String.class);
-                                element.addVariation(rendition.getName(), title, contentType, new String[]{content},
-                                        true, content, content.split(PARA_SPLIT_REGEX));
-                            } else {
-                                element.values = new String[]{content};
-                                element.contentType = contentType;
-                            }
-                        }
-                    } catch (IOException e) {
-                        return null;
-                    }
-
-                    return element;
-                }
-
-                /**
-                 * Collects and returns the information of a content element for structured content fragment.
-                 */
-                private Element getStructuredElement(Resource resource, Resource model, String name) {
-                    Element element = new Element();
-                    element.name = name;
-
-                    // loop through element definitions in the model and find the matching one (or first one, if name is null)
-                    boolean found = false;
-                    Resource items = model.getChild(PATH_MODEL_DIALOG_ITEMS);
-                    for (Resource item : items.getChildren()) {
-                        ValueMap properties = item.getValueMap();
-                        String elementName = properties.get(PN_ELEMENT_NAME, String.class);
-                        if (element.name == null || element.name.equals(elementName)) {
-                            // set the element name (in case it was null)
-                            element.name = elementName;
-                            // set the element title
-                            element.title = properties.get(PN_ELEMENT_TITLE, String.class);
-                            // determine if the element is multi-valued (if the value type is e.g. "string[]")
-                            element.isMultiValued = properties.get(PN_VALUE_TYPE, "").endsWith("[]");
-                            found = true;
-                            break;
-                        }
-                    }
-                    // return if we didn't find an element with the given name
-                    if (!found) {
-                        return null;
-                    }
-
-                    // loop over the data nodes
-                    for (Resource data : resource.getChild(PATH_DATA).getChildren()) {
-                        ValueMap properties = data.getValueMap();
-                        String[] values = properties.get(element.name, String[].class);
-                        String contentType = properties.get(element.name + "@ContentType", String.class);
-                        if ("master".equals(data.getName())) {
-                            element.values = values;
-                            element.contentType = contentType;
-                        } else {
-                            properties = resource.getChild(PATH_MODEL_VARIATIONS + "/" + data.getName()).getValueMap();
-                            String title = properties.get(JCR_TITLE, String.class);
-                            element.addVariation(data.getName(), title, contentType, values, true, values[0],
-                                    values[0].split(PARA_SPLIT_REGEX));
-                        }
-                    }
-
-                    return element;
-                }
-
-                /**
-                 * Returns a list of resources representing the associated content for a content fragment.
-                 */
-                private Iterator<Resource> getAssociatedContent(Resource resource) {
-                    List<Resource> associatedContent = new LinkedList<>();
-                    ResourceResolver resolver = resource.getResourceResolver();
-                    Resource members = resource.getChild(PATH_ASSOCIATED_CONTENT);
-                    if (resource != null) {
-                        String[] paths = members.getValueMap().get("sling:resources", String[].class);
-                        if (paths != null) {
-                            for (String path : paths) {
-                                associatedContent.add(resolver.getResource(path));
-                            }
-                        }
-                    }
-                    return associatedContent.iterator();
-                }
-
-            };
-
-    /**
-     * Helper class to represent an element and its variations, used to model expected values and to mock objects.
-     */
-    private static class Element {
-
-        private static class Variation {
-
-            String name;
-            String title;
-            String contentType;
-            String[] values;
-            boolean isMultiLine;
-            String htmlValue;
-            String[] paragraphs;
-
-            Variation(String name, String title, String contentType, String[] values, boolean isMultiLine,
-                      String htmlValue, String[] paragraphs) {
-                this.name = name;
-                this.title = title;
-                this.contentType = contentType;
-                this.values = values;
-                this.isMultiLine = isMultiLine;
-                this.htmlValue = htmlValue;
-                this.paragraphs = paragraphs;
-            }
-
-            Variation(String name, String title, String contentType, String value, boolean isMultiLine,
-                      String htmlValue, String[] paragraphs) {
-                this(name, title, contentType, new String[]{value}, isMultiLine, htmlValue, paragraphs);
-            }
-
-        }
-
-        String name;
-        String title;
-        boolean isMultiValued;
-        String contentType;
-        String[] values;
-        boolean isMultiLine;
-        String htmlValue;
-        String[] paragraphs;
-        Map<String, Variation> variations = new LinkedHashMap<>();
-
-        Element() {
-        }
-
-        Element(String name, String title, String contentType, String value, boolean isMultiLine,
-                String htmlValue, String[] paragraphs) {
-            this(name, title, contentType, new String[]{value}, isMultiLine, htmlValue, paragraphs);
-            this.isMultiValued = false;
-        }
-
-        Element(String name, String title, String contentType, String[] values, boolean isMultiLine,
-                String htmlValue, String[] paragraphs) {
-            this.name = name;
-            this.title = title;
-            this.contentType = contentType;
-            this.isMultiValued = true;
-            this.values = values;
-            this.isMultiLine = isMultiLine;
-            this.htmlValue = htmlValue;
-            this.paragraphs = paragraphs;
-        }
-
-        private void addVariation(String name, String title, String contentType, String[] values, boolean isMultiline,
-                                  String htmlValue, String[] paragraphs) {
-            variations.put(name, new Variation(name, title, contentType, values, isMultiline, htmlValue, paragraphs));
-        }
-
-        private void addVariation(String name, String title, String contentType, String value, boolean isMultiline,
-                                  String htmlValue, String[] paragraphs) {
-            variations.put(name, new Variation(name, title, contentType, value, isMultiline, htmlValue, paragraphs));
-        }
-
-    }
-
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentMockAdapter.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentMockAdapter.java
@@ -1,0 +1,370 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+
+import com.adobe.cq.dam.cfm.ContentElement;
+import com.adobe.cq.dam.cfm.ContentFragment;
+import com.adobe.cq.dam.cfm.ContentVariation;
+import com.adobe.cq.dam.cfm.DataType;
+import com.adobe.cq.dam.cfm.FragmentData;
+import com.adobe.cq.dam.cfm.FragmentTemplate;
+import com.adobe.cq.dam.cfm.VariationDef;
+import com.day.cq.commons.jcr.JcrConstants;
+
+import static com.day.cq.commons.jcr.JcrConstants.JCR_CONTENT;
+import static com.day.cq.commons.jcr.JcrConstants.JCR_DATA;
+import static com.day.cq.commons.jcr.JcrConstants.JCR_DESCRIPTION;
+import static com.day.cq.commons.jcr.JcrConstants.JCR_MIMETYPE;
+import static com.day.cq.commons.jcr.JcrConstants.JCR_TITLE;
+import static com.day.cq.dam.api.DamConstants.NT_DAM_ASSET;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Adapts resources to {@link ContentFragment} objects by mocking parts of their API.
+ */
+public class ContentFragmentMockAdapter implements Function<Resource, ContentFragment> {
+
+    private final String PATH_DATA = JCR_CONTENT + "/data";
+    private final String PATH_MASTER = PATH_DATA + "/master";
+    private final String PATH_MODEL = JCR_CONTENT + "/model";
+    private final String PATH_MODEL_ELEMENTS = PATH_MODEL + "/elements";
+    private final String PATH_MODEL_VARIATIONS = PATH_MODEL + "/variations";
+    private final String PATH_MODEL_DIALOG_ITEMS = JCR_CONTENT + "/model/cq:dialog/content/items";
+    private final String PATH_ASSOCIATED_CONTENT = JCR_CONTENT + "/associated/sling:members";
+    private final String PN_CONTENT_FRAGMENT = "contentFragment";
+    private final String PN_MODEL = "cq:model";
+    private final String PN_ELEMENT_NAME = "name";
+    private final String PN_ELEMENT_TITLE = "fieldLabel";
+    private final String PN_VALUE_TYPE = "valueType";
+    private final String MAIN_ELEMENT = "main";
+
+    @Nullable
+    @Override
+    public ContentFragment apply(@Nullable Resource resource) {
+        // check if the resource is valid and an asset
+        if (resource == null || !resource.isResourceType(NT_DAM_ASSET)) {
+            return null;
+        }
+
+        // check if the resource is a content fragment
+        Resource content = resource.getChild(JCR_CONTENT);
+        ValueMap contentProperties = content.getValueMap();
+        if (!contentProperties.get(PN_CONTENT_FRAGMENT, Boolean.FALSE)) {
+            return null;
+        }
+
+        // check if the content fragment is text-only or structured
+        Resource data = resource.getChild(PATH_DATA);
+        boolean isStructured = data != null;
+
+        /* get content fragment properties, model and elements */
+
+        String title = contentProperties.get(JCR_TITLE, String.class);
+        String description = contentProperties.get(JCR_DESCRIPTION, String.class);
+        Resource model;
+        Resource modelAdaptee;
+        List<ContentElement> elements = new LinkedList<>();
+
+        if (isStructured) {
+            // get the model (referenced in the property)
+            model = resource.getResourceResolver().getResource(data.getValueMap().get(PN_MODEL, String.class));
+            // for the 'adaptTo' mock below we use the jcr:content child to mimick the real behavior
+            modelAdaptee = model.getChild(JCR_CONTENT);
+            // create an element mock for each property on the master node
+            Resource master = resource.getChild(PATH_MASTER);
+            for (String name : master.getValueMap().keySet()) {
+                // skip the primary type and content type properties
+                if (JcrConstants.JCR_PRIMARYTYPE.equals(name) || name.endsWith("@ContentType")) {
+                    continue;
+                }
+                elements.add(getMockElement(resource, name, model));
+            }
+        } else {
+            // get the model (stored in the fragment itself)
+            model = resource.getChild(PATH_MODEL);
+            modelAdaptee = model;
+            // add the "main" element to the list
+            elements.add(getMockElement(resource, null, null));
+            // create an element mock for each subasset
+            Resource subassets = resource.getChild("subassets");
+            if (subassets != null) {
+                for (Resource subasset : subassets.getChildren()) {
+                    elements.add(getMockElement(resource, subasset.getName(), null));
+                }
+            }
+        }
+
+        /* create mock objects */
+
+        ContentFragment fragment = mock(ContentFragment.class, withSettings().lenient());
+        when(fragment.getTitle()).thenReturn(title);
+        when(fragment.getDescription()).thenReturn(description);
+        when(fragment.adaptTo(Resource.class)).thenReturn(resource);
+        when(fragment.getElement(isNull())).thenAnswer(invocation -> {
+            String name = invocation.getArgument(0);
+            return getMockElement(resource, name, isStructured ? model : null);
+        });
+        when(fragment.getElement(any(String.class))).thenAnswer(invocation -> {
+            String name = invocation.getArgument(0);
+            return getMockElement(resource, name, isStructured ? model : null);
+        });
+        when(fragment.hasElement(any(String.class))).thenAnswer(invocation -> {
+            String name = invocation.getArgument(0);
+            return fragment.getElement(name) != null;
+        });
+        when(fragment.getElements()).thenReturn(elements.iterator());
+
+        List<VariationDef> variations = new LinkedList<>();
+        ContentElement main = fragment.getElement(null);
+        Iterator<ContentVariation> iterator = main.getVariations();
+        while (iterator.hasNext()) {
+            ContentVariation variation = iterator.next();
+            variations.add(new VariationDef() {
+                @Override
+                public String getName() {
+                    return variation.getName();
+                }
+
+                @Override
+                public String getTitle() {
+                    return variation.getTitle();
+                }
+
+                @Override
+                public String getDescription() {
+                    return variation.getDescription();
+                }
+            });
+        }
+        when(fragment.listAllVariations()).thenReturn(variations.iterator());
+
+        FragmentTemplate template = mock(FragmentTemplate.class, withSettings().lenient());
+        when(template.adaptTo(Resource.class)).thenReturn(modelAdaptee);
+        when(fragment.getTemplate()).thenReturn(template);
+
+        Iterator<Resource> associatedContent = getAssociatedContent(resource);
+        when(fragment.getAssociatedContent()).thenReturn(associatedContent);
+
+        return fragment;
+    }
+
+    /**
+     * Creates a mock of a content element for a text-only (if {@code model} is {@code null}) or structured
+     * (if {@code model} is not {@code null}) content fragment.
+     */
+    private ContentElement getMockElement(Resource resource, String name, Resource model) {
+        // get the respective element
+        MockElement element;
+        if (model == null) {
+            element = getTextOnlyElement(resource, name);
+        } else {
+            element = getStructuredElement(resource, model, name);
+        }
+        if (element == null) {
+            return null;
+        }
+
+        /* create mock objects */
+
+        // mock data type
+        DataType dataType = mock(DataType.class, withSettings().lenient());
+        when(dataType.isMultiValue()).thenReturn(element.isMultiValued);
+
+        // mock fragment data
+        FragmentData data = mock(FragmentData.class, withSettings().lenient());
+        when(data.getValue()).thenReturn(element.isMultiValued ? element.values : element.values[0]);
+        when(data.getValue(String.class)).thenReturn(element.values[0]);
+        when(data.getValue(String[].class)).thenReturn(element.values);
+        when(data.getContentType()).thenReturn(element.contentType);
+        when(data.getDataType()).thenReturn(dataType);
+
+        // mock content element
+        ContentElement contentElement = mock(ContentElement.class, withSettings().lenient());
+        when(contentElement.getName()).thenReturn(element.name);
+        when(contentElement.getTitle()).thenReturn(element.title);
+        when(contentElement.getContent()).thenReturn(element.values[0]);
+        when(contentElement.getContentType()).thenReturn(element.contentType);
+        when(contentElement.getValue()).thenReturn(data);
+
+        // mock variations
+        Map<String, ContentVariation> variations = new LinkedHashMap<>();
+        for (MockVariation variation : element.variations.values()) {
+            FragmentData variationData = mock(FragmentData.class, withSettings().lenient());
+            when(variationData.getValue()).thenReturn(element.isMultiValued ? variation.values : variation.values[0]);
+            when(variationData.getValue(String.class)).thenReturn(variation.values[0]);
+            when(variationData.getValue(String[].class)).thenReturn(variation.values);
+            when(variationData.getContentType()).thenReturn(variation.contentType);
+            when(variationData.getDataType()).thenReturn(dataType);
+
+            ContentVariation contentVariation = mock(ContentVariation.class, withSettings().lenient());
+            when(contentVariation.getName()).thenReturn(variation.name);
+            when(contentVariation.getTitle()).thenReturn(variation.title);
+            when(contentVariation.getContent()).thenReturn(variation.values[0]);
+            when(contentVariation.getContentType()).thenReturn(variation.contentType);
+            when(contentVariation.getValue()).thenReturn(variationData);
+            variations.put(variation.name, contentVariation);
+        }
+        when(contentElement.getVariations()).thenReturn(variations.values().iterator());
+        when(contentElement.getVariation(any(String.class))).thenAnswer(invocation -> {
+            String variationName = invocation.getArgument(0);
+            return variations.get(variationName);
+        });
+
+        return contentElement;
+    }
+
+    /**
+     * Collects and returns the information of a content element for text-only content fragment.
+     */
+    private MockElement getTextOnlyElement(Resource resource, String name) {
+        MockElement element = new MockElement();
+        // text-only elements are never multi-valued
+        element.isMultiValued = false;
+        // if the name is null we use the main element
+        element.name = name == null ? MAIN_ELEMENT : name;
+
+        // loop through element definitions in the model and find the matching one
+        boolean found = false;
+        Resource elements = resource.getChild(PATH_MODEL_ELEMENTS);
+        for (Resource elementResource : elements.getChildren()) {
+            ValueMap properties = elementResource.getValueMap();
+            if (element.name.equals(properties.get(PN_ELEMENT_NAME))) {
+                // set the element title
+                element.title = properties.get(JCR_TITLE, String.class);
+                found = true;
+                break;
+            }
+        }
+        // return if we didn't find an element with the given name
+        if (!found) {
+            return null;
+        }
+
+        try {
+            // get path to the asset resource (main element or correct subasset)
+            String path = MAIN_ELEMENT.equals(element.name) ? "" : "subassets/" + element.name + "/";
+            Resource renditions = resource.getChild(path + JCR_CONTENT + "/renditions");
+            // loop over the renditions (i.e. variations)
+            for (Resource rendition : renditions.getChildren()) {
+                // get content and content type
+                ValueMap properties = rendition.getChild(JCR_CONTENT).getValueMap();
+                String content = IOUtils.toString(properties.get(JCR_DATA, InputStream.class), UTF_8);
+                String contentType = properties.get(JCR_MIMETYPE, String.class);
+
+                // get variation definition from model
+                Resource variation = resource.getChild(PATH_MODEL_VARIATIONS + "/" + rendition.getName());
+                if (variation != null) {
+                    String title = variation.getValueMap().get(JCR_TITLE, String.class);
+                    element.addVariation(rendition.getName(), title, contentType, new String[]{content},
+                            true, content);
+                } else {
+                    element.values = new String[]{content};
+                    element.contentType = contentType;
+                }
+            }
+        } catch (IOException e) {
+            return null;
+        }
+
+        return element;
+    }
+
+    /**
+     * Collects and returns the information of a content element for structured content fragment.
+     */
+    private MockElement getStructuredElement(Resource resource, Resource model, String name) {
+        MockElement element = new MockElement();
+        element.name = name;
+
+        // loop through element definitions in the model and find the matching one (or first one, if name is null)
+        boolean found = false;
+        Resource items = model.getChild(PATH_MODEL_DIALOG_ITEMS);
+        for (Resource item : items.getChildren()) {
+            ValueMap properties = item.getValueMap();
+            String elementName = properties.get(PN_ELEMENT_NAME, String.class);
+            if (element.name == null || element.name.equals(elementName)) {
+                // set the element name (in case it was null)
+                element.name = elementName;
+                // set the element title
+                element.title = properties.get(PN_ELEMENT_TITLE, String.class);
+                // determine if the element is multi-valued (if the value type is e.g. "string[]")
+                element.isMultiValued = properties.get(PN_VALUE_TYPE, "").endsWith("[]");
+                found = true;
+                break;
+            }
+        }
+        // return if we didn't find an element with the given name
+        if (!found) {
+            return null;
+        }
+
+        // loop over the data nodes
+        for (Resource data : resource.getChild(PATH_DATA).getChildren()) {
+            ValueMap properties = data.getValueMap();
+            String[] values = properties.get(element.name, String[].class);
+            String contentType = properties.get(element.name + "@ContentType", String.class);
+            if ("master".equals(data.getName())) {
+                element.values = values;
+                element.contentType = contentType;
+            } else {
+                properties = resource.getChild(PATH_MODEL_VARIATIONS + "/" + data.getName()).getValueMap();
+                String title = properties.get(JCR_TITLE, String.class);
+                element.addVariation(data.getName(), title, contentType, values, true, values[0]);
+            }
+        }
+
+        return element;
+    }
+
+    /**
+     * Returns a list of resources representing the associated content for a content fragment.
+     */
+    private Iterator<Resource> getAssociatedContent(Resource resource) {
+        List<Resource> associatedContent = new LinkedList<>();
+        ResourceResolver resolver = resource.getResourceResolver();
+        Resource members = resource.getChild(PATH_ASSOCIATED_CONTENT);
+        if (resource != null) {
+            String[] paths = members.getValueMap().get("sling:resources", String[].class);
+            if (paths != null) {
+                for (String path : paths) {
+                    associatedContent.add(resolver.getResource(path));
+                }
+            }
+        }
+        return associatedContent.iterator();
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/MockElement.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/MockElement.java
@@ -1,0 +1,60 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class MockElement {
+
+    public String name;
+    public String title;
+    boolean isMultiValued;
+    public String contentType;
+    public String[] values;
+    public boolean isMultiLine;
+    public String htmlValue;
+    public Map<String, MockVariation> variations = new LinkedHashMap<>();
+
+    public MockElement() {
+    }
+
+    public MockElement(String name, String title, String contentType, String value, boolean isMultiLine, String htmlValue) {
+        this(name, title, contentType, new String[]{value}, isMultiLine, htmlValue);
+        this.isMultiValued = false;
+    }
+
+    public MockElement(String name, String title, String contentType, String[] values, boolean isMultiLine,
+                       String htmlValue) {
+        this.name = name;
+        this.title = title;
+        this.contentType = contentType;
+        this.isMultiValued = true;
+        this.values = values;
+        this.isMultiLine = isMultiLine;
+        this.htmlValue = htmlValue;
+    }
+
+    public void addVariation(String name, String title, String contentType, String[] values, boolean isMultiline,
+                             String htmlValue) {
+        variations.put(name, new MockVariation(name, title, contentType, values, isMultiline, htmlValue));
+    }
+
+    public void addVariation(String name, String title, String contentType, String value, boolean isMultiline,
+                             String htmlValue) {
+        variations.put(name, new MockVariation(name, title, contentType, value, isMultiline, htmlValue));
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/MockVariation.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/MockVariation.java
@@ -1,0 +1,41 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment;
+
+public class MockVariation {
+
+    String name;
+    String title;
+    public String contentType;
+    public String[] values;
+    public boolean isMultiLine;
+    public String htmlValue;
+
+    public MockVariation(String name, String title, String contentType, String[] values, boolean isMultiLine,
+                         String htmlValue) {
+        this.name = name;
+        this.title = title;
+        this.contentType = contentType;
+        this.values = values;
+        this.isMultiLine = isMultiLine;
+        this.htmlValue = htmlValue;
+    }
+
+    public MockVariation(String name, String title, String contentType, String value, boolean isMultiLine,
+                         String htmlValue) {
+        this(name, title, contentType, new String[]{value}, isMultiLine, htmlValue);
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/AbstractDataSourceServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/AbstractDataSourceServletTest.java
@@ -42,7 +42,7 @@ import com.adobe.granite.ui.components.ExpressionResolver;
 import com.adobe.granite.ui.components.ds.DataSource;
 import io.wcm.testing.mock.aem.junit.AemContext;
 
-import static com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment.ContentFragmentImplTest.ADAPTER;
+import static com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment.AbstractContentFragmentTest.ADAPTER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ElementNamesRenderConditionTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ElementNamesRenderConditionTest.java
@@ -40,7 +40,7 @@ import com.adobe.granite.ui.components.ExpressionResolver;
 import com.adobe.granite.ui.components.rendercondition.RenderCondition;
 import io.wcm.testing.mock.aem.junit.AemContext;
 
-import static com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment.ContentFragmentImplTest.ADAPTER;
+import static com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment.AbstractContentFragmentTest.ADAPTER;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;

--- a/bundles/core/src/test/resources/com/adobe/cq/wcm/core/components/internal/expectedJson.json
+++ b/bundles/core/src/test/resources/com/adobe/cq/wcm/core/components/internal/expectedJson.json
@@ -1,0 +1,15 @@
+{
+    "title": "titleOfTheContentFragment",
+    "path": "/path/to/the/content/fragment",
+    "variation": "slave",
+    "elements": [
+        "foo",
+        "bar"
+    ],
+    "associatedContent": [
+        {
+            "title": "associatedContentTitle",
+            "path": "/path/to/the/associated/content"
+        }
+    ]
+}

--- a/bundles/core/src/test/resources/com/adobe/cq/wcm/core/components/internal/foo.json
+++ b/bundles/core/src/test/resources/com/adobe/cq/wcm/core/components/internal/foo.json
@@ -1,0 +1,9 @@
+{
+    "jcr:primaryType": "nt:unstructured",
+    "bar": {
+        "jcr:primaryType": "nt:unstructured"
+    },
+    "qux": {
+        "jcr:primaryType": "nt:unstructured"
+    }
+}

--- a/bundles/core/src/test/resources/contentfragment/test-content.json
+++ b/bundles/core/src/test/resources/contentfragment/test-content.json
@@ -89,7 +89,8 @@
                         "jcr:primaryType"   : "nt:unstructured",
                         "sling:resourceType": "core/wcm/components/contentfragment/v1/contentfragment",
                         "fragmentPath"      : "/content/dam/contentfragments/structured",
-                        "variationName"     : "non-existing"
+                        "variationName"     : "non-existing",
+                        "displayMode"       : "singleText"
                     },
                     "structured-nested-model"              : {
                         "jcr:primaryType"   : "nt:unstructured",
@@ -106,7 +107,8 @@
                         "jcr:primaryType"   : "nt:unstructured",
                         "sling:resourceType": "core/wcm/components/contentfragment/v1/contentfragment",
                         "fragmentPath"      : "/content/dam/contentfragments/structured",
-                        "elementNames"      : ["main"]
+                        "elementNames"      : ["main"],
+                        "displayMode"       : "singleText"
                     },
                     "structured-multiple-elements"         : {
                         "jcr:primaryType"   : "nt:unstructured",

--- a/bundles/core/src/test/resources/contentfragment/test-expected-content-export.json
+++ b/bundles/core/src/test/resources/contentfragment/test-expected-content-export.json
@@ -1,24 +1,26 @@
 {
-  "title": "Test Content Fragment",
-  "description": "This is a test content fragment.",
-  "model": "/content/dam/contentfragments/text-only/jcr:content/model",
-  "elements": {
-    "main": {
-      "value": "<p>Main content</p>",
-      "title": "Main",
-      ":type": "text/html"
+    "title": "Test Content Fragment",
+    "description": "This is a test content fragment.",
+    "model": "/content/dam/contentfragments/text-only/jcr:content/model",
+    ":type": "core/wcm/components/contentfragment/v1/contentfragment",
+    "elements": {
+        "main": {
+            "value": "<p>Main content</p>",
+            "title": "Main",
+            ":type": "text/html",
+            "multiValue": false
+        },
+        "second": {
+            "value": "Second content",
+            "title": "Second",
+            ":type": "text/plain",
+            "multiValue": false
+        }
     },
-    "second": {
-      "value": "Second content",
-      "title": "Second",
-      ":type": "text/plain"
-    }
-  },
-  "elementsOrder": [
-    "main",
-    "second"
-  ],
-  ":type": "core/wcm/components/contentfragment/v1/contentfragment",
-  ":items": {},
-  ":itemsOrder": []
+    ":items": {},
+    ":itemsOrder": [],
+    "elementsOrder": [
+        "main",
+        "second"
+    ]
 }

--- a/bundles/core/src/test/resources/findbugs-exclude.xml
+++ b/bundles/core/src/test/resources/findbugs-exclude.xml
@@ -27,4 +27,9 @@
     <Match>
         <Bug pattern="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS" />
     </Match>
+    <Match>
+        <Class name="com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment.ContentFragmentImpl" />
+        <Method name="getParagraphs" />
+        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
+    </Match>
 </FindBugsFilter>

--- a/content/package-lock.json
+++ b/content/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "com.adobe.cq.core.wcm.components.content",
-    "version": "2.3.0",
+    "version": "2.3.3-SNAPSHOT",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/editAction.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/editAction.js
@@ -19,7 +19,7 @@
     // class of the content fragment
     var CLASS_CONTENTFRAGMENT = "cmp-contentfragment";
     // name of the attribute on the content fragment storing its path
-    var ATTRIBUTE_PATH = "data-path";
+    var ATTRIBUTE_PATH = "data-cmp-contentfragment-path";
     // base URL of the editor
     var EDITOR_URL = "/editor.html";
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/contentfragment.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/contentfragment.html
@@ -15,12 +15,8 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <sly data-sly-use.fragment="com.adobe.cq.wcm.core.components.models.contentfragment.ContentFragment"
      data-sly-test="${properties.fragmentPath}" data-sly-use.cfTemplates="templates.html">
-    <sly data-sly-test.isParagraphMode="${fragment.elements.size == 1 && fragment.elements[0].isMultiLine && properties.displayMode == 'singleText'}">
-        <sly data-sly-call="${cfTemplates.paragraphs @ fragment=fragment, fragmentPath=properties.fragmentPath, wcmmode=wcmmode}"></sly>
-    </sly>
-    <sly data-sly-test="${!isParagraphMode}">
-        <sly data-sly-call="${cfTemplates.elements @ fragment=fragment, fragmentPath=properties.fragmentPath, wcmmode=wcmmode}"></sly>
-    </sly>
+    <sly data-sly-call="${cfTemplates.contentFragment @ fragment=fragment, fragmentPath=properties.fragmentPath, wcmmode=wcmmode}"></sly>
 </sly>
+
 <sly data-sly-use.template="core/wcm/components/commons/v1/templates.html"
-     data-sly-call="${template.placeholder @ isEmpty=!properties.fragmentPath || !fragment.elements || fragment.elements.isEmpty, classAppend='cq-dd-contentfragment'}"></sly>
+     data-sly-call="${template.placeholder @ isEmpty=!properties.fragmentPath, classAppend='cq-dd-contentfragment'}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/element.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/element.html
@@ -14,8 +14,8 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <template data-sly-template.element="${@ element='The content fragment element'}">
-    <div class="cmp-contentfragment__element cmp-contentfragment__element--${element.name}">
-        <dt class="cmp-contentfragment__element-label">${element.title}</dt>
+    <div class="cmp-contentfragment__element cmp-contentfragment__element--${element.name}" data-cmp-contentfragment-element-type="${element.dataType}">
+        <dt class="cmp-contentfragment__element-title">${element.title}</dt>
         <dd class="cmp-contentfragment__element-value">
             <sly data-sly-test="${element.dataType == 'calendar'}" data-sly-use.tpl="calendar.html"
                  data-sly-call="${tpl.element @ date = element.value}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/rawcontent.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/rawcontent.html
@@ -13,4 +13,5 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/--><sly data-sly-use.fragment="com.adobe.cq.wcm.core.components.models.contentfragment.ContentFragment">${fragment.elements[0].html @ context="unsafe"}</sly>
+*/-->
+<sly data-sly-use.fragment="com.adobe.cq.wcm.core.components.models.contentfragment.ContentFragment">${fragment.elements[0].html @ context="unsafe"}</sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/templates.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/templates.html
@@ -14,26 +14,39 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 
-<template data-sly-template.paragraphs="${@ fragment='The content fragment', fragmentPath='fragment path', wcmmode = 'WCM mode'}">
-    <div data-path="${fragmentPath}"
-         data-json="${!wcmmode.disabled && fragment.editorJSON}"
-         class="cmp-contentfragment">
+<template data-sly-template.contentFragment="${@ fragment='The content fragment', fragmentPath='', wcmmode='WCM mode'}">
+    <article class="cmp-contentfragment"
+             data-cmp-contentfragment-model="${fragment.type}"
+             data-sly-attribute.data-cmp-contentfragment-path="${fragmentPath}"
+             data-json="${!wcmmode.disabled && fragment.editorJSON}">
+        <h3 class="cmp-contentfragment__title">${fragment.title}</h3>
+        <sly data-sly-test="${fragment.description}">
+            <p class="cmp-contentfragment__description">${fragment.description}</p>
+        </sly>
+
+        <sly data-sly-test.isParagraphMode="${fragment.elements.size == 1 && fragment.elements[0].isMultiLine && properties.displayMode == 'singleText'}">
+            <sly data-sly-call="${paragraphs @ fragment=fragment}"></sly>
+        </sly>
+        <sly data-sly-test="${!isParagraphMode}">
+            <sly data-sly-call="${elements @ fragment=fragment, wcmmode=wcmmode}"></sly>
+        </sly>
+    </article>
+</template>
+
+<template data-sly-template.paragraphs="${@ fragment='The content fragment'}">
+    <div class="cmp-contentfragment__elements">
         <div data-sly-resource="${'par0' @ resourceType=fragment.gridResourceType}"></div>
-        <div data-sly-list="${fragment.elements[0].paragraphs}">
+        <div data-sly-list="${fragment.paragraphs}">
             ${item @ context="html"}
             <div data-sly-resource="${'par{0}' @ format=itemList.count, resourceType=fragment.gridResourceType}"></div>
         </div>
     </div>
 </template>
 
-<template data-sly-template.elements="${@ fragment='The content fragment', fragmentPath='fragment path', wcmmode = 'WCM mode'}">
-    <dl data-path="${fragmentPath}"
-        data-type="${fragment.type}"
-        data-json="${!wcmmode.disabled && fragment.editorJSON}"
-        class="cmp-contentfragment${!wcmmode.disabled ? ' cq-dd-contentfragment' : ''}"
+<template data-sly-template.elements="${@ fragment='The content fragment', wcmmode='WCM mode'}">
+    <dl class="cmp-contentfragment__elements${!wcmmode.disabled ? ' cq-dd-contentfragment' : ''}"
         data-sly-list.element="${fragment.elements}"
         data-sly-use.elementTemplate="element.html">
         <sly data-sly-call="${elementTemplate.element @ element=element}"></sly>
     </dl>
 </template>
-

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -716,6 +716,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-all</artifactId>
+                <version>1.3</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
                 <version>2.3.2</version>

--- a/testing/it/ui-js/package-lock.json
+++ b/testing/it/ui-js/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "com.adobe.cq.core.wcm.components.it.ui-js",
-    "version": "6.3.54",
+    "version": "6.3.57-SNAPSHOT",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
This PR is based on https://github.com/adobe/aem-core-wcm-components/pull/498

It modifies the newly added content fragment component and
* Separates content fragment (exporter) model logic from component logic
* Extracts common logic into utility class and adds tests
* Refactors tests and mainly extract test classes to simplify
  maintenance
* Improves templates and HTML to reflect requirements from PM

Todos:
- [x] Merge https://github.com/adobe/aem-core-wcm-components/pull/498
- [x] Rebase after integration of https://github.com/adobe/aem-core-wcm-components/pull/498