### PR TITLE
[Page] Design Dialog missing for page component v1

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v1/page/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v1/page/.content.xml
@@ -4,5 +4,4 @@
     jcr:primaryType="cq:Component"
     jcr:title="Page (v1)"
     sling:resourceSuperType="wcm/foundation/components/basicpage/v1/basicpage"
-    componentGroup=".core-wcm"
-    designDialogPath="core/wcm/components/page/v1/page/cq:design_dialog"/>
+    componentGroup=".core-wcm"/>


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #428`

The designDialogPath property of the page V1 component was pointing to a non-existent design dialog location. removed it so it inherits the dialog from wcm/foundation/components/basicpage/v1/basicpage