### PR TITLE
[Carousel] Lack of tabindex on cmp-carousel__indicator

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -57,6 +57,8 @@
         <ol role="tablist" class="cmp-carousel__indicators" data-cmp-hook-carousel="indicators">
             <li data-sly-repeat.item="${carousel.items}"
                 role="tab"
+                tabindex="${itemList.first ? 0 : -1}"
+                aria-selected="${itemList.first ? true : false}"
                 class="cmp-carousel__indicator${itemList.first ? ' cmp-carousel__indicator--active' : ''}"
                 data-cmp-hook-carousel="indicator">${item.title}</li>
         </ol>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
@@ -23,6 +23,8 @@
         aria-multiselectable="false">
         <li data-sly-repeat.item="${tabs.items}"
             role="tab"
+            tabindex="${item.name == tabs.activeItem ? 0 : -1}"
+            aria-selected="${item.name == tabs.activeItem ? true : false}"
             class="cmp-tabs__tab${item.name == tabs.activeItem ? ' cmp-tabs__tab--active' : ''}"
             data-cmp-hook-tabs="tab">${item.title}</li>
     </ol>


### PR DESCRIPTION
- adds `tabindex`, `aria-selected` initial state for Carousel (indicators) and Tabs components.

The JS Widgets for the components setup both properties when loaded, we add them here to the templates for ensuring the initial state and to provide clarity on the expected accessibility behaviour.

fixes: #572