### PR TITLE
[Navigation] Navigation is missing the role attribute

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/navigation.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/navigation.html
@@ -14,6 +14,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <nav class="cmp-navigation"
+     role="navigation"
      itemscope itemtype="http://schema.org/SiteNavigationElement"
      data-sly-use.template="core/wcm/components/commons/v1/templates.html"
      data-sly-use.navigation="com.adobe.cq.wcm.core.components.models.Navigation"


### PR DESCRIPTION
Although this generates a warning in the HTML validator, we should still add it while we support IE11 for publish side code which still doesn't map roles to HTML5 element names.


<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #584` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | N/A
| Documentation Provided   | N/A
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
