### PR TITLE
[ExperienceFragment] Create a Experience fragment component

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -1,0 +1,130 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.models.annotations.Exporter;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.export.json.ComponentExporter;
+import com.adobe.cq.export.json.ExporterConstants;
+import com.adobe.cq.wcm.core.components.models.ExperienceFragment;
+import com.day.cq.commons.LanguageUtil;
+import com.day.cq.wcm.api.LanguageManager;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+
+@Model(adaptables = SlingHttpServletRequest.class, adapters = {
+    ExperienceFragment.class, ComponentExporter.class }, resourceType = {
+        ExperienceFragmentImpl.RESOURCE_TYPE_V1 })
+@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+public class ExperienceFragmentImpl implements ExperienceFragment {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+        ExperienceFragmentImpl.class);
+
+    public static final String RESOURCE_TYPE_V1 = "core/wcm/components/experiencefragment/v1/experiencefragment";
+
+    public static final String PATH_DELIMITER = "/";
+
+    @Self
+    private SlingHttpServletRequest request;
+
+    @OSGiService
+    private LanguageManager languageManager;
+
+    @ScriptVariable
+    private Page currentPage;
+
+    @ScriptVariable
+    private ValueMap properties;
+
+    private String fragmentPath;
+
+    @PostConstruct
+    private void initModel() {
+        fragmentPath = properties.get(PN_FRAGMENT_PATH, String.class);
+    }
+
+    @Override
+    public String getExperienceFragmentVariationPath() {
+        String experFragmentVariationPath = null;
+        PageManager pageManager = currentPage.getPageManager();
+        Page xfpage = pageManager.getPage(fragmentPath);
+        if (xfpage != null) {
+            Page localizedXfPage = getLocalizedXfPage(currentPage, xfpage);
+            if (localizedXfPage != null) {
+                experFragmentVariationPath = localizedXfPage.getContentResource().getPath();
+            } else {
+                experFragmentVariationPath = xfpage.getContentResource().getPath();
+            }
+        } else {
+            LOGGER.debug("Experience Fragment variation not found at path:{}",
+                fragmentPath);
+        }
+        return experFragmentVariationPath;
+    }
+
+    @NotNull
+    @Override
+    public String getExportedType() {
+        return request.getResource().getResourceType();
+    }
+
+    private Page getLocalizedXfPage(Page currentPage, Page xfPage) {
+        Page localizedXfPage = null;
+
+        String xfPageLanguageRootPath = LanguageUtil.getLanguageRoot(
+            xfPage.getPath());
+        Page currentPageLanguageRoot = languageManager.getLanguageRoot(
+            currentPage.getContentResource());
+
+        if (xfPageLanguageRootPath != null && currentPageLanguageRoot != null) {
+
+            String xfPageLanguageRootName = xfPageLanguageRootPath.substring(
+                xfPageLanguageRootPath.lastIndexOf('/') + 1);
+            String currentPageLanguageRootName = currentPageLanguageRoot.getName();
+
+            PageManager pageManager = currentPage.getPageManager();
+
+            if (currentPageLanguageRootName.equals(xfPageLanguageRootName)) {
+                localizedXfPage = xfPage;
+            } else {
+                String expFragmentVariationPath = xfPage.getPath().substring(
+                    xfPageLanguageRootPath.length());
+                // Replace language root in the variation path
+                String languageVariationPath = xfPageLanguageRootPath.replaceAll(
+                    PATH_DELIMITER + xfPageLanguageRootName + "$",
+                    PATH_DELIMITER + currentPageLanguageRootName);
+                Page localizedXfVariationPage = pageManager.getPage(
+                    languageVariationPath + expFragmentVariationPath);
+                if (localizedXfVariationPage != null) {
+                    localizedXfPage = localizedXfVariationPage;
+                }
+            }
+        }
+        return localizedXfPage;
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -87,6 +87,11 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
         return experFragmentVariationPath;
     }
 
+    @Override
+    public String getConfiguredExperienceFragmentPath() {
+        return fragmentPath;
+    }
+
     @NotNull
     @Override
     public String getExportedType() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ExperienceFragment.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ExperienceFragment.java
