### PR TITLE
[Download] General Review

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Download.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Download.java
@@ -40,9 +40,8 @@ public interface Download extends ComponentExporter {
      */
     String PN_INLINE = "inline";
 
-
     /**
-     * Name of the policy property that defines the text to be displayed on the Call-to-Action.
+     * Name of the policy property that defines the text to be displayed on the action.
      */
     String PN_ACTION_TEXT = "actionText";
 
@@ -67,7 +66,6 @@ public interface Download extends ComponentExporter {
      * Name of the policy property that defines whether the filename will be displayed.
      */
     String PN_DISPLAY_FILENAME = "displayFilename";
-
 
     /**
      * Returns either the title configured in the dialog or the title of the DAM asset,
@@ -99,7 +97,7 @@ public interface Download extends ComponentExporter {
     }
 
     /**
-     * Returns the button text from the dialog if it is configured there. Otherwise, it returns the value set in the
+     * Returns the action text from the dialog if it is configured there. Otherwise, it returns the value set in the
      * component policy.
      *
      * @return the button text

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/.content.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:description="Creates a tile for a downloadable DAM asset"
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     cq:icon="download"
+    jcr:description="Displays a downloadable DAM asset with optional title, description, metadata and action text."
     jcr:primaryType="cq:Component"
     jcr:title="Download (v1)"
-    componentGroup=".core-wcm"
-    sling:resourceSuperType="core/wcm/components/image"/>
+    componentGroup=".core-wcm"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
@@ -16,41 +16,56 @@ limitations under the License.
 
 Download (v1)
 ====
-Download component written in HTL that displays a downloadable asset on a page.
+Download component written in HTL that displays a downloadable asset on the page.
 
 ## Features
-* Displays an asset on a page for download with
-    * preview, title and description information 
-    * custom CTA link
-* DownloadServlet with support of conditional header information and Content-Disposition
+* Displays an asset on the page for download with the following elements:
+    * Title
+    * Description
+    * File Size, File Format, Filename
+    * Action
+* Optionally allows assets to be displayed inline in the browser rather than directly downloaded.
+* Direct upload from a local file system is configurable.
+* Download Servlet with support for conditional header information and Content-Disposition.
+* Style System support.
 
 ### Use Object
 The Download component uses the `com.adobe.cq.wcm.core.components.models.Download` Sling model as its Use-object.
 
-### Edit dialog properties
+### Component Policy Configuration Properties
+The following configuration properties are used:
+
+1. `./actionText` - defines the default action text to use if none is provided in the edit dialog.
+2. `./allowUpload` - defines whether direct upload from a local file system is allowed.
+3. `./titleType` - defines the HTML element to use for the download title
+4. `./displaySize` - defines whether the file size should be displayed.
+5. `./displayFormat` - defines whether the file format should be displayed.
+6. `./displayFilename` - defines whether the filename should be displayed.
+
+### Edit Dialog Properties
 The following JCR properties are used:
 
-1. `./fileReference` - defines the path to the asset from DAM
-2. `./inline` - defines if the download item should be displayed inline in the browser vs. attachment
-3. `./jcr:title` - title of the download item
-4. `./titleFromAsset` - defines if the the title should be reused from the asset dam title
-5. `./jcr:description` - description of the download item
-6. `./descriptionFromAsset` - defines if the description should be reused from the asset dam description
-7. `./actionText` - defines the CTA link text
+1. `./fileReference` - defines the path to the asset from DAM.
+2. `./inline` - defines whether the download item should be displayed inline in the browser vs. attachment.
+3. `./jcr:title` - defines the download title.
+4. `./titleFromAsset` - defines whether the title should be taken from the DAM asset title.
+5. `./jcr:description` - defines the download description.
+6. `./descriptionFromAsset` - defines whether the description should be taken from the DAM asset description.
+7. `./actionText` - defines the action text.
 
-## BEM description
+## BEM Description
 ```
 BLOCK cmp-download
-    ELEMENT cmp-download__image
     ELEMENT cmp-download__title
     ELEMENT cmp-download__description
+    ELEMENT cmp-download__metadata
+    ELEMENT cmp-download__filename
+    ELEMENT cmp-download__size
+    ELEMENT cmp-download__format
     ELEMENT cmp-download__action
         ELEMENT cmp-download__action-icon
             MOD cmp-download__action-icon--<extension>
         ELEMENT cmp-download__action-text
-    ELEMENT cmp-download__filename
-    ELEMENT cmp-download__size
-    ELEMENT cmp-download__format
 ```
 
 ## Information

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
@@ -37,7 +37,7 @@ The following configuration properties are used:
 
 1. `./actionText` - defines the default action text to use if none is provided in the edit dialog.
 2. `./allowUpload` - defines whether direct upload from a local file system is allowed.
-3. `./titleType` - defines the HTML element to use for the download title
+3. `./titleType` - defines the HTML element to use for the download title.
 4. `./displaySize` - defines whether the file size should be displayed.
 5. `./displayFormat` - defines whether the file format should be displayed.
 6. `./displayFilename` - defines whether the filename should be displayed.

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/_cq_design_dialog/.content.xml
@@ -13,9 +13,9 @@
                 sling:resourceType="granite/ui/components/coral/foundation/tabs"
                 maximized="{Boolean}true">
                 <items jcr:primaryType="nt:unstructured">
-                    <main
+                    <properties
                         jcr:primaryType="nt:unstructured"
-                        jcr:title="Download"
+                        jcr:title="Properties"
                         sling:resourceType="granite/ui/components/coral/foundation/container"
                         margin="{Boolean}true">
                         <items jcr:primaryType="nt:unstructured">
@@ -27,17 +27,27 @@
                                     <actionText
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                        fieldDescription="The default text for the call-to-action."
-                                        fieldLabel="Default Call-to-Action Text"
+                                        fieldDescription="The default text for the download action."
+                                        fieldLabel="Default Action Text"
                                         name="./actionText"/>
                                 </items>
                             </action>
+                            <allowUpload
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                checked="{Boolean}false"
+                                deleteHint="{Boolean}false"
+                                fieldDescription="Allow direct asset upload from a local file system."
+                                name="./allowUpload"
+                                text="Allow upload from file system"
+                                uncheckedValue="{Boolean}false"
+                                value="{Boolean}true"/>
                             <type
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                fieldDescription="The HTML element to use for the download title. If no type is configured, the default (H3) will be used."
                                 fieldLabel="Title Type"
-                                name="./titleType"
-                                granite:class="foundation-toggleable">
+                                name="./titleType">
                                 <items jcr:primaryType="nt:unstructured">
                                     <def
                                         jcr:primaryType="nt:unstructured"
@@ -97,50 +107,7 @@
                                 uncheckedValue="false"
                                 value="{Boolean}true"/>
                         </items>
-                    </main>
-                    <features
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="Features"
-                        sling:resourceType="granite/ui/components/coral/foundation/container"
-                        margin="{Boolean}true">
-                        <items jcr:primaryType="nt:unstructured">
-                            <content
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/container"
-                                margin="{Boolean}false">
-                                <items jcr:primaryType="nt:unstructured">
-                                    <accordion
-                                        granite:class="js-cq-IPEPlugin-container"
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/coral/foundation/accordion"
-                                        variant="quiet">
-                                        <items jcr:primaryType="nt:unstructured">
-                                            <source
-                                                jcr:primaryType="nt:unstructured"
-                                                jcr:title="Source"
-                                                sling:resourceType="granite/ui/components/coral/foundation/container"
-                                                maximized="{Boolean}true">
-                                                <items jcr:primaryType="nt:unstructured">
-                                                    <allowupload
-                                                        jcr:primaryType="nt:unstructured"
-                                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                                        checked="{Boolean}false"
-                                                        deleteHint="{Boolean}false"
-                                                        name="./allowUpload"
-                                                        text="Allow asset upload from file system"
-                                                        uncheckedValue="{Boolean}false"
-                                                        value="{Boolean}true"/>
-                                                </items>
-                                                <parentConfig
-                                                    jcr:primaryType="nt:unstructured"
-                                                    active="{Boolean}true"/>
-                                            </source>
-                                        </items>
-                                    </accordion>
-                                </items>
-                            </content>
-                        </items>
-                    </features>
+                    </properties>
                     <styletab
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="granite/ui/components/coral/foundation/include"

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/_cq_dialog/.content.xml
@@ -3,7 +3,7 @@
     jcr:primaryType="nt:unstructured"
     jcr:title="Download"
     sling:resourceType="cq/gui/components/authoring/dialog"
-    extraClientlibs="[core.wcm.components.download.v1.download.editor]">
+    extraClientlibs="[core.wcm.components.download.v1.editor]">
     <content
         granite:class="cmp-download__editor"
         jcr:primaryType="nt:unstructured"
@@ -246,7 +246,7 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
                                                 checked="{Boolean}false"
-                                                fieldDescription="When checked, download item will be displayed inline in the browser"
+                                                fieldDescription="When checked, the download asset will be displayed inline in the browser."
                                                 name="./inline"
                                                 text="Display inline"
                                                 uncheckedValue="{Boolean}false"

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/clientlibs/editor/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/clientlibs/editor/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
-    categories="[core.wcm.components.download.v1.download.editor]"
+    categories="[core.wcm.components.download.v1.editor]"
     dependencies="[jquery,core.wcm.components.commons.v1.editor.checkboxTextfieldTuple]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
@@ -15,20 +15,19 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.download="com.adobe.cq.wcm.core.components.models.Download"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-     data-sly-test.hasContent="download.title || download.description}"
+     data-sly-test.hasContent="${download.title || download.description || download.actionText}"
      class="cmp-download${!wcmmode.disabled ? ' cq-dd-file' : ''}">
-    <h2 class="cmp-download__title" data-sly-test.title="${download.title}" data-sly-element="${download.titleType}">
-        ${title}
-    </h2>
-    <div class="cmp-download__description" data-sly-test.description="${download.description}">
-        ${description @ context="html"}
+    <h3 class="cmp-download__title" data-sly-test.title="${download.title}" data-sly-element="${download.titleType}">${title}</h3>
+    <div class="cmp-download__description" data-sly-test.description="${download.description}">${description @ context="html"}</div>
+    <div data-sly-test="${(download.displayFilename && download.filename) || (download.displaySize && download.size) || (download.displayFormat && download.format)}"
+         class="cmp-download__metadata">
+        <span data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__filename">${download.filename}</span>
+        <span data-sly-test="${download.displaySize && download.size}" class="cmp-download__size">${download.size}</span>
+        <span data-sly-test="${download.displayFormat && download.format}" class="cmp-download__format">${download.format}</span>
     </div>
     <a class="cmp-download__action" href="${download.url}">
         <span class="cmp-download__action-icon cmp-download__action-icon--${download.extension}"></span>
         <span class="cmp-download__action-text">${download.actionText}</span>
     </a>
-    <span data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__filename">${download.filename}</span>
-    <span data-sly-test="${download.displaySize && download.size}" class="cmp-download__size">${download.size}</span>
-    <span data-sly-test="${download.displayFormat && download.format}" class="cmp-download__format">${download.format}</span>
 </div>
 <sly data-sly-call="${templates.placeholder @ isEmpty=!hasContent, classAppend='cmp-download cq-dd-file'}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_design_dialog/.content.xml
@@ -49,7 +49,8 @@
                                         cq:showOnCreate="{Boolean}true"
                                         granite:class="core-title-sizes-allowed"
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset"
+                                        fieldDescription="The HTML element to use for the download title. If no type is configured, the default (H3) will be used.">
                                         <items jcr:primaryType="nt:unstructured">
                                             <h1
                                                 jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/download/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/download/.content.xml
@@ -6,7 +6,7 @@
         cq:lastModifiedBy="admin"
         cq:tags="[core-components-examples:component-type/basic]"
         cq:template="/conf/core-components-examples/settings/wcm/templates/content-page"
-        jcr:description="Provide a download item"
+        jcr:description="Display an asset for download"
         jcr:primaryType="cq:PageContent"
         jcr:title="Download"
         sling:resourceType="core-components-examples/components/page">
@@ -39,7 +39,7 @@
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/text/v2/text"
-                    text="&lt;p>Download allows linking to an asset for download. Optionally displays a preview of the asset, its title, description, metadata and a download link.&lt;/p>&#xa;"
+                    text="&lt;p>Download allows linking to an asset for download. Optionally displays a title, description, metadata and a download link.&lt;/p>&#xa;"
                     textIsRich="true"/>
                 <teaser_copy
                     cq:styleIds="[1550165685463]"
@@ -93,6 +93,15 @@
                     jcr:title="Standard"
                     sling:resourceType="core/wcm/components/title/v2/title"
                     type="h3"/>
+                <text_1337506761
+                    jcr:created="{Date}2018-12-06T19:23:41.968+01:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2018-12-07T13:32:55.756+01:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core/wcm/components/text/v2/text"
+                    text="&lt;p>Simple Download with only an &lt;i>Action Text&lt;/i> and &lt;i>Download Asset&lt;/i> configured. The &lt;i>Title&lt;/i> and &lt;i>Description&lt;/i> are by default taken from the provided asset.&lt;/p>&#xa;"
+                    textIsRich="true"/>
                 <demo
                     jcr:created="{Date}2019-05-21T12:30:58.953+02:00"
                     jcr:createdBy="admin"
@@ -142,9 +151,18 @@
                     jcr:lastModified="{Date}2019-05-27T23:05:47.431+02:00"
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
-                    jcr:title="Download with custom title and description"
+                    jcr:title="Title and Description"
                     sling:resourceType="core/wcm/components/title/v2/title"
                     type="h3"/>
+                <text_1337506762
+                    jcr:created="{Date}2018-12-06T19:23:41.968+01:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2018-12-07T13:32:55.756+01:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core/wcm/components/text/v2/text"
+                    text="&lt;p>By default, the &lt;i>Title&lt;/i> and &lt;i>Description&lt;/i> are taken from the provided asset. In this example, we provide a custom title and description for the download.&lt;/p>&#xa;"
+                    textIsRich="true"/>
                 <demo_1197373359
                     jcr:created="{Date}2019-05-27T22:44:51.891+02:00"
                     jcr:createdBy="admin"
@@ -191,16 +209,25 @@
                             reference="../../component"/>
                     </info>
                 </demo_1197373359>
-                <title_233487318
+                <title_233487331
                     jcr:created="{Date}2019-05-27T23:06:43.454+02:00"
                     jcr:createdBy="admin"
                     jcr:lastModified="{Date}2019-05-27T23:22:34.595+02:00"
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
-                    jcr:title="Download with direct upload and display inline in the browser"
+                    jcr:title="Direct Upload"
                     sling:resourceType="core/wcm/components/title/v2/title"
                     type="h3"/>
-                <demo_68071485
+                <text_1338806794
+                    jcr:created="{Date}2018-12-06T19:23:41.968+01:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2018-12-07T13:32:55.756+01:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core/wcm/components/text/v2/text"
+                    text="&lt;p>It is possible to upload an asset directly from a local file system rather than selecting an asset from DAM.&lt;/p>&#xa;"
+                    textIsRich="true"/>
+                <demo_68071479
                     jcr:created="{Date}2019-05-27T23:07:59.121+02:00"
                     jcr:createdBy="admin"
                     jcr:lastModified="{Date}2019-05-27T23:07:59.121+02:00"
@@ -213,11 +240,11 @@
                         <download
                             jcr:created="{Date}2019-05-21T12:49:52.210+02:00"
                             jcr:createdBy="admin"
-                            jcr:description="&lt;p>Custom description&lt;/p>&#xd;&#xa;"
+                            jcr:description="&lt;p>Asset uploaded directly from a local file system&lt;/p>&#xd;&#xa;"
                             jcr:lastModified="{Date}2019-05-27T23:24:13.561+02:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            jcr:title="Custom Asset"
+                            jcr:title="Uploaded Asset"
                             sling:resourceType="core/wcm/components/download/v1/download"
                             actionText="Download"
                             descriptionFromAsset="false"
@@ -247,7 +274,71 @@
                             sling:resourceType="core-components-examples/components/demo/json"
                             reference="../../component"/>
                     </info>
-                </demo_68071485>
+                </demo_68071479>
+                <title_233487320
+                    jcr:created="{Date}2019-05-27T23:06:43.454+02:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2019-05-27T23:22:34.595+02:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Display Inline"
+                    sling:resourceType="core/wcm/components/title/v2/title"
+                    type="h3"/>
+                <text_1337506794
+                    jcr:created="{Date}2018-12-06T19:23:41.968+01:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2018-12-07T13:32:55.756+01:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core/wcm/components/text/v2/text"
+                    text="&lt;p>By default the asset is downloaded directly, but it is also possible to display it inline in the browser.&lt;/p>&#xa;"
+                    textIsRich="true"/>
+                <demo_69071411
+                    jcr:created="{Date}2019-05-27T23:07:59.121+02:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2019-05-27T23:07:59.121+02:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/demo">
+                    <component
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/demo/component">
+                        <download
+                            jcr:created="{Date}2019-05-21T12:49:52.210+02:00"
+                            jcr:createdBy="admin"
+                            jcr:lastModified="{Date}2019-05-27T23:24:13.561+02:00"
+                            jcr:lastModifiedBy="admin"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core/wcm/components/download/v1/download"
+                            actionText="Download"
+                            descriptionFromAsset="true"
+                            fileReference="/content/dam/core-components-examples/library/sample-assets/lava-into-ocean.jpg"
+                            inline="true"
+                            textIsRich="true"
+                            titleFromAsset="true">
+                            <file/>
+                        </download>
+                    </component>
+                    <info
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        <properties
+                            cq:panelTitle="Properties"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/properties"
+                            reference="../../component"/>
+                        <markup
+                            cq:panelTitle="Markup"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/markup"
+                            reference="../../component"/>
+                        <json
+                            cq:panelTitle="JSON"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/json"
+                            reference="../../component"/>
+                    </info>
+                </demo_69071411>
             </responsivegrid>
         </root>
         <image jcr:primaryType="nt:unstructured">


### PR DESCRIPTION
- adds descriptions to component library examples.
- splits inline and direct upload examples in component library into separate examples.
- changes default title heading HTML element to `H3` from `H2`.
- fixes editor clientlib category name format.
- merges content policy `Download` and `Features` tabs into single `Properties` tab, as with other components, for simplicity:
<img width="531" alt="Screenshot 2019-06-05 at 12 33 21" src="https://user-images.githubusercontent.com/25616660/58953515-02e6c380-8797-11e9-9395-309e81d5c24e.png">


- wraps metadata with `cmp-download__metadata` and orders metadata before the action in the markup. Allows easier control of metadata positioning in the card.
- fixes `hasContent` test in the template.
- improves README.md description, adding content policy parameters.
- removes references to preview image capability.
- removes unnecessary image resource type in download `content.xml`.
- consistently references `action` rather than `button` or `Call-to-Action`.
- minor formatting fixes.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | NA
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
