### PR TITLE
initial commit of result limit for Content fragment list component

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentListImpl.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
@@ -69,6 +70,8 @@ public class ContentFragmentListImpl implements ContentFragmentList {
     public static final String RESOURCE_TYPE = "core/wcm/components/contentfragmentlist/v1/contentfragmentlist";
 
     public static final String DEFAULT_DAM_PARENT_PATH = "/content/dam";
+    
+    public static final int DEFAULT_RESULT_LIMIT = 10;
 
     @Self(injectionStrategy = InjectionStrategy.REQUIRED)
     private SlingHttpServletRequest slingHttpServletRequest;
@@ -90,6 +93,10 @@ public class ContentFragmentListImpl implements ContentFragmentList {
 
     @ValueMapValue(name = ContentFragmentList.PN_PARENT_PATH, injectionStrategy = InjectionStrategy.OPTIONAL)
     private String parentPath;
+
+    @ValueMapValue(name = ContentFragmentList.PN_RESULT_LIMIT, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Default(intValues = DEFAULT_RESULT_LIMIT)
+    private int resultLimit;
 
     private List<DAMContentFragment> items = new ArrayList<>();
 
@@ -120,6 +127,7 @@ public class ContentFragmentListImpl implements ContentFragmentList {
         Map<String, String> queryParameterMap = new HashMap<>();
         queryParameterMap.put("path", parentPath);
         queryParameterMap.put("type", "dam:Asset");
+        queryParameterMap.put("p.limit", Integer.toString(resultLimit));
         queryParameterMap.put("1_property", JcrConstants.JCR_CONTENT + "/data/cq:model");
         queryParameterMap.put("1_property.value", modelPath);
 
@@ -141,7 +149,7 @@ public class ContentFragmentListImpl implements ContentFragmentList {
 
         PredicateGroup predicateGroup = PredicateGroup.create(queryParameterMap);
         Query query = queryBuilder.createQuery(predicateGroup, session);
-
+        
         SearchResult searchResult = query.getResult();
 
         LOG.debug("Query statement: '{}'", searchResult.getQueryStatement());

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentListImpl.java
@@ -71,7 +71,7 @@ public class ContentFragmentListImpl implements ContentFragmentList {
 
     public static final String DEFAULT_DAM_PARENT_PATH = "/content/dam";
     
-    public static final int DEFAULT_RESULT_LIMIT = 10;
+    public static final int DEFAULT_MAX_ITEMS = -1;
 
     @Self(injectionStrategy = InjectionStrategy.REQUIRED)
     private SlingHttpServletRequest slingHttpServletRequest;
@@ -94,9 +94,9 @@ public class ContentFragmentListImpl implements ContentFragmentList {
     @ValueMapValue(name = ContentFragmentList.PN_PARENT_PATH, injectionStrategy = InjectionStrategy.OPTIONAL)
     private String parentPath;
 
-    @ValueMapValue(name = ContentFragmentList.PN_RESULT_LIMIT, injectionStrategy = InjectionStrategy.OPTIONAL)
-    @Default(intValues = DEFAULT_RESULT_LIMIT)
-    private int resultLimit;
+    @ValueMapValue(name = ContentFragmentList.PN_MAX_ITEMS, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Default(intValues = DEFAULT_MAX_ITEMS)
+    private int maxItems;
 
     private List<DAMContentFragment> items = new ArrayList<>();
 
@@ -127,7 +127,7 @@ public class ContentFragmentListImpl implements ContentFragmentList {
         Map<String, String> queryParameterMap = new HashMap<>();
         queryParameterMap.put("path", parentPath);
         queryParameterMap.put("type", "dam:Asset");
-        queryParameterMap.put("p.limit", Integer.toString(resultLimit));
+        queryParameterMap.put("p.limit", Integer.toString(maxItems));
         queryParameterMap.put("1_property", JcrConstants.JCR_CONTENT + "/data/cq:model");
         queryParameterMap.put("1_property.value", modelPath);
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/ContentFragmentList.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/ContentFragmentList.java
@@ -72,7 +72,7 @@ public interface ContentFragmentList extends ComponentExporter {
      *
      * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.1.0
      */
-    String PN_RESULT_LIMIT = "resultLimit";
+    String PN_MAX_ITEMS= "maxItems";
 
     /**
      * Returns a list of {@link DAMContentFragment content fragments}.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/ContentFragmentList.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/ContentFragmentList.java
@@ -68,6 +68,13 @@ public interface ContentFragmentList extends ComponentExporter {
     String PN_PARENT_PATH = "parentPath";
 
     /**
+     * Name of the optional resource property that sets the query limit for the number of results to return.
+     *
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.1.0
+     */
+    String PN_RESULT_LIMIT = "resultLimit";
+
+    /**
      * Returns a list of {@link DAMContentFragment content fragments}.
      *
      * @return the list of content fragments

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/package-info.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("1.0.0")
+@Version("1.1.0")
 package com.adobe.cq.wcm.core.components.models.contentfragment;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/resources/contentfragmentlist/test-content.json
+++ b/bundles/core/src/test/resources/contentfragmentlist/test-content.json
@@ -39,6 +39,12 @@
                         "sling:resourceType": "core/wcm/components/contentfragmentlist/v1/contentfragmentlist",
                         "modelPath"         : "foobar",
                         "elementNames"      : "main"
+                    },
+                    "model-max-limit"       : {
+                        "jcr:primaryType"   : "nt:unstructured",
+                        "sling:resourceType": "core/wcm/components/contentfragmentlist/v1/contentfragmentlist",
+                        "modelPath"         : "foobar",
+                        "maxItems"          : "20"
                     }
                 }
             }

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/README.md
@@ -32,7 +32,8 @@ The following properties are written to JCR for the Content Fragment List compon
 1. `./modelPath` - path to the Content Fragment Model on which the list is based.
 2. `./parentPath` - parent path from which the list should be built.
 3. `./tagNames` - tag names for filtering the list.
-4. `./elementNames` - element names for limiting the model data displayed in the result.
+4. `./maxItems` - defines the maximum number of items rendered by the list. If not defined, all fragments matching the query criteria are returned.
+5. `./elementNames` - element names for limiting the model data displayed in the result.
 
 ## Client Libraries
 The component provides a `core.wcm.components.contentfragmentlist.v1.editor` editor client library category that includes JavaScript

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/_cq_dialog/.content.xml
@@ -53,6 +53,14 @@
                                         fieldLabel="Tags"
                                         multiple="{Boolean}true"
                                         name="./tagNames"/>
+                                    <maxItems
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                        fieldDescription="Maximum number of items displayed in list. Empty for all items."
+                                        fieldLabel="Max Items"
+                                        min="{Long}0"
+                                        value="{Long}10"
+                                        name="./maxItems"/>
                                 </items>
                             </column>
                         </items>
@@ -92,27 +100,6 @@
                             </column>
                         </items>
                     </elements>
-                    <results
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="Results"
-                        sling:resourceType="granite/ui/components/coral/foundation/container"
-                        margin="{Boolean}true">
-                        <items jcr:primaryType="nt:unstructured">
-                            <column
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/container">
-                                <items jcr:primaryType="nt:unstructured">
-                                    <resultLimit
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
-                                        fieldDescription="Maximum number of fragments displayed, defaults to 10. Enter -1 for all items"
-                                        fieldLabel="Result Limit"
-                                        min="{Long}-1"
-                                        name="./resultLimit"/>
-                                </items>
-                            </column>
-                        </items>
-                    </results>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/_cq_dialog/.content.xml
@@ -92,6 +92,27 @@
                             </column>
                         </items>
                     </elements>
+                    <results
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Results"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <column
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <resultLimit
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                        fieldDescription="Maximum number of fragments displayed, defaults to 10. Enter -1 for all items"
+                                        fieldLabel="Result Limit"
+                                        min="{Long}-1"
+                                        name="./resultLimit"/>
+                                </items>
+                            </column>
+                        </items>
+                    </results>
                 </items>
             </tabs>
         </items>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #598 
| Patch: Bug Fix?          | Could be interpreted as an enhancement or bugfix (depending on perspective)
| Minor: New Feature?      | Yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | No, initial PR to gather feedback
| Documentation Provided   | No, initial PR to gather feedback
| Any Dependency Changes?  | Yes incremented `com.adobe.cq.wcm.core.components.models.contentfragment` from 1.0.0 to 1.1.0
| License                  | Apache License, Version 2.0

Currently, the CF List component appears to return a max number of 10 fragments, see issue #598. This PR adds a Result Limit to the Content Fragment List dialog. 

This allows a content author to:

* configure the max amount of fragments to display in the component or
* add a value of **-1** to include all content fragments (that are returned by the filter)

![image](https://user-images.githubusercontent.com/8974514/58140104-aa3df500-7bf2-11e9-9cdb-ca9f5f07090a.png)

The `resultLimit` property value is translated to the `p.limit` value of the querybuilder parameters. Continues to use a default of 10 results (as before) if no `resultLimit` property is set but this time explicitly sets the `p.limit`.