@@ -1,0 +1,59 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.models;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.adobe.cq.export.json.ComponentExporter;
+
+/**
+ * Defines the {@code ExperienceFragment} Sling Model used for the
+ * {@code /apps/core/wcm/components/experiencefragment} component.
+ *
+ * @since com.adobe.cq.wcm.core.components.models 12.8.0
+ */
+public interface ExperienceFragment extends ComponentExporter {
+
+    /**
+     * Name of the resource / configuration policy property that specifies the
+     * experience fragment path variation. The property should provide a String
+     * value.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
+     */
+    String PN_FRAGMENT_PATH = "fragmentPath";
+
+    /**
+     * Returns the configured experience fragment path variation.
+     *
+     * @return experience fragment variation path
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
+     */
+    default String getExperienceFragmentVariationPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @see ComponentExporter#getExportedType()
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
+     */
+    @NotNull
+    @Override
+    default String getExportedType() {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ExperienceFragment.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ExperienceFragment.java
@@ -37,12 +37,22 @@ public interface ExperienceFragment extends ComponentExporter {
     String PN_FRAGMENT_PATH = "fragmentPath";
 
     /**
-     * Returns the configured experience fragment path variation.
+     * Returns the evaluated localized experience fragment path variation.
      *
-     * @return experience fragment variation path
+     * @return Localized experience fragment variation path
      * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default String getExperienceFragmentVariationPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the configured experience fragment path variation.
+     *
+     * @return Configured experience fragment variation path
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
+     */
+    default String getConfiguredExperienceFragmentPath() {
         throw new UnsupportedOperationException();
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.7.1")
+@Version("12.8.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImplTest.java
@@ -1,0 +1,149 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.adobe.cq.sightly.WCMBindings;
+import com.adobe.cq.wcm.core.components.Utils;
+import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
+import com.adobe.cq.wcm.core.components.models.ExperienceFragment;
+import com.adobe.cq.wcm.core.components.testing.MockLanguageManager;
+import com.day.cq.wcm.api.LanguageManager;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.WCMException;
+
+import io.wcm.testing.mock.aem.junit.AemContext;
+
+public class ExperienceFragmentImplTest {
+
+    private static final String TEST_BASE = "/experiencefragment";
+
+    @ClassRule
+    public static final AemContext AEM_CONTEXT = CoreComponentTestContext.createContext(
+        TEST_BASE, "/content");
+
+    private static final String CONTEXT_PATH = "/core";
+
+    private static final String EXPERIENCE_FRAGMENT_ROOT = "/content/experiencefragment";
+
+    @BeforeClass
+    public static void init() throws WCMException {
+        AEM_CONTEXT.registerService(LanguageManager.class,
+            new MockLanguageManager());
+    }
+
+    @Test
+    public void testInvalidXfVariationPath() {
+        ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
+            EXPERIENCE_FRAGMENT_ROOT
+                + "/en/page/jcr:content/root/expfragment-component-1");
+        String expFragmentPath = experienceFragment.getExperienceFragmentVariationPath();
+        assertEquals(null, expFragmentPath);
+
+        Utils.testJSONExport(experienceFragment,
+            Utils.getTestExporterJSONPath(TEST_BASE, "experiencefragment1"));
+
+    }
+
+    @Test
+    public void testValidXfVariationPath() {
+        ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
+            EXPERIENCE_FRAGMENT_ROOT
+                + "/en/page/jcr:content/root/expfragment-component-2");
+        String expFragmentPath = experienceFragment.getExperienceFragmentVariationPath();
+        assertEquals(
+            "/content/experience-fragments/language-masters/en/footer/master/jcr:content",
+            expFragmentPath);
+
+        Utils.testJSONExport(experienceFragment,
+            Utils.getTestExporterJSONPath(TEST_BASE, "experiencefragment2"));
+
+    }
+
+    @Test
+    public void testValidLanguageXfVariationPath() {
+        ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
+            EXPERIENCE_FRAGMENT_ROOT
+                + "/es/page/jcr:content/root/expfragment-component-1");
+        String expFragmentPath = experienceFragment.getExperienceFragmentVariationPath();
+        assertEquals(
+            "/content/experience-fragments/language-masters/es/footer/master/jcr:content",
+            expFragmentPath);
+
+        Utils.testJSONExport(experienceFragment,
+            Utils.getTestExporterJSONPath(TEST_BASE, "experiencefragment3"));
+
+    }
+
+    @Test
+    public void testInvalidLanguageXfVariationPath() {
+        ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
+            EXPERIENCE_FRAGMENT_ROOT
+                + "/es/page/jcr:content/root/expfragment-component-2");
+        String expFragmentPath = experienceFragment.getExperienceFragmentVariationPath();
+        assertEquals("/content/experience-fragments/language-masters/en/footer/variation/jcr:content", expFragmentPath);
+
+        Utils.testJSONExport(experienceFragment,
+            Utils.getTestExporterJSONPath(TEST_BASE, "experiencefragment4"));
+
+    }
+
+    @Test
+    public void testXfVariationPathWhenPageStructureFollowsLocale() {
+        ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
+            EXPERIENCE_FRAGMENT_ROOT
+                + "/it-it/page/jcr:content/root/expfragment-component-1");
+        String expFragmentPath = experienceFragment.getExperienceFragmentVariationPath();
+        assertEquals(
+            "/content/experience-fragments/it-it/footer/master/jcr:content",
+            expFragmentPath);
+
+        Utils.testJSONExport(experienceFragment,
+            Utils.getTestExporterJSONPath(TEST_BASE, "experiencefragment5"));
+
+    }
+
+    private ExperienceFragment getExperienceFragmentUnderTest(
+            String resourcePath) {
+        Resource resource = AEM_CONTEXT.resourceResolver().getResource(
+            resourcePath);
+        if (resource == null) {
+            throw new IllegalStateException(
+                "Does the test resource " + resourcePath + " exist?");
+        }
+        final MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(
+            AEM_CONTEXT.resourceResolver(), AEM_CONTEXT.bundleContext());
+        request.setContextPath(CONTEXT_PATH);
+        request.setResource(resource);
+        Page currentPage = AEM_CONTEXT.pageManager().getContainingPage(
+            resource);
+        SlingBindings slingBindings = new SlingBindings();
+        slingBindings.put(SlingBindings.RESOURCE, resource);
+        slingBindings.put(WCMBindings.CURRENT_PAGE, currentPage);
+        slingBindings.put(WCMBindings.PROPERTIES, resource.getValueMap());
+        request.setAttribute(SlingBindings.class.getName(), slingBindings);
+        return request.adaptTo(ExperienceFragment.class);
+    }
+
+}

