### PR TITLE
Navigation custom templates

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImpl.java
@@ -36,6 +36,8 @@ import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.designer.Style;
 
+import static com.adobe.cq.wcm.core.components.internal.models.v1.navigation.StyleUtils.getContentPolicyStyleFromPage;
+
 @Model(adaptables = SlingHttpServletRequest.class,
        adapters = {Breadcrumb.class, ComponentExporter.class},
        resourceType = {BreadcrumbImpl.RESOURCE_TYPE_V1, BreadcrumbImpl.RESOURCE_TYPE_V2})
@@ -98,7 +100,7 @@ public class BreadcrumbImpl implements Breadcrumb {
                     break;
                 }
                 if (checkIfNotHidden(page)) {
-                    NavigationItem navigationItem = new BreadcrumbItemImpl(page, isActivePage, request, currentLevel, Collections.emptyList());
+                    NavigationItem navigationItem = new BreadcrumbItemImpl(page, isActivePage, request, currentLevel, Collections.emptyList(), getContentPolicyStyleFromPage(currentStyle, page));
                     items.add(navigationItem);
                 }
             }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImpl.java
@@ -67,7 +67,7 @@ public class BreadcrumbImpl implements Breadcrumb {
     private boolean hideCurrent;
     private int startLevel;
     private List<NavigationItem> items;
-
+    
     @PostConstruct
     private void initModel() {
         startLevel = properties.get(PN_START_LEVEL, currentStyle.get(PN_START_LEVEL, PROP_START_LEVEL_DEFAULT));
@@ -100,7 +100,7 @@ public class BreadcrumbImpl implements Breadcrumb {
                     break;
                 }
                 if (checkIfNotHidden(page)) {
-                    NavigationItem navigationItem = new BreadcrumbItemImpl(page, isActivePage, request, currentLevel, Collections.emptyList(), getContentPolicyStyleFromPage(currentStyle, page));
+                    NavigationItem navigationItem = new BreadcrumbItemImpl(page, isActivePage, request, currentLevel, Collections.emptyList(), getContentPolicyStyleFromPage(currentStyle, page), true);
                     items.add(navigationItem);
                 }
             }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbItemImpl.java
@@ -18,6 +18,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.List;
 
+import com.day.cq.wcm.api.designer.Style;
 import org.apache.sling.api.SlingHttpServletRequest;
 
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
@@ -27,8 +28,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(value = {"page", "children", "level", "description", "lastModified", "path"})
 public class BreadcrumbItemImpl extends NavigationItemImpl implements NavigationItem {
 
-    public BreadcrumbItemImpl(Page page, boolean active, SlingHttpServletRequest request, int level, List<NavigationItem> children) {
-        super(page, active, request, level, children);
+    public BreadcrumbItemImpl(Page page, boolean active, SlingHttpServletRequest request, int level, List<NavigationItem> children, Style style) {
+        super(page, active, request, level, children, style);
     }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbItemImpl.java
@@ -28,8 +28,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(value = {"page", "children", "level", "description", "lastModified", "path"})
 public class BreadcrumbItemImpl extends NavigationItemImpl implements NavigationItem {
 
-    public BreadcrumbItemImpl(Page page, boolean active, SlingHttpServletRequest request, int level, List<NavigationItem> children, Style style) {
-        super(page, active, request, level, children, style);
+    public BreadcrumbItemImpl(Page page, boolean active, SlingHttpServletRequest request, int level, List<NavigationItem> children, Style style, boolean markActiveItem) {
+        super(page, active, request, level, children, style, markActiveItem);
     }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationImpl.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 
 import org.apache.commons.lang3.StringUtils;
@@ -28,7 +30,6 @@ import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
-import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
@@ -38,6 +39,8 @@ import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageFilter;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.designer.Style;
+
+import static com.adobe.cq.wcm.core.components.internal.models.v1.navigation.StyleUtils.getContentPolicyStyleFromPage;
 
 @Model(adaptables = SlingHttpServletRequest.class,
        adapters = {LanguageNavigation.class, ComponentExporter.class},
@@ -89,7 +92,7 @@ public class LanguageNavigationImpl implements LanguageNavigation {
         return items;
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public String getExportedType() {
         return request.getResource().getResourceType();
@@ -112,7 +115,7 @@ public class LanguageNavigationImpl implements LanguageNavigation {
                 if (localizedPage != null) {
                     page = localizedPage;
                 }
-                pages.add(new LanguageNavigationItemImpl(page, active, request, level, children, title));
+                pages.add(new LanguageNavigationItemImpl(page, active, request, level, children, title, getContentPolicyStyleFromPage(currentStyle,page)));
             }
         }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationImpl.java
@@ -68,11 +68,13 @@ public class LanguageNavigationImpl implements LanguageNavigation {
     private Page rootPage;
     private List<NavigationItem> items;
     private int startLevel;
+    private boolean markActiveItem;
 
     @PostConstruct
     private void initModel() {
         navigationRoot = properties.get(PN_NAVIGATION_ROOT, currentStyle.get(PN_NAVIGATION_ROOT, String.class));
         structureDepth = properties.get(PN_STRUCTURE_DEPTH, currentStyle.get(PN_STRUCTURE_DEPTH, 1));
+        markActiveItem = properties.get(PN_MARK_ACTIVE_NAVIGATION_ITEM, currentStyle.get(PN_MARK_ACTIVE_NAVIGATION_ITEM, true));
     }
 
     @Override
@@ -115,7 +117,7 @@ public class LanguageNavigationImpl implements LanguageNavigation {
                 if (localizedPage != null) {
                     page = localizedPage;
                 }
-                pages.add(new LanguageNavigationItemImpl(page, active, request, level, children, title, getContentPolicyStyleFromPage(currentStyle,page)));
+                pages.add(new LanguageNavigationItemImpl(page, active, request, level, children, title, getContentPolicyStyleFromPage(currentStyle,page), markActiveItem));
             }
         }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationItemImpl.java
@@ -18,6 +18,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 import java.util.List;
 import java.util.Locale;
 
+import com.day.cq.wcm.api.designer.Style;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import com.adobe.cq.wcm.core.components.models.LanguageNavigationItem;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;
+
 
 public class LanguageNavigationItemImpl extends NavigationItemImpl implements LanguageNavigationItem {
 
@@ -35,8 +37,8 @@ public class LanguageNavigationItemImpl extends NavigationItemImpl implements La
     protected String country;
     protected String language;
 
-    public LanguageNavigationItemImpl(Page page, boolean active, SlingHttpServletRequest request, int level, List<NavigationItem> children, String title) {
-        super(page, active, request, level, children);
+    public LanguageNavigationItemImpl(Page page, boolean active, SlingHttpServletRequest request, int level, List<NavigationItem> children, String title, Style style) {
+        super(page, active, request, level, children, style);
         this.title = title;
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationItemImpl.java
@@ -37,8 +37,8 @@ public class LanguageNavigationItemImpl extends NavigationItemImpl implements La
     protected String country;
     protected String language;
 
-    public LanguageNavigationItemImpl(Page page, boolean active, SlingHttpServletRequest request, int level, List<NavigationItem> children, String title, Style style) {
-        super(page, active, request, level, children, style);
+    public LanguageNavigationItemImpl(Page page, boolean active, SlingHttpServletRequest request, int level, List<NavigationItem> children, String title, Style style, boolean markActiveItem) {
+        super(page, active, request, level, children, style, markActiveItem);
         this.title = title;
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
@@ -86,6 +86,7 @@ public class NavigationImpl implements Navigation {
     private String navigationRootPage;
     private List<NavigationItem> items;
     private boolean skipNavigationRoot;
+    private boolean markActiveItem;
 
     @PostConstruct
     private void initModel() {
@@ -96,6 +97,7 @@ public class NavigationImpl implements Navigation {
         }
         navigationRootPage = properties.get(PN_NAVIGATION_ROOT, currentStyle.get(PN_NAVIGATION_ROOT, String.class));
         skipNavigationRoot = properties.get(PN_SKIP_NAVIGATION_ROOT, currentStyle.get(PN_SKIP_NAVIGATION_ROOT, true));
+        markActiveItem = properties.get(PN_MARK_ACTIVE_NAVIGATION_ITEM, currentStyle.get(PN_MARK_ACTIVE_NAVIGATION_ITEM, true));
     }
 
     @Override
@@ -136,7 +138,7 @@ public class NavigationImpl implements Navigation {
                 items = getItems(navigationRoot, navigationRoot.page);
                 if (!skipNavigationRoot) {
                     boolean isSelected = checkSelected(navigationRoot.page);
-                    NavigationItemImpl root = new NavigationItemImpl(navigationRoot.page, isSelected, request, 0, items, getContentPolicyStyleFromPage(currentStyle, navigationRoot.page));
+                    NavigationItemImpl root = new NavigationItemImpl(navigationRoot.page, isSelected, request, 0, items, getContentPolicyStyleFromPage(currentStyle, navigationRoot.page), markActiveItem);
                     items = new ArrayList<>();
                     items.add(root);
                 }
@@ -179,7 +181,7 @@ public class NavigationImpl implements Navigation {
                 if (skipNavigationRoot) {
                     level = level - 1;
                 }
-                pages.add(new NavigationItemImpl(page, isSelected, request, level, children, getContentPolicyStyleFromPage(currentStyle, page)));
+                pages.add(new NavigationItemImpl(page, isSelected, request, level, children, getContentPolicyStyleFromPage(currentStyle, page), markActiveItem));
             }
         }
         return pages;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
@@ -51,6 +51,8 @@ import com.day.cq.wcm.api.designer.Style;
 import com.day.cq.wcm.msm.api.LiveRelationship;
 import com.day.cq.wcm.msm.api.LiveRelationshipManager;
 
+import static com.adobe.cq.wcm.core.components.internal.models.v1.navigation.StyleUtils.getContentPolicyStyleFromPage;
+
 @Model(adaptables = SlingHttpServletRequest.class,
        adapters = {Navigation.class, ComponentExporter.class},
        resourceType = {NavigationImpl.RESOURCE_TYPE})
@@ -134,7 +136,7 @@ public class NavigationImpl implements Navigation {
                 items = getItems(navigationRoot, navigationRoot.page);
                 if (!skipNavigationRoot) {
                     boolean isSelected = checkSelected(navigationRoot.page);
-                    NavigationItemImpl root = new NavigationItemImpl(navigationRoot.page, isSelected, request, 0, items);
+                    NavigationItemImpl root = new NavigationItemImpl(navigationRoot.page, isSelected, request, 0, items, getContentPolicyStyleFromPage(currentStyle, navigationRoot.page));
                     items = new ArrayList<>();
                     items.add(root);
                 }
@@ -150,7 +152,13 @@ public class NavigationImpl implements Navigation {
     public String getExportedType() {
         return request.getResource().getResourceType();
     }
-
+    
+    
+    @Override
+    public String getGroupTemplatePath() {
+        return currentStyle.get(PN_CUSTOM_GROUP_TEMPLATE_PATH, DEFAULT_GROUP_TEMPLATE_PATH);
+    }
+    
     /**
      * Builds the navigation tree for a {@code navigationRoot} page.
      *
@@ -171,7 +179,7 @@ public class NavigationImpl implements Navigation {
                 if (skipNavigationRoot) {
                     level = level - 1;
                 }
-                pages.add(new NavigationItemImpl(page, isSelected, request, level, children));
+                pages.add(new NavigationItemImpl(page, isSelected, request, level, children, getContentPolicyStyleFromPage(currentStyle, page)));
             }
         }
         return pages;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationItemImpl.java
@@ -26,18 +26,19 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class NavigationItemImpl extends PageListItemImpl implements NavigationItem {
     
-    
     protected final List<NavigationItem> children;
     protected final int level;
     protected final boolean active;
     protected final Style style;
+    protected final boolean markActiveItem;
     
-    public NavigationItemImpl(Page page, boolean active, SlingHttpServletRequest request, int level, List<NavigationItem> children, Style style) {
+    public NavigationItemImpl(Page page, boolean active, SlingHttpServletRequest request, int level, List<NavigationItem> children, Style style, boolean markActiveItem) {
         super(request, page);
         this.active = active;
         this.level = level;
         this.children = children;
         this.style = style;
+        this.markActiveItem = markActiveItem;
     }
 
     @Override
@@ -48,7 +49,7 @@ public class NavigationItemImpl extends PageListItemImpl implements NavigationIt
 
     @Override
     public boolean isActive() {
-        return active;
+        return markActiveItem && active;
     }
 
     @Override
@@ -74,5 +75,20 @@ public class NavigationItemImpl extends PageListItemImpl implements NavigationIt
     @Override
     public String getItemContentTemplatePath() {
         return style.get(PN_CUSTOM_ITEM_CONTENT_TEMPLATE_PATH, DEFAULT_ITEM_CONTENT_TEMPLATE_PATH);
+    }
+    
+    @Override
+    public String getSecondaryGroupTemplatePath() {
+        return style.get(PN_CUSTOM_SECONDARY_GROUP_TEMPLATE_PATH, DEFAULT_SECONDARY_GROUP_TEMPLATE_PATH);
+    }
+    
+    @Override
+    public String getSecondaryItemTemplatePath() {
+        return style.get(PN_CUSTOM_SECONDARY_ITEM_TEMPLATE_PATH, DEFAULT_SECONDARY_ITEM_TEMPLATE_PATH);
+    }
+    
+    @Override
+    public String getSecondaryItemContentTemplatePath() {
+        return style.get(PN_CUSTOM_SECONDARY_ITEM_CONTENT_TEMPLATE_PATH, DEFAULT_SECONDARY_ITEM_CONTENT_TEMPLATE_PATH);
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationItemImpl.java
@@ -15,9 +15,9 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
-import java.util.Collections;
 import java.util.List;
 
+import com.day.cq.wcm.api.designer.Style;
 import org.apache.sling.api.SlingHttpServletRequest;
 
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
@@ -25,16 +25,19 @@ import com.day.cq.wcm.api.Page;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class NavigationItemImpl extends PageListItemImpl implements NavigationItem {
-
-    protected List<NavigationItem> children = Collections.emptyList();
-    protected int level;
-    protected boolean active;
-
-    public NavigationItemImpl(Page page, boolean active, SlingHttpServletRequest request, int level, List<NavigationItem> children) {
+    
+    
+    protected final List<NavigationItem> children;
+    protected final int level;
+    protected final boolean active;
+    protected final Style style;
+    
+    public NavigationItemImpl(Page page, boolean active, SlingHttpServletRequest request, int level, List<NavigationItem> children, Style style) {
         super(request, page);
         this.active = active;
         this.level = level;
         this.children = children;
+        this.style = style;
     }
 
     @Override
@@ -57,5 +60,19 @@ public class NavigationItemImpl extends PageListItemImpl implements NavigationIt
     public int getLevel() {
         return level;
     }
-
+    
+    @Override
+    public String getGroupTemplatePath() {
+        return style.get(PN_CUSTOM_GROUP_TEMPLATE_PATH, DEFAULT_GROUP_TEMPLATE_PATH);
+    }
+    
+    @Override
+    public String getItemTemplatePath() {
+        return style.get(PN_CUSTOM_ITEM_TEMPLATE_PATH, DEFAULT_ITEM_TEMPLATE_PATH);
+    }
+    
+    @Override
+    public String getItemContentTemplatePath() {
+        return style.get(PN_CUSTOM_ITEM_CONTENT_TEMPLATE_PATH, DEFAULT_ITEM_CONTENT_TEMPLATE_PATH);
+    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/navigation/StyleUtils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/navigation/StyleUtils.java
@@ -1,0 +1,67 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2017 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1.navigation;
+
+
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.designer.Cell;
+import com.day.cq.wcm.api.designer.Designer;
+import com.day.cq.wcm.api.designer.Style;
+import com.day.cq.wcm.api.policies.ContentPolicy;
+import com.day.cq.wcm.api.policies.ContentPolicyManager;
+import com.day.cq.wcm.commons.policy.ContentPolicyStyle;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Utility class for styles
+ */
+public class StyleUtils {
+    
+    /**
+     * Gets the content policy wrapped in a style for a specified page
+     * @param currentStyle fallback style in case of nothing found or lacking of rights
+     * @param page specified page
+     * @return found content policy or provided currentStyle as fallback.
+     */
+    public static Style getContentPolicyStyleFromPage(Style currentStyle, Page page){
+    
+        final Resource contentResource = page.getContentResource();
+        final ResourceResolver resourceResolver = contentResource.getResourceResolver();
+        @Nullable final Designer designer = resourceResolver.adaptTo(Designer.class);
+        @Nullable final ContentPolicyManager contentPolicyManager = resourceResolver.adaptTo(ContentPolicyManager.class);
+        
+        if(designer == null || contentPolicyManager == null){
+            return currentStyle;
+        }
+        
+        ContentPolicy policy = contentPolicyManager.getPolicy(contentResource);
+        
+        if(policy == null){
+            return currentStyle;
+        }
+        
+        @Nonnull final Cell cell = designer.getStyle(contentResource).getCell();
+        return new ContentPolicyStyle(policy, cell);
+        
+    }
+    
+    
+    
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Breadcrumb.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Breadcrumb.java
@@ -30,6 +30,7 @@ import com.adobe.cq.export.json.ComponentExporter;
 @ConsumerType
 public interface Breadcrumb extends ComponentExporter {
 
+    
     /**
      * Name of the resource property that will indicate if pages that are hidden for navigation will still be displayed.
      *

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/LanguageNavigation.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/LanguageNavigation.java
@@ -27,7 +27,13 @@ import com.adobe.cq.export.json.ComponentExporter;
  * @since com.adobe.cq.wcm.core.components.models 12.2.0
  */
 public interface LanguageNavigation extends ComponentExporter {
-
+    
+    /**
+     * Name of the resource / configuration policy property that defines if an active navigation item should get the CSS class 'cmp-navigation__item--active'
+     * The property should provide a Boolean value.
+     */
+    String PN_MARK_ACTIVE_NAVIGATION_ITEM = "markActiveNavigationItem";
+    
     /**
      * Name of the resource / configuration policy property that defines the navigation root from which to build the global
      * language structure navigation. The property should provide a String value.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Navigation.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Navigation.java
@@ -27,7 +27,12 @@ import com.adobe.cq.export.json.ComponentExporter;
  * @since com.adobe.cq.wcm.core.components.models 12.2.0
  */
 public interface Navigation extends ComponentExporter {
-
+    
+    /**
+     * Name of the resource / configuration policy property that defines if an active navigation item should get the CSS class 'cmp-navigation__item--active'
+     * The property should provide a Boolean value.
+     */
+    String PN_MARK_ACTIVE_NAVIGATION_ITEM = "markActiveNavigationItem";
     /**
      * Name of the resource / configuration policy property that defines the site's navigation root for which to build the navigation tree.
      * The property should provide a String value.
@@ -68,6 +73,8 @@ public interface Navigation extends ComponentExporter {
      * Default template path that will render the group's of navigation items.
      */
     String DEFAULT_GROUP_TEMPLATE_PATH = "group.html";
+    
+    String SECONDARY_GROUP_TEMPLATE_PATH = "secondary/group.html";
 
     /**
      * Returns the list of navigation items.
@@ -83,6 +90,9 @@ public interface Navigation extends ComponentExporter {
         return DEFAULT_GROUP_TEMPLATE_PATH;
     }
     
+    default String getSecondaryGroupTemplatePath(){
+        return SECONDARY_GROUP_TEMPLATE_PATH;
+    }
     /**
      * @see ComponentExporter#getExportedType()
      * @since com.adobe.cq.wcm.core.components.models 12.2.0

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Navigation.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Navigation.java
@@ -61,6 +61,13 @@ public interface Navigation extends ComponentExporter {
      * @since com.adobe.cq.wcm.core.components.models 12.2.0
      */
     String PN_STRUCTURE_DEPTH = "structureDepth";
+    
+    String PN_CUSTOM_GROUP_TEMPLATE_PATH = "navigationCustomGroupTemplatePath";
+    
+    /**
+     * Default template path that will render the group's of navigation items.
+     */
+    String DEFAULT_GROUP_TEMPLATE_PATH = "group.html";
 
     /**
      * Returns the list of navigation items.
@@ -72,6 +79,10 @@ public interface Navigation extends ComponentExporter {
         throw new UnsupportedOperationException();
     }
 
+    default String getGroupTemplatePath(){
+        return DEFAULT_GROUP_TEMPLATE_PATH;
+    }
+    
     /**
      * @see ComponentExporter#getExportedType()
      * @since com.adobe.cq.wcm.core.components.models 12.2.0

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/NavigationItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/NavigationItem.java
@@ -52,6 +52,39 @@ public interface NavigationItem extends ListItem {
      */
     String DEFAULT_GROUP_TEMPLATE_PATH = "group.html";
     
+    /**
+     * Default template path that will render the group's of navigation items.
+     * This is applicable for the secondary / alternative rendition of the navigation, useful for flyouts / complex menu structures.
+     */
+    String PN_CUSTOM_SECONDARY_GROUP_TEMPLATE_PATH = "secondary/group.html";
+    
+    /**
+     * Default template path that will render the item's of navigation items.
+     * This is applicable for the secondary / alternative rendition of the navigation, useful for flyouts / complex menu structures.
+     */
+    String PN_CUSTOM_SECONDARY_ITEM_TEMPLATE_PATH = "secondary/item.html";
+    
+    /**
+     * Default template path that will render the item content of navigation items.
+     * This is applicable for the secondary / alternative rendition of the navigation, useful for flyouts / complex menu structures.
+     */
+    String  PN_CUSTOM_SECONDARY_ITEM_CONTENT_TEMPLATE_PATH = "secondary/itemContent.html";
+    
+    /**
+     * Default template path that will render the item content of navigation items.
+     */
+    String DEFAULT_SECONDARY_ITEM_CONTENT_TEMPLATE_PATH = "secondary/itemContent.html";
+    
+    /**
+     * Default template path that will render the item's of navigation items.
+     */
+    String DEFAULT_SECONDARY_ITEM_TEMPLATE_PATH = "secondary/item.html";
+    
+    /**
+     * Default template path that will render the group's of navigation items.
+     */
+    String DEFAULT_SECONDARY_GROUP_TEMPLATE_PATH = "secondary/group.html";
+    
     
     /**
      * Returns the {@link Page} contained by this navigation item.
@@ -132,5 +165,21 @@ public interface NavigationItem extends ListItem {
      */
     default String getItemContentTemplatePath() { return DEFAULT_ITEM_CONTENT_TEMPLATE_PATH; }
     
+    /**
+     * Returns whether or not a custom template to render this navigation items' group (children) should be used
+     * @return
+     */
+    default String getSecondaryGroupTemplatePath() { return DEFAULT_SECONDARY_GROUP_TEMPLATE_PATH; }
     
+    /**
+     * Returns whether or not a custom template to render this navigation item should be used
+     * @return
+     */
+    default String getSecondaryItemTemplatePath() { return DEFAULT_SECONDARY_ITEM_TEMPLATE_PATH; }
+    
+    /**
+     * Returns whether or not a custom template to render this navigation item content should be used
+     * @return
+     */
+    default String getSecondaryItemContentTemplatePath() { return DEFAULT_SECONDARY_ITEM_CONTENT_TEMPLATE_PATH; }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/NavigationItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/NavigationItem.java
@@ -29,7 +29,30 @@ import com.day.cq.wcm.api.Page;
  */
 @ConsumerType
 public interface NavigationItem extends ListItem {
-
+    
+    String PN_CUSTOM_GROUP_TEMPLATE_PATH = "navigationCustomGroupTemplatePath";
+    
+    String PN_CUSTOM_ITEM_TEMPLATE_PATH = "navigationCustomItemTemplatePath";
+    
+    String PN_CUSTOM_ITEM_CONTENT_TEMPLATE_PATH = "navigationCustomItemContentTemplatePath";
+    
+    
+    /**
+     * Default template path that will render the item content of navigation items.
+     */
+    String DEFAULT_ITEM_CONTENT_TEMPLATE_PATH = "itemContent.html";
+    
+    /**
+     * Default template path that will render the item's of navigation items.
+     */
+    String DEFAULT_ITEM_TEMPLATE_PATH = "item.html";
+    
+    /**
+     * Default template path that will render the group's of navigation items.
+     */
+    String DEFAULT_GROUP_TEMPLATE_PATH = "group.html";
+    
+    
     /**
      * Returns the {@link Page} contained by this navigation item.
      *
@@ -72,5 +95,42 @@ public interface NavigationItem extends ListItem {
     default int getLevel() {
         throw new UnsupportedOperationException();
     }
-
+    
+    /**
+     * Returns whether or not a custom template to render this navigation items' group (children) should be used
+     * @return
+     */
+    default boolean isCustomGroupTemplateActive() { return false; }
+    
+    /**
+     * Returns whether or not a custom template to render this navigation item should be used
+     * @return
+     */
+    default boolean isCustomItemTemplateActive() { return false; }
+    
+    /**
+     * Returns whether or not a custom template to render this navigation item content should be used
+     * @return
+     */
+    default boolean isCustomItemContentTemplateActive() { return false; }
+    
+    /**
+     * Returns whether or not a custom template to render this navigation items' group (children) should be used
+     * @return
+     */
+    default String getGroupTemplatePath() { return DEFAULT_GROUP_TEMPLATE_PATH; }
+    
+    /**
+     * Returns whether or not a custom template to render this navigation item should be used
+     * @return
+     */
+    default String getItemTemplatePath() { return DEFAULT_ITEM_TEMPLATE_PATH; }
+    
+    /**
+     * Returns whether or not a custom template to render this navigation item content should be used
+     * @return
+     */
+    default String getItemContentTemplatePath() { return DEFAULT_ITEM_CONTENT_TEMPLATE_PATH; }
+    
+    
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.7.1")
+@Version("12.8.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/group.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/group.html
@@ -13,8 +13,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<template data-sly-template.group="${@ items='The navigation items for the current level'}" data-sly-use.itemTemplate="item.html">
+<template data-sly-template.group="${@ items='The navigation items for the current level'}">
     <ul class="cmp-navigation__group" data-sly-list="${items}">
-        <sly data-sly-call="${itemTemplate.item @ item=item}"></sly>
+        <sly data-sly-use.itemTemplate="${item.itemTemplatePath}" data-sly-call="${itemTemplate.item @ item=item}"></sly>
     </ul>
 </template>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/item.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/item.html
@@ -15,10 +15,10 @@
   ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <template data-sly-template.item="${@ item='The navigation item'}"
-          data-sly-use.groupTemplate="group.html"
-          data-sly-use.itemContentTemplate="itemContent.html">
-    <li class="cmp-navigation__item cmp-navigation__item--level-${item.level}${item.active ? ' cmp-navigation__item--active' : ''}">
-        <sly data-sly-call="${itemContentTemplate.itemContent @ item = item}"></sly>
-        <sly data-sly-test="${item.children.size > 0}" data-sly-call="${groupTemplate.group @ items = item.children}"></sly>
-    </li>
+          data-sly-use.groupTemplate="${item.groupTemplatePath}"
+          data-sly-use.itemContentTemplate="${item.itemContentTemplatePath}">
+        <li class="cmp-navigation__item cmp-navigation__item--level-${item.level}${item.active ? ' cmp-navigation__item--active' : ''}">
+            <sly data-sly-call="${itemContentTemplate.itemContent @ item = item}"></sly>
+            <sly data-sly-test="${item.children.size > 0}" data-sly-call="${groupTemplate.group @ items = item.children}"></sly>
+        </li>
 </template>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/navigation.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/navigation.html
@@ -18,7 +18,7 @@
      data-sly-use.template="core/wcm/components/commons/v1/templates.html"
      data-sly-use.navigation="com.adobe.cq.wcm.core.components.models.Navigation"
      data-sly-test.hasContent="${navigation.items.size > 0}"
-     data-sly-use.groupTemplate="group.html"
+     data-sly-use.groupTemplate="${navigation.groupTemplatePath}"
      data-sly-call="${groupTemplate.group @ items=navigation.items}">
 </nav>
 <sly data-sly-call="${template.placeholder @ isEmpty=!hasContent, classAppend='cmp-navigation'}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/secondary.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/secondary.html
@@ -1,0 +1,24 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2017 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<div class="cmp-navigation cmp-navigation--secondary"
+     itemscope itemtype="http://schema.org/SiteNavigationElement"
+     data-sly-use.template="core/wcm/components/commons/v1/templates.html"
+     data-sly-use.navigation="com.adobe.cq.wcm.core.components.models.Navigation"
+     data-sly-test.hasContent="${navigation.items.size > 0}"
+     data-sly-use.groupTemplate="${navigation.secondaryGroupTemplatePath}"
+     data-sly-call="${groupTemplate.group @ items=navigation.items}">
+</div>
+<sly data-sly-call="${template.placeholder @ isEmpty=!hasContent, classAppend='cmp-navigation'}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/secondary/group.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/secondary/group.html
@@ -1,0 +1,20 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2017 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<template data-sly-template.group="${@ items='The navigation items for the current level'}">
+    <div class="cmp-navigation__group" data-sly-list="${items}">
+        <sly data-sly-use.itemTemplate="${item.secondaryItemTemplatePath}" data-sly-call="${itemTemplate.item @ item=item}"></sly>
+    </div>
+</template>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/secondary/item.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/secondary/item.html
@@ -15,10 +15,10 @@
   ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <template data-sly-template.item="${@ item='The navigation item'}"
-          data-sly-use.groupTemplate="${item.groupTemplatePath}"
-          data-sly-use.itemContentTemplate="${item.itemContentTemplatePath}">
-        <li data-item-target="${item.URL}" data-item-path="${item.path}" class="cmp-navigation__item cmp-navigation__item--level-${item.level}${item.active ? ' cmp-navigation__item--active' : ''}">
+          data-sly-use.groupTemplate="${item.secondaryGroupTemplatePath}"
+          data-sly-use.itemContentTemplate="${item.secondaryItemContentTemplatePath}">
+        <div data-item-target="${item.URL}" data-item-path="${item.path}" class="cmp-navigation__item cmp-navigation__item--level-${item.level}${item.active ? ' cmp-navigation__item--active' : ''}">
             <sly data-sly-call="${itemContentTemplate.itemContent @ item = item}"></sly>
             <sly data-sly-test="${item.children.size > 0}" data-sly-call="${groupTemplate.group @ items = item.children}"></sly>
-        </li>
+        </div>
 </template>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/secondary/itemContent.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/secondary/itemContent.html
@@ -14,11 +14,7 @@
   ~ limitations under the License.
   ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<template data-sly-template.item="${@ item='The navigation item'}"
-          data-sly-use.groupTemplate="${item.groupTemplatePath}"
-          data-sly-use.itemContentTemplate="${item.itemContentTemplatePath}">
-        <li data-item-target="${item.URL}" data-item-path="${item.path}" class="cmp-navigation__item cmp-navigation__item--level-${item.level}${item.active ? ' cmp-navigation__item--active' : ''}">
-            <sly data-sly-call="${itemContentTemplate.itemContent @ item = item}"></sly>
-            <sly data-sly-test="${item.children.size > 0}" data-sly-call="${groupTemplate.group @ items = item.children}"></sly>
-        </li>
+<template data-sly-template.itemContent="${@ item='The navigation item'}">
+    <a href="${item.URL}" title="${item.title}"
+       class="cmp-navigation__item-link">${item.title}</a>
 </template>


### PR DESCRIPTION
Preliminary PR to see if it's something the community will receive.

Backwards compatible adjustments to navigation component, that makes the component greatly more flexible.
-Adds possibility to choose a custom template per page on a content policy or property level to override the item, itemContent and group templates.
-Adds a secondary tree if called with secondary selector - this is good to render complex flyouts etc where 2 trees are required. 
-Adds possibility to turn off marking an item active server side, you don't want this when caching the menu in HTTP cache. Adds data attributes instead so javascript can do this.

With these adjustments I can make a great showcase example for many clients. WDYT?