### PR TITLE
[ContentFragment] Move content fragment component from extension to core

### DIFF
--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
@@ -217,7 +217,7 @@ public class ContentFragmentImplTest extends AbstractContentFragmentTest<Content
         ObjectMapper mapper = new ObjectMapper();
         mapper.writerWithView(DAMContentFragmentImpl.class).writeValue(writer, fragment);
         JsonReader jsonReaderOutput = Json.createReader(IOUtils.toInputStream(writer.toString(), StandardCharsets.UTF_8));
-        JsonReader jsonReaderExpected = Json.createReader(Thread.currentThread().getContextClassLoader().getClass()
+        JsonReader jsonReaderExpected = Json.createReader(getClass()
             .getResourceAsStream("/contentfragment/test-expected-content-export.json"));
         assertEquals(jsonReaderExpected.read(), jsonReaderOutput.read());
     }


### PR DESCRIPTION
- fix failing test with JDK 11