### PR TITLE
[Tabs] Sling Resource Merger properties break item add button

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/editor/js/tabs.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/editor/js/tabs.js
@@ -56,23 +56,25 @@
      * @param {HTMLElement} activeItem Active tab hidden input
      */
     function updateActiveSelect(childrenEditor, activeSelect, activeItem) {
-        var selectedValue = activeSelect.value || activeItem.value;
-        activeSelect.items.getAll().forEach(function(item) {
-            if (item.value !== "") {
-                activeSelect.items.remove(item);
-            }
-        });
-        var cmpChildrenEditor = $(childrenEditor).adaptTo("cmp-childreneditor");
-        if (cmpChildrenEditor) {
-            cmpChildrenEditor.items().forEach(function(item) {
-                activeSelect.items.add({
-                    selected: item.name === selectedValue,
-                    value: item.name,
-                    content: {
-                        textContent: item.description
-                    }
-                });
+        if (childrenEditor && activeSelect && activeItem) {
+            var selectedValue = activeSelect.value || activeItem.value;
+            activeSelect.items.getAll().forEach(function(item) {
+                if (item.value !== "") {
+                    activeSelect.items.remove(item);
+                }
             });
+            var cmpChildrenEditor = $(childrenEditor).adaptTo("cmp-childreneditor");
+            if (cmpChildrenEditor) {
+                cmpChildrenEditor.items().forEach(function(item) {
+                    activeSelect.items.add({
+                        selected: item.name === selectedValue,
+                        value: item.name,
+                        content: {
+                            textContent: item.description
+                        }
+                    });
+                });
+            }
         }
     }
 })(jQuery, Coral);

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/editor/js/tabs.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/editor/js/tabs.js
@@ -32,17 +32,19 @@
             var activeSelect = tabsEditor.querySelector(activeSelectSelector);
             var activeItem = tabsEditor.querySelector(activeItemSelector);
 
-            Coral.commons.ready(childrenEditor, function() {
-                updateActiveSelect(childrenEditor, activeSelect, activeItem);
-            });
+            if (childrenEditor && activeSelect && activeItem) {
+                Coral.commons.ready(childrenEditor, function() {
+                    updateActiveSelect(childrenEditor, activeSelect, activeItem);
+                });
 
-            childrenEditor.on("change", function() {
-                updateActiveSelect(childrenEditor, activeSelect, activeItem);
-            });
+                childrenEditor.on("change", function() {
+                    updateActiveSelect(childrenEditor, activeSelect, activeItem);
+                });
 
-            activeSelect.on("change", function() {
-                activeItem.value = activeSelect.value;
-            });
+                activeSelect.on("change", function() {
+                    activeItem.value = activeSelect.value;
+                });
+            }
         }
     });
 


### PR DESCRIPTION
- ensure the children editor works if the properties tab and its elements aren't available

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #618` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      |
| Documentation Provided   | (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