--- a/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment1.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment1.json
@@ -1,0 +1,3 @@
+{
+   ":type": "core/wcm/components/experiencefragment/v1/experiencefragment"
+}

--- a/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment1.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment1.json
@@ -1,3 +1,4 @@
 {
+   "configuredExperienceFragmentPath":"/content/experience-fragments/language-masters/en/invalid-path",
    ":type": "core/wcm/components/experiencefragment/v1/experiencefragment"
 }

--- a/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment2.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment2.json
@@ -1,4 +1,5 @@
 {
    "experienceFragmentVariationPath":"/content/experience-fragments/language-masters/en/footer/master/jcr:content",
+   "configuredExperienceFragmentPath":"/content/experience-fragments/language-masters/en/footer/master",
    ":type": "core/wcm/components/experiencefragment/v1/experiencefragment"
 }

--- a/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment2.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment2.json
@@ -1,0 +1,4 @@
+{
+   "experienceFragmentVariationPath":"/content/experience-fragments/language-masters/en/footer/master/jcr:content",
+   ":type": "core/wcm/components/experiencefragment/v1/experiencefragment"
+}

--- a/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment3.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment3.json
@@ -1,0 +1,4 @@
+{
+   "experienceFragmentVariationPath":"/content/experience-fragments/language-masters/es/footer/master/jcr:content",
+   ":type": "core/wcm/components/experiencefragment/v1/experiencefragment"
+}

--- a/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment3.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment3.json
@@ -1,4 +1,5 @@
 {
    "experienceFragmentVariationPath":"/content/experience-fragments/language-masters/es/footer/master/jcr:content",
+   "configuredExperienceFragmentPath":"/content/experience-fragments/language-masters/en/footer/master",
    ":type": "core/wcm/components/experiencefragment/v1/experiencefragment"
 }

--- a/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment4.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment4.json
@@ -1,0 +1,4 @@
+{
+   "experienceFragmentVariationPath":"/content/experience-fragments/language-masters/en/footer/variation/jcr:content",
+   ":type": "core/wcm/components/experiencefragment/v1/experiencefragment"
+}

--- a/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment4.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment4.json
@@ -1,4 +1,5 @@
 {
    "experienceFragmentVariationPath":"/content/experience-fragments/language-masters/en/footer/variation/jcr:content",
+   "configuredExperienceFragmentPath":"/content/experience-fragments/language-masters/en/footer/variation",
    ":type": "core/wcm/components/experiencefragment/v1/experiencefragment"
 }

--- a/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment5.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment5.json
@@ -1,0 +1,4 @@
+{
+   "experienceFragmentVariationPath":"/content/experience-fragments/it-it/footer/master/jcr:content",
+   ":type": "core/wcm/components/experiencefragment/v1/experiencefragment"
+}

--- a/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment5.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-experiencefragment5.json
@@ -1,4 +1,5 @@
 {
    "experienceFragmentVariationPath":"/content/experience-fragments/it-it/footer/master/jcr:content",
+   "configuredExperienceFragmentPath":"/content/experience-fragments/it-it/footer/master",
    ":type": "core/wcm/components/experiencefragment/v1/experiencefragment"
 }

