### PR TITLE
[Docs] Improve contributing guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ install the latest snapshot version from the master branch.
 ## Bug Report
 
 **Current Behavior**
-A clear and concise description of the behavior and your setup; if applicable, proxy component pattern and component version.
+A clear and concise description of the behavior, including steps that are repeatable, and your setup; if applicable, proxy component pattern and component version.
 
 **Expected behavior/code**
 A clear and concise description of what you expected to happen.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,21 @@
 # Contributing
 
-Thank you for choosing to contribute to Adobe Experience Manager Core Components, we really appreciate your time and effort! :smiley::confetti_ball:
+Thank you for choosing to contribute to the Adobe Experience Manager Core Components project, we really appreciate your time and effort! 😃🎊
 
-The following are a set of guidelines to follow when contributing to the project.
+The following are a set of guidelines for contributing to the project.
 
 #### Contents
 
 * [Code of Conduct](#code-of-conduct)
 * [Ways of Contributing](#ways-of-contributing)
-  * [Joining Feature Discussions](#commenting-on-feature-requirements)
-  * [Joining Developer Discussions](https://groups.google.com/forum/#!forum/aem-core-components-dev)
-  * [Reporting Bugs](#reporting-bugs)
-  * [Suggesting Enhancements](#suggesting-enhancements)
-  * [Contributing Code](#contributing-code)
-  * [Reviewing Code](#reviewing-code)
-  * [Documenting](#documenting)
+  * [Joining Feature Discussions](#joining-feature-discussions) 💭
+  * [Joining Developer Discussions](#joining-developer-discussions) 💬
+  * [Reporting Bugs](#reporting-bugs) 🐛
+  * [Requesting Features](#requesting-features) 🚀
+  * [Contributing Code](#contributing-code) 👾
+  * [Reviewing Code](#reviewing-code) 👀
+  * [Documenting](#documenting) 📜
+* [Issue Report Guidelines](#issue-report-guidelines)
 * [Contributor License Agreement](#contributor-license-agreement)
 
 ## Code of Conduct
@@ -25,9 +26,9 @@ This project adheres to the Adobe [Code of Conduct](CODE_OF_CONDUCT.md). By part
 
 There are many ways of contributing, from testing and reporting an issue to suggesting and coding full components or features. Below is a summary of some of the best ways to get involved. 
 
-### Joining Feature Discussions
+### Joining Feature Discussions 💭
 
-There are a few different ways that you can add your voice to discussions around new and existing component features:
+You can add your voice to discussions around new and existing component features by:
 
 * Commenting on an RTC. New components and features that openly invite public comment are marked by an [RTC](https://github.com/adobe/aem-core-wcm-components/labels/rtc) (Request to Comment) label. We strongly encourage users of the Core Components to bring their own project experience to these issues, as there may be alternative use-cases or requirements that haven't yet been considered.
 * Subscribing to the [Component Round Table](https://gabrielwalt.typeform.com/to/aKeZS6) to participate in sessions on the Core Components.
@@ -36,33 +37,43 @@ There are a few different ways that you can add your voice to discussions around
 
 If you have thoughts on the code, the general architecture of the project, or would like some initial feedback on a feature you are thinking of coding, you can join the [Core Components Developer Mailing List](https://groups.google.com/forum/#!forum/aem-core-components-dev).
 
-### Reporting Bugs
+### Reporting Bugs 🐛
 
 ##### Before Reporting 
 
 * Have a quick search through the currently open [bug reports](https://github.com/adobe/aem-core-wcm-components/labels/bug) to see if the issue has already been reported.
 * Ensure that the issue is repeatable and that the actual behavior versus the expected results can be easily described.
-* Check that the issue you are experiencing is related to the Core Components project. It may be that the problem derives from the core AEM editor code rather than Core Components. If you're not sure, then feel free to report the issue anyway and the committers will clarify for you. Issues in the product can be reported via [Adobe Enterprise Support](https://helpx.adobe.com/contact/enterprise-support.ec.html).
+* Check that the issue you are experiencing is related to the Core Components project. It may be that the problem derives from AEM itself, typically editor code, rather than the Core Components. If you're not sure, then feel free to report the issue anyway and the committers will clarify for you. Issues in the product can be reported via [Adobe Enterprise Support](https://helpx.adobe.com/contact/enterprise-support.ec.html).
 
 ##### Filing a Bug
 
-### Suggesting Enhancements
+1. Visit our issue [tracker on GitHub](https://github.com/adobe/aem-core-wcm-components/issues).
+1. File a `New Issue` as a `Bug Report`.
+1. Ensure your issue follows the `Issue Report Guidelines`.
+1. Thanks for the report! The committers will get back to you in a timely manner, typically within one week.
 
-##### Before Suggesting an Enhancement
+### Requesting Features 🚀
 
-* Have a quick search through the currently open [Enhancement](https://github.com/adobe/aem-core-wcm-components/labels/enhancement), [Feature](https://github.com/adobe/aem-core-wcm-components/labels/feature) and [Request to Comment](https://github.com/adobe/aem-core-wcm-components/labels/rtc) issues to see if the idea has already been suggested. If it has, you may still have a slightly different requirement that isn't covered, in which case, feel free to comment on the open issue. 
+##### Before Requesting a Feature
+
+* Have a quick search through the currently open [enhancement](https://github.com/adobe/aem-core-wcm-components/labels/enhancement), [feature](https://github.com/adobe/aem-core-wcm-components/labels/feature) and [request to comment](https://github.com/adobe/aem-core-wcm-components/labels/rtc) issues to see if the idea has already been suggested. If it has, you may still have a slightly different requirement that isn't covered, in which case, feel free to comment on the open issue. 
 * Take a look at the [Core Components Roadmap](https://github.com/adobe/aem-core-wcm-components/wiki#roadmap) to see if your feature is already on the radar. If it is and doesn't have a public issue yet, feel free to create one, listing your own requirements.
 * Consider whether your requirement is generically useful rather than project-specific and would therefore benefit all users of the Core Components.
 
-##### Suggesting an Enhancement
+##### Requesting a Feature
 
-### Contributing Code
+1. Visit our issue [tracker on GitHub](https://github.com/adobe/aem-core-wcm-components/issues).
+1. File a `New Issue` as a `Feature Request`.
+1. Ensure your issue follows the `Issue Report Guidelines`.
+1. Thanks for the feature request!  The committers will get back to you in a timely manner, typically within one week.
+
+### Contributing Code 👾 
 
 High quality code is important to the project, and to keep it that way, all code submissions are reviewed by committers before being accepted. A close adherence to the guidelines below can help speed up the review process and increase the likelihood of the submission being accepted.
 
 ##### Before Contributing
 
-* Consider [Joining the Developer Discussion](#joining-the-developer-discussion) to get feedback what you are thinking of contributing. It's better to get this early feedback before going ahead, and having to rewrite everything later.
+* Consider [Joining Developer Discussions](#joining-developer-discussions) to get feedback on what you are thinking of contributing. It's better to get this early feedback before going ahead and potentially having to rewrite everything later.
 * Create a [bug report](#reporting-bugs) or [feature request](#suggesting-enhancements) issue summarizing the problem that you will be solving. This will again help with early feedback and tracking.
 * Check through the project [development guidelines](Guidelines.md).
 
@@ -70,13 +81,23 @@ High quality code is important to the project, and to keep it that way, all code
 
 New code contributions should be made primarily using GitHub pull requests. This involves creating a fork of the project in your personal space, adding your new code in a branch and triggering a pull request. Check the GitHub [Using Pull Requests](https://help.github.com/articles/using-pull-requests) article on how to perform pull requests.
 
-### Reviewing Code
+### Reviewing Code 👀
 
 Reviewing others' code contributions is another great way to contribute - more eyes on the code help to improve its overall quality. To review a pull request, check the [open pull requests](https://github.com/adobe/aem-core-wcm-components/pulls) for anything you can comment on. 
 
-### Documenting
+### Documenting 📜
 
 We very much welcome issue reports or pull requests that improve our documentation pages. While the best effort is made to keep them error free, useful and up-to-date there are always things that could be improved. The component documentation pages (for example the [Image Component](https://github.com/adobe/aem-core-wcm-components/blob/master/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/README.md)), this contribution guide or our [GitHub Wiki](https://github.com/adobe/aem-core-wcm-components/wiki) pages are good places to start.
+
+## Issue Report Guidelines
+
+A well defined issue report will help in quickly understanding and replicating the problem faced, or the feature requested. Below are some rough guidelines on what to include when reporting an issue:
+
+* Title
+    * **Descriptive** - Should be easy to understand.
+    * **Succinct** - If the issue can't be easily described in the title, then the problem is likely unfocused.
+    * **Keyword Rich** - Including keywords can help with quickly finding the issue in the backlog. Component related issues can be bracketed with label, for example `[Image]`.
+* Description - See our `bug report` and `feature request` issue templates for details on what is expected to be described.
 
 ## Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ If you have thoughts on the code, the general architecture of the project, or wo
 
 ##### Before Requesting a Feature
 
-* Have a quick search through the currently open [enhancement](https://github.com/adobe/aem-core-wcm-components/labels/enhancement), [feature](https://github.com/adobe/aem-core-wcm-components/labels/feature) and [request to comment](https://github.com/adobe/aem-core-wcm-components/labels/rtc) issues to see if the idea has already been suggested. If it has, you may still have a slightly different requirement that isn't covered, in which case, feel free to comment on the open issue. 
+* Have a quick search through the currently open [enhancement](https://github.com/adobe/aem-core-wcm-components/labels/enhancement) and [request to comment](https://github.com/adobe/aem-core-wcm-components/labels/rtc) issues to see if the idea has already been suggested. If it has, you may still have a slightly different requirement that isn't covered, in which case, feel free to comment on the open issue. 
 * Take a look at the [Core Components Roadmap](https://github.com/adobe/aem-core-wcm-components/wiki#roadmap) to see if your feature is already on the radar. If it is and doesn't have a public issue yet, feel free to create one, listing your own requirements.
 * Consider whether your requirement is generically useful rather than project-specific and would therefore benefit all users of the Core Components.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,13 @@ The following are a set of guidelines for contributing to the project.
 
 * [Code of Conduct](#code-of-conduct)
 * [Ways of Contributing](#ways-of-contributing)
-  * [Joining Feature Discussions](#joining-feature-discussions) 💭
-  * [Joining Developer Discussions](#joining-developer-discussions) 💬
-  * [Reporting Bugs](#reporting-bugs) 🐛
-  * [Requesting Features](#requesting-features) 🚀
-  * [Contributing Code](#contributing-code) 👾
-  * [Reviewing Code](#reviewing-code) 👀
-  * [Documenting](#documenting) 📜
+  * [Joining Feature Discussions](#joining-feature-discussions-) 💭
+  * [Joining Developer Discussions](#joining-developer-discussions-) 💬
+  * [Reporting Bugs](#reporting-bugs-) 🐛
+  * [Requesting Features](#requesting-features-) 🚀
+  * [Contributing Code](#contributing-code-) 👾
+  * [Reviewing Code](#reviewing-code-) 👀
+  * [Documenting](#documenting-) 📜
 * [Issue Report Guidelines](#issue-report-guidelines)
 * [Contributor License Agreement](#contributor-license-agreement)
 
@@ -91,16 +91,16 @@ We very much welcome issue reports or pull requests that improve our documentati
 
 ## Issue Report Guidelines
 
-A well defined issue report will help in quickly understanding and replicating the problem faced, or the feature requested. Below are some rough guidelines on what to include when reporting an issue:
+A well defined issue report will help in quickly understanding and replicating the problem faced, or the feature requested. Below are some guidelines on what to include when reporting an issue:
 
 * Title
     * **Descriptive** - Should be specific and well described.
     * **Understandable** - Should be readable at a glance.
     * **Succinct** - If the issue can't be easily described in a short title, then the problem is likely unfocused.
-    * **Keyword Rich** - Including keywords can help with quickly finding the issue in the backlog. Component related issues can be prefixed with a bracketed with label with the component name, for example `[Image]`.
+    * **Keyword Rich** - Including keywords can help with quickly finding the issue in the backlog. Component related issues can be prefixed with a bracketed label with the component name, for example `[Image]` for the image component.
 * Description - See our [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) or [feature request template](.github/ISSUE_TEMPLATE/feature_request.md) for details on what is expected to be described. The same information is available when creating a new issue on GitHub.
 
-See [this community reported issue](https://github.com/adobe/aem-core-wcm-components/issues/247) for an excellent example of how to write a successful issue report.
+See [this community reported issue](https://github.com/adobe/aem-core-wcm-components/issues/247) for a good example of how to write a successful issue report.
 
 ## Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,82 @@
 # Contributing
 
-Thanks for choosing to contribute!
+Thank you for choosing to contribute to Adobe Experience Manager Core Components, we really appreciate your time and effort! :smiley::confetti_ball:
 
-The following are a set of guidelines to follow when contributing to this project.
+The following are a set of guidelines to follow when contributing to the project.
 
-## Code Of Conduct
+#### Contents
 
-This project adheres to the Adobe [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to the team.
+* [Code of Conduct](#code-of-conduct)
+* [Ways of Contributing](#ways-of-contributing)
+  * [Joining Feature Discussions](#commenting-on-feature-requirements)
+  * [Joining Developer Discussions](https://groups.google.com/forum/#!forum/aem-core-components-dev)
+  * [Reporting Bugs](#reporting-bugs)
+  * [Suggesting Enhancements](#suggesting-enhancements)
+  * [Contributing Code](#contributing-code)
+  * [Reviewing Code](#reviewing-code)
+  * [Documenting](#documenting)
+* [Contributor License Agreement](#contributor-license-agreement)
+
+## Code of Conduct
+
+This project adheres to the Adobe [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to the team.
+
+## Ways of Contributing
+
+There are many ways of contributing, from testing and reporting an issue to suggesting and coding full components or features. Below is a summary of some of the best ways to get involved. 
+
+### Joining Feature Discussions
+
+There are a few different ways that you can add your voice to discussions around new and existing component features:
+
+* Commenting on an RTC. New components and features that openly invite public comment are marked by an [RTC](https://github.com/adobe/aem-core-wcm-components/labels/rtc) (Request to Comment) label. We strongly encourage users of the Core Components to bring their own project experience to these issues, as there may be alternative use-cases or requirements that haven't yet been considered.
+* Subscribing to the [Component Round Table](https://gabrielwalt.typeform.com/to/aKeZS6) to participate in sessions on the Core Components.
+
+### Joining Developer Discussions
+
+If you have thoughts on the code, the general architecture of the project, or would like some initial feedback on a feature you are thinking of coding, you can join the [Core Components Developer Mailing List](https://groups.google.com/forum/#!forum/aem-core-components-dev).
+
+### Reporting Bugs
+
+##### Before Reporting 
+
+* Have a quick search through the currently open [bug reports](https://github.com/adobe/aem-core-wcm-components/labels/bug) to see if the issue has already been reported.
+* Ensure that the issue is repeatable and that the actual behavior versus the expected results can be easily described.
+* Check that the issue you are experiencing is related to the Core Components project. It may be that the problem derives from the core AEM editor code rather than Core Components. If you're not sure, then feel free to report the issue anyway and the committers will clarify for you. Issues in the product can be reported via [Adobe Enterprise Support](https://helpx.adobe.com/contact/enterprise-support.ec.html).
+
+##### Filing a Bug
+
+### Suggesting Enhancements
+
+##### Before Suggesting an Enhancement
+
+* Have a quick search through the currently open [Enhancement](https://github.com/adobe/aem-core-wcm-components/labels/enhancement), [Feature](https://github.com/adobe/aem-core-wcm-components/labels/feature) and [Request to Comment](https://github.com/adobe/aem-core-wcm-components/labels/rtc) issues to see if the idea has already been suggested. If it has, you may still have a slightly different requirement that isn't covered, in which case, feel free to comment on the open issue. 
+* Take a look at the [Core Components Roadmap](https://github.com/adobe/aem-core-wcm-components/wiki#roadmap) to see if your feature is already on the radar. If it is and doesn't have a public issue yet, feel free to create one, listing your own requirements.
+* Consider whether your requirement is generically useful rather than project-specific and would therefore benefit all users of the Core Components.
+
+##### Suggesting an Enhancement
+
+### Contributing Code
+
+High quality code is important to the project, and to keep it that way, all code submissions are reviewed by committers before being accepted. A close adherence to the guidelines below can help speed up the review process and increase the likelihood of the submission being accepted.
+
+##### Before Contributing
+
+* Consider [Joining the Developer Discussion](#joining-the-developer-discussion) to get feedback what you are thinking of contributing. It's better to get this early feedback before going ahead, and having to rewrite everything later.
+* Create a [bug report](#reporting-bugs) or [feature request](#suggesting-enhancements) issue summarizing the problem that you will be solving. This will again help with early feedback and tracking.
+* Check through the project [development guidelines](Guidelines.md).
+
+##### Contributing
+
+New code contributions should be made primarily using GitHub pull requests. This involves creating a fork of the project in your personal space, adding your new code in a branch and triggering a pull request. Check the GitHub [Using Pull Requests](https://help.github.com/articles/using-pull-requests) article on how to perform pull requests.
+
+### Reviewing Code
+
+Reviewing others' code contributions is another great way to contribute - more eyes on the code help to improve its overall quality. To review a pull request, check the [open pull requests](https://github.com/adobe/aem-core-wcm-components/pulls) for anything you can comment on. 
+
+### Documenting
+
+We very much welcome issue reports or pull requests that improve our documentation pages. While the best effort is made to keep them error free, useful and up-to-date there are always things that could be improved. The component documentation pages (for example the [Image Component](https://github.com/adobe/aem-core-wcm-components/blob/master/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/README.md)), this contribution guide or our [GitHub Wiki](https://github.com/adobe/aem-core-wcm-components/wiki) pages are good places to start.
 
 ## Contributor License Agreement
 
@@ -17,19 +87,3 @@ You confirm that you are able to grant us these rights. You represent that You a
 You represent that the Contributions are Your original works of authorship, and to Your knowledge, no other person claims, or has the right to claim, any right in any invention or patent related to the Contributions. You also represent that You are not legally obligated, whether by entering into an agreement or otherwise, in any way that conflicts with the terms of this license.
 
 YOU ARE NOT EXPECTED TO PROVIDE SUPPORT FOR YOUR SUBMISSION, UNLESS AND EXCEPT TO THE EXTENT YOU CHOOSE TO DO SO. UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, THE SUBMISSION PROVIDED UNDER THIS AGREEMENT IS PROVIDED WITHOUT WARRANTY OF ANY KIND.
-
-## How to contribute
-
-New code contributions should be made primarily using GitHub pull requests. This involves creating a fork of the project in your personal space, adding your new code in a branch and triggering a pull request.
-
-See how to perform pull requests at https://help.github.com/articles/using-pull-requests.
-
-Also make sure to check our [development guidelines](Guidelines.md) before submitting your contribution.
-
-## Issues
-
-Filing [issues](https://github.com/adobe/aem-core-wcm-components/issues) and joining in conversations is the recommended way to provide feedback.
-
-## Code Reviews
-
-Reviewing others' code contributions is another great way to contribute. To do that, see the [open pull requests](https://github.com/adobe/aem-core-wcm-components/pulls). Committers will review all pull requests before accepting them as contributions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,16 +91,23 @@ We very much welcome issue reports or pull requests that improve our documentati
 
 ## Issue Report Guidelines
 
-A well defined issue report will help in quickly understanding and replicating the problem faced, or the feature requested. Below are some guidelines on what to include when reporting an issue:
+A well defined issue report will help in quickly understanding and replicating the problem faced, or the feature requested. Below are some guidelines on what to include when reporting an issue. You can also see [this community reported issue](https://github.com/adobe/aem-core-wcm-components/issues/247) for an example of a well written issue report.
 
-* Title
-    * **Descriptive** - Should be specific and well described.
-    * **Understandable** - Should be readable at a glance.
-    * **Succinct** - If the issue can't be easily described in a short title, then the problem is likely unfocused.
-    * **Keyword Rich** - Including keywords can help with quickly finding the issue in the backlog. Component related issues can be prefixed with a bracketed label with the component name, for example `[Image]` for the image component.
-* Description - See our [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) or [feature request template](.github/ISSUE_TEMPLATE/feature_request.md) for details on what is expected to be described. The same information is available when creating a new issue on GitHub.
+##### Title
+* **Descriptive** - Should be specific, well described and readable at a glance.
+* **Concise** - If the issue can't be easily described in a short title, then it is likely unfocused.
+* **Keyword-rich** - Including keywords can help with quickly finding the issue in the backlog. Component related issues can be prefixed with a bracketed label with the component name, for example `[Image]` for the image component.
 
-See [this community reported issue](https://github.com/adobe/aem-core-wcm-components/issues/247) for a good example of how to write a successful issue report.
+Bad title: `Search component has security problems`  
+Good title: `[Search] Fulltext search of pages might lead to DDOS`
+
+##### Description
+
+See our [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) or [feature request template](.github/ISSUE_TEMPLATE/feature_request.md) for details on what is expected to be described. The same information is available when creating a new issue on GitHub.
+
+##### Labels
+
+Once an issue is reported, the project committers will assign it a relevant label. You can see our [label list on GitHub](https://github.com/adobe/aem-core-wcm-components/labels) to better understand what each label means.
 
 ## Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,16 @@ High quality code is important to the project, and to keep it that way, all code
 
 ##### Contributing
 
-New code contributions should be made primarily using GitHub pull requests. This involves creating a fork of the project in your personal space, adding your new code in a branch and triggering a pull request. Check the GitHub [Using Pull Requests](https://help.github.com/articles/using-pull-requests) article on how to perform pull requests.
+The project accepts contributions primarily using GitHub pull requests. This process:
+* Helps to maintain project quality
+* Engages the community in working towards commonly accepted solutions with peer review
+* Leads to a more meaningful and cleaner git history
+* Ensures sustainable code management 
+
+Creating a pull request involves creating a fork of the project in your personal space, adding your new code in a branch and triggering a pull request. Check the GitHub [Using Pull Requests](https://help.github.com/articles/using-pull-requests) article on how to perform pull requests.
+
+##### Your first contribution
+Would you would like to contribute to the project but don't have an issue in mind? Or are still fairly unfamiliar with the code? Then have a look at our [good first issues](https://github.com/adobe/aem-core-wcm-components/labels/good%20first%20issue), they are fairly simple starter issues that should only require a small amount of code and simple testing.
 
 ### Reviewing Code 👀
 
@@ -87,7 +96,7 @@ Reviewing others' code contributions is another great way to contribute - more e
 
 ### Documenting 📜
 
-We very much welcome issue reports or pull requests that improve our documentation pages. While the best effort is made to keep them error free, useful and up-to-date there are always things that could be improved. The component documentation pages (for example the [Image Component](https://github.com/adobe/aem-core-wcm-components/blob/master/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/README.md)), this contribution guide or our [GitHub Wiki](https://github.com/adobe/aem-core-wcm-components/wiki) pages are good places to start.
+We very much welcome issue reports or pull requests that improve our documentation pages. While the best effort is made to keep them error free, useful and up-to-date there are always things that could be improved. The component documentation pages (for example the [Image Component Documentation](https://github.com/adobe/aem-core-wcm-components/blob/master/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/README.md)), this contributing guide or our [GitHub Wiki](https://github.com/adobe/aem-core-wcm-components/wiki) pages are good places to start.
 
 ## Issue Report Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ If you have thoughts on the code, the general architecture of the project, or wo
 
 ### Reporting Bugs 🐛
 
-##### Before Reporting 
+##### Before Reporting a Bug 
 
 * Have a quick search through the currently open [bug reports](https://github.com/adobe/aem-core-wcm-components/labels/bug) to see if the issue has already been reported.
 * Ensure that the issue is repeatable and that the actual behavior versus the expected results can be easily described.
@@ -49,7 +49,7 @@ If you have thoughts on the code, the general architecture of the project, or wo
 
 1. Visit our [issue tracker on GitHub](https://github.com/adobe/aem-core-wcm-components/issues).
 1. File a `New Issue` as a `Bug Report`.
-1. Ensure your issue follows the [Issue Report Guidelines](#issue-report-guidelines).
+1. Ensure your issue follows the [issue report guidelines](#issue-report-guidelines).
 1. Thanks for the report! The committers will get back to you in a timely manner, typically within one week.
 
 ### Requesting Features 🚀
@@ -64,7 +64,7 @@ If you have thoughts on the code, the general architecture of the project, or wo
 
 1. Visit our [issue tracker on GitHub](https://github.com/adobe/aem-core-wcm-components/issues).
 1. File a `New Issue` as a `Feature Request`.
-1. Ensure your issue follows the [Issue Report Guidelines](#issue-report-guidelines).
+1. Ensure your issue follows the [issue report guidelines](#issue-report-guidelines).
 1. Thanks for the feature request! The committers will get back to you in a timely manner, typically within one week.
 
 ### Contributing Code 👾 
@@ -73,7 +73,7 @@ High quality code is important to the project, and to keep it that way, all code
 
 ##### Before Contributing
 
-* Consider [Joining Developer Discussions](#joining-developer-discussions-) to get feedback on what you are thinking of contributing. It's better to get this early feedback before going ahead and potentially having to rewrite everything later.
+* Consider [joining developer discussions](#joining-developer-discussions-) to get feedback on what you are thinking of contributing. It's better to get this early feedback before going ahead and potentially having to rewrite everything later.
 * Create a [bug report](#reporting-bugs-) or [feature request](#requesting-features-) issue summarizing the problem that you will be solving. This will again help with early feedback and tracking.
 * Have a look at our [component checklist](Guidelines.md), for an idea of what certifies a production ready component.
 
@@ -87,7 +87,7 @@ The project accepts contributions primarily using GitHub pull requests. This pro
 
 Creating a pull request involves creating a fork of the project in your personal space, adding your new code in a branch and triggering a pull request. Check the GitHub [Using Pull Requests](https://help.github.com/articles/using-pull-requests) article on how to perform pull requests.
 
-The title of the pull request typically matches that of the issue it fixes, see [Issue Report Guidelines](#issue-report-guidelines).
+The title of the pull request typically matches that of the issue it fixes, see the [issue report guidelines](#issue-report-guidelines).
 Have a look at our [pull request template](.github/pull_request_template.md) to see what is expected to be included in the pull request description. The same template is available when the pull request is triggered. 
 
 ##### Your first contribution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ If you have thoughts on the code, the general architecture of the project, or wo
 1. Visit our [issue tracker on GitHub](https://github.com/adobe/aem-core-wcm-components/issues).
 1. File a `New Issue` as a `Feature Request`.
 1. Ensure your issue follows the [Issue Report Guidelines](#issue-report-guidelines).
-1. Thanks for the feature request!  The committers will get back to you in a timely manner, typically within one week.
+1. Thanks for the feature request! The committers will get back to you in a timely manner, typically within one week.
 
 ### Contributing Code 👾 
 
@@ -73,9 +73,9 @@ High quality code is important to the project, and to keep it that way, all code
 
 ##### Before Contributing
 
-* Consider [Joining Developer Discussions](#joining-developer-discussions) to get feedback on what you are thinking of contributing. It's better to get this early feedback before going ahead and potentially having to rewrite everything later.
-* Create a [bug report](#reporting-bugs) or [feature request](#suggesting-enhancements) issue summarizing the problem that you will be solving. This will again help with early feedback and tracking.
-* Check through the project [development guidelines](Guidelines.md).
+* Consider [Joining Developer Discussions](#joining-developer-discussions-) to get feedback on what you are thinking of contributing. It's better to get this early feedback before going ahead and potentially having to rewrite everything later.
+* Create a [bug report](#reporting-bugs-) or [feature request](#requesting-features-) issue summarizing the problem that you will be solving. This will again help with early feedback and tracking.
+* Have a look at our [component checklist](Guidelines.md), for an idea of what certifies a production ready component.
 
 ##### Contributing
 
@@ -86,6 +86,9 @@ The project accepts contributions primarily using GitHub pull requests. This pro
 * Ensures sustainable code management 
 
 Creating a pull request involves creating a fork of the project in your personal space, adding your new code in a branch and triggering a pull request. Check the GitHub [Using Pull Requests](https://help.github.com/articles/using-pull-requests) article on how to perform pull requests.
+
+The title of the pull request typically matches that of the issue it fixes, see [Issue Report Guidelines](#issue-report-guidelines).
+Have a look at our [pull request template](.github/pull_request_template.md) to see what is expected to be included in the pull request description. The same template is available when the pull request is triggered. 
 
 ##### Your first contribution
 Would you would like to contribute to the project but don't have an issue in mind? Or are still fairly unfamiliar with the code? Then have a look at our [good first issues](https://github.com/adobe/aem-core-wcm-components/labels/good%20first%20issue), they are fairly simple starter issues that should only require a small amount of code and simple testing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ You can add your voice to discussions around new and existing component features
 
 ### Joining Developer Discussions 💬
 
-If you have thoughts on the code, the general architecture of the project, or would like some initial feedback on a feature you are thinking of coding, you can join the [Core Components Developer Mailing List](https://groups.google.com/forum/#!forum/aem-core-components-dev).
+If you have thoughts on the code, the general architecture of the project, or would like some initial feedback on a feature you are thinking of coding, you can visit the [Core Components Developer Mailing List](https://groups.google.com/forum/#!forum/aem-core-components-dev) on Google Groups, or [subscribe via email](mailto:aem-core-components-dev+subscribe@googlegroups.com).
 
 ### Reporting Bugs 🐛
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ You can add your voice to discussions around new and existing component features
 * Commenting on an RTC. New components and features that openly invite public comment are marked by an [RTC](https://github.com/adobe/aem-core-wcm-components/labels/rtc) (Request to Comment) label. We strongly encourage users of the Core Components to bring their own project experience to these issues, as there may be alternative use-cases or requirements that haven't yet been considered.
 * Subscribing to the [Component Round Table](https://gabrielwalt.typeform.com/to/aKeZS6) to participate in sessions on the Core Components.
 
-### Joining Developer Discussions
+### Joining Developer Discussions 💬
 
 If you have thoughts on the code, the general architecture of the project, or would like some initial feedback on a feature you are thinking of coding, you can join the [Core Components Developer Mailing List](https://groups.google.com/forum/#!forum/aem-core-components-dev).
 
@@ -47,9 +47,9 @@ If you have thoughts on the code, the general architecture of the project, or wo
 
 ##### Filing a Bug
 
-1. Visit our issue [tracker on GitHub](https://github.com/adobe/aem-core-wcm-components/issues).
+1. Visit our [issue tracker on GitHub](https://github.com/adobe/aem-core-wcm-components/issues).
 1. File a `New Issue` as a `Bug Report`.
-1. Ensure your issue follows the `Issue Report Guidelines`.
+1. Ensure your issue follows the [Issue Report Guidelines](#issue-report-guidelines).
 1. Thanks for the report! The committers will get back to you in a timely manner, typically within one week.
 
 ### Requesting Features 🚀
@@ -62,9 +62,9 @@ If you have thoughts on the code, the general architecture of the project, or wo
 
 ##### Requesting a Feature
 
-1. Visit our issue [tracker on GitHub](https://github.com/adobe/aem-core-wcm-components/issues).
+1. Visit our [issue tracker on GitHub](https://github.com/adobe/aem-core-wcm-components/issues).
 1. File a `New Issue` as a `Feature Request`.
-1. Ensure your issue follows the `Issue Report Guidelines`.
+1. Ensure your issue follows the [Issue Report Guidelines](#issue-report-guidelines).
 1. Thanks for the feature request!  The committers will get back to you in a timely manner, typically within one week.
 
 ### Contributing Code 👾 
@@ -94,10 +94,13 @@ We very much welcome issue reports or pull requests that improve our documentati
 A well defined issue report will help in quickly understanding and replicating the problem faced, or the feature requested. Below are some rough guidelines on what to include when reporting an issue:
 
 * Title
-    * **Descriptive** - Should be easy to understand.
-    * **Succinct** - If the issue can't be easily described in the title, then the problem is likely unfocused.
-    * **Keyword Rich** - Including keywords can help with quickly finding the issue in the backlog. Component related issues can be bracketed with label, for example `[Image]`.
-* Description - See our `bug report` and `feature request` issue templates for details on what is expected to be described.
+    * **Descriptive** - Should be specific and well described.
+    * **Understandable** - Should be readable at a glance.
+    * **Succinct** - If the issue can't be easily described in a short title, then the problem is likely unfocused.
+    * **Keyword Rich** - Including keywords can help with quickly finding the issue in the backlog. Component related issues can be prefixed with a bracketed with label with the component name, for example `[Image]`.
+* Description - See our [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) or [feature request template](.github/ISSUE_TEMPLATE/feature_request.md) for details on what is expected to be described. The same information is available when creating a new issue on GitHub.
+
+See [this community reported issue](https://github.com/adobe/aem-core-wcm-components/issues/247) for an excellent example of how to write a successful issue report.
 
 ## Contributor License Agreement
 


### PR DESCRIPTION
Improve the contributing guidelines to include:

• more information on the different ways to contribute to the project
• more specific guidelines for ensuring bug reports, feature requests and contributions are successful

see: https://github.com/adobe/aem-core-wcm-components/blob/issue/contributing-guidelines/CONTRIBUTING.md

fixes #528 