### PR TITLE
[Download] Markup cleanup adjustments

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
@@ -58,11 +58,13 @@ The following JCR properties are used:
 BLOCK cmp-download
     ELEMENT cmp-download__title
     ELEMENT cmp-download__description
-    ELEMENT cmp-download__metadata
-        ELEMENT cmp-download__property-label
-        ELEMENT cmp-download__property-content
+    ELEMENT cmp-download__properties
+    ELEMENT cmp-download__property
+        MOD cmp-download__property--<property>
+    ELEMENT cmp-download__property-label
+    ELEMENT cmp-download__property-content
     ELEMENT cmp-download__action
-        ELEMENT cmp-download__action-text
+    ELEMENT cmp-download__action-text
 ```
 
 ## Information

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
@@ -21,13 +21,19 @@
         <a data-sly-unwrap="${!download.url}" href="${download.url}">${title}</a>
     </h3>
     <div class="cmp-download__description" data-sly-test.description="${download.description}">${description @ context="html"}</div>
-    <dl data-sly-test="${(download.displayFilename && download.filename) || (download.displaySize && download.size) || (download.displayFormat && download.format)}" class="cmp-download__metadata">
-        <dt data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__property-label">${'Filename' @ i18n}</dt>
-        <dd data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__property-content">${download.filename}</dd>
-        <dt data-sly-test="${download.displaySize && download.size}" class="cmp-download__property-label">${'Size' @ i18n}</dt>
-        <dd data-sly-test="${download.displaySize && download.size}" class="cmp-download__property-content">${download.size}</dd>
-        <dt data-sly-test="${download.displayFormat && download.format}" class="cmp-download__property-label">${'Format' @ i18n}</dt>
-        <dd data-sly-test="${download.displayFormat && download.format}" class="cmp-download__property-content">${download.format}</dd>
+    <dl data-sly-test="${(download.displayFilename && download.filename) || (download.displaySize && download.size) || (download.displayFormat && download.format)}" class="cmp-download__properties">
+        <div data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__property cmp-download__property--filename">
+            <dt class="cmp-download__property-label">${'Filename' @ i18n}</dt>
+            <dd class="cmp-download__property-content">${download.filename}</dd>
+        </div>
+        <div data-sly-test="${download.displaySize && download.size}" class="cmp-download__property cmp-download__property--size">
+            <dt class="cmp-download__property-label">${'Size' @ i18n}</dt>
+            <dd class="cmp-download__property-content">${download.size}</dd>
+        </div>
+        <div data-sly-test="${download.displayFormat && download.format}" class="cmp-download__property cmp-download__property--format">
+            <dt class="cmp-download__property-label">${'Format' @ i18n}</dt>
+            <dd class="cmp-download__property-content">${download.format}</dd>
+        </div>
     </dl>
     <a data-sly-test="${download.url && download.actionText}" class="cmp-download__action" href="${download.url}">
         <span class="cmp-download__action-text">${download.actionText}</span>


### PR DESCRIPTION
@bpauli, some changes on top of your pull request. I wrapped each property, it allows us to add the modifier for the property type (`cmp-download__property--filename` etc.) as you initially had it, and is also consistent with the content fragment markup approach. divs wrapping dt, dd is valid.