--- a/bundles/core/src/test/resources/experiencefragment/test-content.json
+++ b/bundles/core/src/test/resources/experiencefragment/test-content.json
@@ -1,0 +1,166 @@
+{
+	"experiencefragment": {
+		"jcr:primaryType": "cq:Page",
+		"jcr:content": {
+			"jcr:primaryType": "cq:PageContent",
+			"jcr:title": "Language Structure",
+			"jcr:created": "Mon Apr 08 2019 20:21:55 GMT+0200"
+		},
+		"en": {
+			"jcr:primaryType": "cq:Page",
+			"jcr:content": {
+				"jcr:primaryType": "cq:PageContent",
+				"jcr:title": "English",
+				"jcr:created": "Mon APR 08 2019 20:21:55 GMT+0200"
+			},
+			"page": {
+				"jcr:primaryType": "cq:Page",
+				"jcr:content": {
+					"jcr:primaryType": "cq:PageContent",
+					"jcr:title": "Test page",
+					"jcr:created": "Mon APR 08 2019 20:21:55 GMT+0200",
+					"root": {
+						"jcr:primaryType": "nt:unstructured",
+						"expfragment-component-1": {
+							"jcr:primaryType": "nt:unstructured",
+							"sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
+							"fragmentPath": "/content/experience-fragments/language-masters/en/invalid-path"
+						},
+						"expfragment-component-2": {
+							"jcr:primaryType": "nt:unstructured",
+							"sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
+							"fragmentPath": "/content/experience-fragments/language-masters/en/footer/master"
+						}
+					}
+				}
+			}
+		},
+		"es": {
+			"jcr:primaryType": "cq:Page",
+			"jcr:content": {
+				"jcr:primaryType": "cq:PageContent",
+				"jcr:title": "Spanish",
+				"jcr:created": "Mon APR 08 2019 20:21:55 GMT+0200"
+			},
+			"page": {
+				"jcr:primaryType": "cq:Page",
+				"jcr:content": {
+					"jcr:primaryType": "cq:PageContent",
+					"jcr:title": "Test page",
+					"jcr:created": "Mon APR 08 2019 20:21:55 GMT+0200",
+					"root": {
+						"jcr:primaryType": "nt:unstructured",
+						"expfragment-component-1": {
+							"jcr:primaryType": "nt:unstructured",
+							"sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
+							"fragmentPath": "/content/experience-fragments/language-masters/en/footer/master"
+						},
+						"expfragment-component-2": {
+							"jcr:primaryType": "nt:unstructured",
+							"sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
+							"fragmentPath": "/content/experience-fragments/language-masters/en/footer/variation"
+						}
+					}
+				}
+			}
+		},
+		"it-it": {
+			"jcr:primaryType": "cq:Page",
+			"jcr:content": {
+				"jcr:primaryType": "cq:PageContent",
+				"jcr:title": "Italian",
+				"jcr:created": "Mon APR 08 2019 20:21:55 GMT+0200",
+				"jcr:language": "it_IT"
+			},
+			"page": {
+				"jcr:primaryType": "cq:Page",
+				"jcr:content": {
+					"jcr:primaryType": "cq:PageContent",
+					"jcr:title": "Test page",
+					"jcr:created": "Mon APR 08 2019 20:21:55 GMT+0200",
+					"root": {
+						"jcr:primaryType": "nt:unstructured",
+						"expfragment-component-1": {
+							"jcr:primaryType": "nt:unstructured",
+							"sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
+							"fragmentPath": "/content/experience-fragments/it-it/footer/master"
+						}
+					}
+				}
+			}
+		}
+	},
+	"experience-fragments": {
+		"jcr:primaryType": "sling:Folder",
+		"language-masters": {
+			"jcr:primaryType": "sling:Folder",
+			"en": {
+				"jcr:primaryType": "sling:Folder",
+				"footer": {
+					"jcr:primaryType": "cq:Page",
+					"jcr:content": {
+						"jcr:primaryType": "cq:PageContent",
+						"jcr:title": "English Test Footer",
+						"jcr:created": "Mon APR 08 2019 20:21:55 GMT+0200",
+						"sling:resourceType": "cq/experience-fragments/components/experiencefragment"
+					},
+					"master": {
+						"jcr:primaryType": "cq:Page",
+						"jcr:content": {
+							"jcr:primaryType": "cq:PageContent",
+							"jcr:title": "English Test Footer Master",
+							"cq:xfMasterVariation": "true"
+						}
+					},
+					"variation": {
+						"jcr:primaryType": "cq:Page",
+						"jcr:content": {
+							"jcr:primaryType": "cq:PageContent",
+							"jcr:title": "English Test Footer Variation"}
+							
+					}
+				}
+			},
+			"es": {
+				"jcr:primaryType": "sling:Folder",
+				"footer": {
+					"jcr:primaryType": "cq:Page",
+					"jcr:content": {
+						"jcr:primaryType": "cq:PageContent",
+						"jcr:title": "Spanish Test Footer",
+						"jcr:created": "Mon APR 08 2019 20:21:55 GMT+0200",
+						"sling:resourceType": "cq/experience-fragments/components/experiencefragment"
+					},
+					"master": {
+						"jcr:primaryType": "cq:Page",
+						"jcr:content": {
+							"jcr:primaryType": "cq:PageContent",
+							"jcr:title": "Spanish Test Footer Master",
+							"cq:xfMasterVariation": "true"
+						}
+					}
+				}
+			}
+		},
+		"it-it": {
+			"jcr:primaryType": "sling:Folder",
+			"footer": {
+				"jcr:primaryType": "cq:Page",
+				"jcr:content": {
+					"jcr:primaryType": "cq:PageContent",
+					"jcr:title": "Italian Test Footer",
+					"jcr:created": "Mon APR 08 2019 20:21:55 GMT+0200",
+					"sling:resourceType": "cq/experience-fragments/components/experiencefragment"
+				},
+				"master": {
+					"jcr:primaryType": "cq:Page",
+					"jcr:content": {
+						"jcr:primaryType": "cq:PageContent",
+						"jcr:title": "Italian Test Footer Master",
+						"cq:xfMasterVariation": "true"
+					}
+				}
+			}
+		}
+	}
+}

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured">
+    <experiencefragment/>
+</jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:icon="experience"
+    jcr:description="Displays experience fragment or its specified variation"
+    jcr:primaryType="cq:Component"
+    jcr:title="Experience Fragment (v1)"
+    sling:resourceSuperType="cq/experience-fragments/editor/components/experiencefragment"
+    componentGroup=".core-wcm"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/README.md
@@ -1,0 +1,40 @@
+<!--
+Copyright 2019 Adobe Systems Incorporated
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+Experience Fragment (v1)
+====
+Experience fragment component written in HTL that renders configured experience fragment variation.
+
+## Features
+* Can be used on both templates and pages
+* Defines a configurable experience fragment variation to be displayed
+* Supports references for translated content
+
+### Use Object
+The Experience fragment component extends the OOTB Experience fragment component and uses the `com.adobe.cq.wcm.core.components.models.ExperienceFragment` Sling model as its Use-object.
+
+## BEM Description
+```
+BLOCK cmp-exp-fragment
+```
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v1
+* **Compatibility**: AEM 6.4
+* **Status**: Not production-ready
+* **Documentation**: [https://www.adobe.com/go/aem\_cmp\_experience_fragment\_v1](https://www.adobe.com/go/aem_cmp_experience_fragment_v1)
+

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_design_dialog/.content.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:description="Experience Fragment Design Dialog"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Experience Fragment Design"
+    sling:resourceType="cq/gui/components/authoring/dialog">
+    <content
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <tabs
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/tabs"
+                maximized="{Boolean}true">
+                <items jcr:primaryType="nt:unstructured">
+                    <styletab
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_design/styletab"/>
+                </items>
+            </tabs>
+        </items>
+    </content>
+</jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/experiencefragment.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/experiencefragment.html
@@ -1,0 +1,27 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2019 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<div class="cmp-experience-fragment">
+	<sly data-sly-test="${!properties.fragmentpath}">
+	<div data-sly-test="${(wcmmode.edit || wcmmode.preview)}"
+		class="cq-dd-experiencefragment cq-placeholder "
+		data-emptytext="${component.properties.jcr:title}${emptyTextAppend && ' - '}${emptyTextAppend}">
+	</div>
+	</sly>
+	<sly
+		data-sly-use.expfragment="com.adobe.cq.wcm.core.components.models.ExperienceFragment"
+		data-sly-test.experienceFragmentVariationPath=${expfragment.experienceFragmentVariationPath}
+		data-sly-resource="${@path=experienceFragmentVariationPath, selectors='content', wcmmode='disabled'}"></sly>
+</div>


### PR DESCRIPTION
• Adds Experience fragment component


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #506 ` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      | Yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Experience fragment component extends the OOTB Experience Fragment component. When experience fragment is used in a page template, then in the language pages, it will dynamically try to fetch corresponding language copy of the experience fragment specified in the component.
