### PR TITLE
[Issue 543] Remove the `selected` radio group from option entries

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/form/options/v2/options/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/options/v2/options/_cq_dialog/.content.xml
@@ -183,17 +183,6 @@
                                                                             text="Active"
                                                                             uncheckedValue="false"
                                                                             value="{Boolean}true"/>
-                                                                        <selected
-                                                                            jcr:primaryType="nt:unstructured"
-                                                                            sling:resourceType="granite/ui/components/coral/foundation/form/radiogroup"
-                                                                            name="./selected">
-                                                                            <items jcr:primaryType="nt:unstructured">
-                                                                                <active
-                                                                                    jcr:primaryType="nt:unstructured"
-                                                                                    text="Active"
-                                                                                    value="{Boolean}true"/>
-                                                                            </items>
-                                                                        </selected>
                                                                         <disabled
                                                                             granite:class="cmp-form-option-item-disabled"
                                                                             jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #543  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | No
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Remove the `selected` radio group from option entries.
The label `Active` and the variable `selected` belong to the checkbox.
A radio group should have at least two