### PR TITLE
[WCM Core Component] Fragment Editor no longer callable (CQ-4271675)

### DIFF
--- a/config/src/content/jcr_root/apps/core/wcm/config/com.adobe.cq.dam.cfm.impl.component.ComponentConfigImpl-core-comp-v1.config
+++ b/config/src/content/jcr_root/apps/core/wcm/config/com.adobe.cq.dam.cfm.impl.component.ComponentConfigImpl-core-comp-v1.config
@@ -1,0 +1,18 @@
+# Copyright 2019 Adobe Systems Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dam.cfm.component.resourceType="core/wcm/components/contentfragment/v1/contentfragment"
+dam.cfm.component.fileReferenceProp="fragmentPath"
+dam.cfm.component.elementsProp="elementName"
+dam.cfm.component.variationProp="variationName"


### PR DESCRIPTION
- add the config for the content fragment component (taken from the removed extension bundle)

