### PR TITLE
[Documentation] Document Java 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ The components' versioning scheme is documented on the [AEM Core WCM Components'
 
 ## System Requirements
 
-The latest version of the Core Components, require the below minimum system requirements:
+The latest version of the Core Components, require the below system requirements:
 
 Core Components | AEM 6.5 | AEM 6.4 | AEM 6.3 | Java
 ----------------|---------|---------|---------|------
-[2.4.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.4.0) | 6.5.0.0 | 6.4.2.0 | 6.3.3.0 | 1.8
+[2.4.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.4.0) | 6.5.0.0+ | 6.4.2.0+ | 6.3.3.0+ | 8, 11
 
 For a list of requirements for previous versions, see [Historical System Requirements](VERSIONS.md).
 
@@ -72,8 +72,8 @@ For more information about the Package Manager please have a look at [How to Wor
 
 ## Build
 
-The project has the following minimal requirements:
-* Java SE Development Kit 8 or newer
+The project has the following requirements:
+* Java SE Development Kit 8 or Java SE Development Kit 11
 * Apache Maven 3.3.1 or newer
 
 For ease of build and installation the following profiles are provided:

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,18 +1,18 @@
 # Core Components Historical System Requirements
 
-See below for a full list of minimum system requirements for historical versions of the Core Components:
+See below for a full list of system requirements for historical versions of the Core Components:
 
 Core Components | Extension | AEM 6.5 | AEM 6.4 | AEM 6.3 | Java
 ----------------|-----------|---------|---------|---------|------
-[2.4.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.4.0) | - | 6.5.0.0 | 6.4.2.0 | 6.3.3.0 | 1.8
-[2.3.2](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.3.2) | 1.0.12 | 6.5.0.0 | 6.4.2.0 | 6.3.3.0 | 1.8
-[2.3.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.3.0) | 1.0.10 | - | 6.4.2.0 | 6.3.3.0 | 1.8
-[2.2.2](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.2.2) | 1.0.10 | - | 6.4.2.0 | 6.3.3.0 | 1.8
-[2.2.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.2.0) | 1.0.8 | - | 6.4.2.0 | 6.3.3.0 | 1.8
-[2.1.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.1.0) | 1.0.6 | - | 6.4.2.0 | 6.3.3.0 | 1.8
-[2.0.6](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.6), [2.0.8](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.8) | 1.0.2, 1.0.4 | - | 6.4.0.0 | 6.3.2.0 | 1.8
-[2.0.4](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.4) | 1.0.0 | - | 6.4.0.0 | 6.3.2.0 | 1.8
-[2.0.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.0) | sandbox/preview | - | 6.4.0.0 | 6.3.2.0 | 1.8
-[1.1.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.1.0) | sandbox/preview | - | 6.4.0.0 | 6.3.1.0 | 1.8
-[1.0.4](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.0.4), [1.0.6](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.0.6) | - | - | 6.4.0.0 | 6.3.0.0 | 1.8
-[1.0.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.0.0), [1.0.2](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.all-1.0.2) | - | - | 6.4.0.0 | 6.3.0.0 | 1.7
+[2.4.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.4.0) | - | 6.5.0.0+ | 6.4.2.0+ | 6.3.3.0+ | 8, 11
+[2.3.2](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.3.2) | 1.0.12 | 6.5.0.0+ | 6.4.2.0+ | 6.3.3.0+ | 8
+[2.3.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.3.0) | 1.0.10 | - | 6.4.2.0+ | 6.3.3.0+ | 8
+[2.2.2](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.2.2) | 1.0.10 | - | 6.4.2.0+ | 6.3.3.0+ | 8
+[2.2.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.2.0) | 1.0.8 | - | 6.4.2.0+ | 6.3.3.0+ | 8
+[2.1.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.1.0) | 1.0.6 | - | 6.4.2.0+ | 6.3.3.0+ | 8
+[2.0.6](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.6), [2.0.8](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.8) | 1.0.2, 1.0.4 | - | 6.4.0.0+ | 6.3.2.0+ | 8
+[2.0.4](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.4) | 1.0.0 | - | 6.4.0.0+ | 6.3.2.0+ | 8
+[2.0.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.0) | sandbox/preview | - | 6.4.0.0+ | 6.3.2.0+ | 8
+[1.1.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.1.0) | sandbox/preview | - | 6.4.0.0+ | 6.3.1.0+ | 8
+[1.0.4](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.0.4), [1.0.6](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.0.6) | - | - | 6.4.0.0+ | 6.3.0.0+ | 8
+[1.0.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.0.0), [1.0.2](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.all-1.0.2) | - | - | 6.4.0.0+ | 6.3.0.0+ | 7


### PR DESCRIPTION
- uses non-decimal java versions (8 rather than 1.8).
- adds java 11 note for 2.4.0.
- uses ranges rather than minimum requirements in versions table.
