### PR TITLE
Updated Readme to reflect Filevault plugin changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,20 +112,24 @@ Please note that
  * ``-pl/-projects`` option specifies the list of projects that you want to install
  * ``-am/-also-make`` options specifies that dependencies should also be built
 
-## Include core components as subpackage into your own project maven build
+## Include core components into your own project maven build
 
-The released version of the core components are available on the public maven repository at https://repo.adobe.com. To include the
-core components package into your own project maven build you can add the dependency
+To add core components to your project, you will need to add it to your maven build.
+The released version of the core components are available on the public maven repository at https://repo1.maven.org/maven2/com/adobe/cq/core.wcm.components.all/ 
+
+### For Projects using Maven Archetype 17 and below
+
+To include the core components package into your own project's maven build using AEM's maven archetype 17 and below, you can add the dependency to your pom.xml like this
  ```
  <dependency>
      <groupId>com.adobe.cq</groupId>
      <artifactId>core.wcm.components.all</artifactId>
      <type>zip</type>
-     <version>2.2.0</version>
+     <version>2.4.0</version>
  </dependency>
  ```
 
- and sub package section
+ and then add this subpackage to your sub package section
 ```
  <subPackage>
      <groupId>com.adobe.cq</groupId>
@@ -134,7 +138,32 @@ core components package into your own project maven build you can add the depend
  </subPackage>
 ```
 
- to the `content-package-maven-plugin`.
+ inside the configuration of the `content-package-maven-plugin`.
+
+ Also, make sure that if you have a sub module like ui.apps to add the core components as a dependency to ui.apps/pom.xml as well.
+
+ ### For Projects Using Maven Archetype 18 and Above
+
+To include the core components package into your own project using AEM Archetype 18+, add it as a dependency to your build like so:
+ ```
+ <dependency>
+     <groupId>com.adobe.cq</groupId>
+     <artifactId>core.wcm.components.all</artifactId>
+     <type>zip</type>
+     <version>2.4.0</version>
+ </dependency>
+ ```
+
+Then add it as a subpackage
+```
+ <subPackage>
+     <groupId>com.adobe.cq</groupId>
+     <artifactId>core.wcm.components.all</artifactId>
+     <filter>true</filter>
+ </subPackage>
+```
+
+inside the configuration of the `filevault-package-maven-plugin`.
 
  For more information how to setup the Adobe Maven Repository (`repo.adobe.com`) for your maven build, please have a look at the
  related [Knowledge Base article](https://helpx.adobe.com/experience-manager/kb/SetUpTheAdobeMavenRepository.html)


### PR DESCRIPTION
Closes #576 

With the new Maven Archetype having been released recently, they updated the file vault plugin. 

Because of this, projects using the latest Maven Archetype should be adding core components as a subpackage to filevault-package-maven-plugin instead of content-package-maven-plugin. 

I updated the README.md to reflect his change. 

Please check over my changes to ensure that I am correct about this configuration. 

Thanks!