### PR TITLE
[Download] Clean up output markup

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
@@ -58,11 +58,13 @@ The following JCR properties are used:
 BLOCK cmp-download
     ELEMENT cmp-download__title
     ELEMENT cmp-download__description
-    ELEMENT cmp-download__metadata
-        ELEMENT cmp-download__property-label
-        ELEMENT cmp-download__property-content
+    ELEMENT cmp-download__properties
+    ELEMENT cmp-download__property
+        MOD cmp-download__property--<property>
+    ELEMENT cmp-download__property-label
+    ELEMENT cmp-download__property-content
     ELEMENT cmp-download__action
-        ELEMENT cmp-download__action-text
+    ELEMENT cmp-download__action-text
 ```
 
 ## Information

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
@@ -59,12 +59,9 @@ BLOCK cmp-download
     ELEMENT cmp-download__title
     ELEMENT cmp-download__description
     ELEMENT cmp-download__metadata
-    ELEMENT cmp-download__filename
-    ELEMENT cmp-download__size
-    ELEMENT cmp-download__format
+        ELEMENT cmp-download__property-label
+        ELEMENT cmp-download__property-content
     ELEMENT cmp-download__action
-        ELEMENT cmp-download__action-icon
-            MOD cmp-download__action-icon--<extension>
         ELEMENT cmp-download__action-text
 ```
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
@@ -21,14 +21,17 @@
         <a data-sly-unwrap="${!download.url}" href="${download.url}">${title}</a>
     </h3>
     <div class="cmp-download__description" data-sly-test.description="${download.description}">${description @ context="html"}</div>
-    <div data-sly-test="${(download.displayFilename && download.filename) || (download.displaySize && download.size) || (download.displayFormat && download.format)}"
-         class="cmp-download__metadata">
-        <span data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__filename">${download.filename}</span>
-        <span data-sly-test="${download.displaySize && download.size}" class="cmp-download__size">${download.size}</span>
-        <span data-sly-test="${download.displayFormat && download.format}" class="cmp-download__format">${download.format}</span>
-    </div>
-    <a data-sly-unwrap="${!download.url}" class="cmp-download__action" href="${download.url}">
-        <span class="cmp-download__action-icon${download.extension ? ' cmp-download__action-icon--${download.extension}' : ''}"></span>
+    <dl class="cmp-download__metadata">
+        <dt data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__filename">${'Filename' @ i18n}</dt>
+        <dd data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__filename">${download.filename}</dd>
+        <dt data-sly-test="${download.displaySize && download.size}" class="cmp-download__size">${'Size' @ i18n}</dt>
+        <dd data-sly-test="${download.displaySize && download.size}" class="cmp-download__size">${download.size}</dd>
+        <dt data-sly-test="${download.displayFormat && download.format}" class="cmp-download__format">${'Format' @ i18n}</dt>
+        <dd data-sly-test="${download.displayFormat && download.format}" class="cmp-download__format">
+            <span class="cmp-download__icon${download.extension ? ' cmp-download__icon-' : ''}${download.extension}"></span>${download.format}
+        </dd>
+    </dl>
+    <a data-sly-test="${download.url && download.actionText}" class="cmp-download__action" href="${download.url}">
         <span class="cmp-download__action-text">${download.actionText}</span>
     </a>
 </div>

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
@@ -21,13 +21,19 @@
         <a data-sly-unwrap="${!download.url}" href="${download.url}">${title}</a>
     </h3>
     <div class="cmp-download__description" data-sly-test.description="${download.description}">${description @ context="html"}</div>
-    <dl data-sly-test="${(download.displayFilename && download.filename) || (download.displaySize && download.size) || (download.displayFormat && download.format)}" class="cmp-download__metadata">
-        <dt data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__property-label">${'Filename' @ i18n}</dt>
-        <dd data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__property-content">${download.filename}</dd>
-        <dt data-sly-test="${download.displaySize && download.size}" class="cmp-download__property-label">${'Size' @ i18n}</dt>
-        <dd data-sly-test="${download.displaySize && download.size}" class="cmp-download__property-content">${download.size}</dd>
-        <dt data-sly-test="${download.displayFormat && download.format}" class="cmp-download__property-label">${'Format' @ i18n}</dt>
-        <dd data-sly-test="${download.displayFormat && download.format}" class="cmp-download__property-content">${download.format}</dd>
+    <dl data-sly-test="${(download.displayFilename && download.filename) || (download.displaySize && download.size) || (download.displayFormat && download.format)}" class="cmp-download__properties">
+        <div data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__property cmp-download__property--filename">
+            <dt class="cmp-download__property-label">${'Filename' @ i18n}</dt>
+            <dd class="cmp-download__property-content">${download.filename}</dd>
+        </div>
+        <div data-sly-test="${download.displaySize && download.size}" class="cmp-download__property cmp-download__property--size">
+            <dt class="cmp-download__property-label">${'Size' @ i18n}</dt>
+            <dd class="cmp-download__property-content">${download.size}</dd>
+        </div>
+        <div data-sly-test="${download.displayFormat && download.format}" class="cmp-download__property cmp-download__property--format">
+            <dt class="cmp-download__property-label">${'Format' @ i18n}</dt>
+            <dd class="cmp-download__property-content">${download.format}</dd>
+        </div>
     </dl>
     <a data-sly-test="${download.url && download.actionText}" class="cmp-download__action" href="${download.url}">
         <span class="cmp-download__action-text">${download.actionText}</span>

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
@@ -21,15 +21,13 @@
         <a data-sly-unwrap="${!download.url}" href="${download.url}">${title}</a>
     </h3>
     <div class="cmp-download__description" data-sly-test.description="${download.description}">${description @ context="html"}</div>
-    <dl class="cmp-download__metadata">
-        <dt data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__filename">${'Filename' @ i18n}</dt>
-        <dd data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__filename">${download.filename}</dd>
-        <dt data-sly-test="${download.displaySize && download.size}" class="cmp-download__size">${'Size' @ i18n}</dt>
-        <dd data-sly-test="${download.displaySize && download.size}" class="cmp-download__size">${download.size}</dd>
-        <dt data-sly-test="${download.displayFormat && download.format}" class="cmp-download__format">${'Format' @ i18n}</dt>
-        <dd data-sly-test="${download.displayFormat && download.format}" class="cmp-download__format">
-            <span class="cmp-download__icon${download.extension ? ' cmp-download__icon-' : ''}${download.extension}"></span>${download.format}
-        </dd>
+    <dl data-sly-test="${(download.displayFilename && download.filename) || (download.displaySize && download.size) || (download.displayFormat && download.format)}" class="cmp-download__metadata">
+        <dt data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__property-label">${'Filename' @ i18n}</dt>
+        <dd data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__property-content">${download.filename}</dd>
+        <dt data-sly-test="${download.displaySize && download.size}" class="cmp-download__property-label">${'Size' @ i18n}</dt>
+        <dd data-sly-test="${download.displaySize && download.size}" class="cmp-download__property-content">${download.size}</dd>
+        <dt data-sly-test="${download.displayFormat && download.format}" class="cmp-download__property-label">${'Format' @ i18n}</dt>
+        <dd data-sly-test="${download.displayFormat && download.format}" class="cmp-download__property-content">${download.format}</dd>
     </dl>
     <a data-sly-test="${download.url && download.actionText}" class="cmp-download__action" href="${download.url}">
         <span class="cmp-download__action-text">${download.actionText}</span>


### PR DESCRIPTION
- don't display action text markup if action text or download url is empty
- display metadata as description list element
- display download icon as part of the metadata