### PR TITLE
[Theme] Add simple accordion, breadcrumb, button, download styling.

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/README.md
@@ -48,6 +48,7 @@ CSS styling. It should be added to a relevant site client library using the `emb
 BLOCK cmp-breadcrumb
     ELEMENT cmp-breadcrumb__list
     ELEMENT cmp-breadcrumb__item
+        MOD cmp-breadcrumb__item--active
     ELEMENT cmp-breadcrumb__item-link
 ```
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
@@ -56,6 +56,7 @@ The following JCR properties are used:
 ```
 BLOCK cmp-download
     ELEMENT cmp-download__title
+    ELEMENT cmp-download__title-link
     ELEMENT cmp-download__description
     ELEMENT cmp-download__metadata
     ELEMENT cmp-download__filename

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
@@ -18,7 +18,7 @@
      data-sly-test.hasContent="${download.title || download.description || download.actionText}"
      class="cmp-download${!wcmmode.disabled ? ' cq-dd-file' : ''}">
     <h3 class="cmp-download__title" data-sly-test.title="${download.title}" data-sly-element="${download.titleType}">
-        <a data-sly-unwrap="${!download.url}" href="${download.url}">${title}</a>
+        <a data-sly-unwrap="${!download.url}" class="cmp-download__title-link" href="${download.url}">${title}</a>
     </h3>
     <div class="cmp-download__description" data-sly-test.description="${download.description}">${description @ context="html"}</div>
     <div data-sly-test="${(download.displayFilename && download.filename) || (download.displaySize && download.size) || (download.displayFormat && download.format)}"

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/accordion/base.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/accordion/base.less
@@ -1,0 +1,88 @@
+/*
+ *  Copyright 2019 Adobe Systems Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+.t-cmp-clean {
+    .cmp-accordion {
+        display: block;
+        margin: 0;
+        padding: 0;
+    }
+
+    .cmp-accordion__item {
+        position: relative;
+    }
+
+    .cmp-accordion__header {
+        font: inherit;
+    }
+
+    .cmp-accordion__button {
+        position: relative;
+
+        border: none;
+        border-bottom: 1*@px solid;
+        padding: 8*@px 0;
+
+        background: none;
+        color: inherit;
+        font: inherit;
+        cursor: pointer;
+        outline: inherit;
+
+        &--expanded {
+            .cmp-accordion__icon {
+                &:before {
+                    content: 'expand_more';
+                }
+            }
+        }
+
+        &--disabled {
+            cursor: default;
+        }
+    }
+
+    .cmp-accordion__icon {
+        &:before {
+            content: 'chevron_right';
+
+            position: absolute;
+            top: 10*@px;
+            right: 8*@px;
+
+            font-family: 'Material Icons';
+            font-weight: normal;
+            font-style: normal;
+            font-size: 18*@px;
+
+            line-height: 1;
+            text-transform: none;
+            letter-spacing: normal;
+            word-wrap: normal;
+            white-space: nowrap;
+            direction: ltr;
+
+            -webkit-font-smoothing: antialiased;
+            text-rendering: optimizeLegibility;
+            -moz-osx-font-smoothing: grayscale;
+            font-feature-settings: 'liga';
+        }
+    }
+
+    .cmp-accordion__panel {
+        padding: 12*@px 0;
+    }
+}

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/accordion/dark.skin.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/accordion/dark.skin.less
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2019 Adobe Systems Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+@cmp-clean-dark-accordion-button-border-color: @cmp-clean-color-gray-700;
+@cmp-clean-dark-accordion-button-color: @cmp-clean-color-gray-400;
+@cmp-clean-dark-accordion-button-expanded-color: @cmp-clean-color-gray-100;
+@cmp-clean-dark-accordion-button-hover-color: @cmp-clean-color-gray-100;
+
+.t-cmp-clean--dark {
+    .cmp-accordion__button {
+        border-color: @cmp-clean-dark-accordion-button-border-color;
+        color: @cmp-clean-dark-accordion-button-color;
+
+        &--expanded {
+            color: @cmp-clean-dark-accordion-button-expanded-color;
+        }
+
+        &:hover {
+            color: @cmp-clean-dark-accordion-button-hover-color;
+        }
+    }
+}

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/accordion/index.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/accordion/index.less
@@ -14,15 +14,6 @@
  *  limitations under the License.
  */
 
-@import 'accordion/index.less';
-@import 'breadcrumb/index.less';
-@import 'button/index.less';
-@import 'carousel/index.less';
-@import 'download/index.less';
-@import 'image/index.less';
-@import 'list/index.less';
-@import 'separator/index.less';
-@import 'tabs/index.less';
-@import 'teaser/index.less';
-@import 'text/index.less';
-@import 'title/index.less';
+@import 'base.less';
+@import 'light.skin.less';
+@import 'dark.skin.less';

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/accordion/light.skin.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/accordion/light.skin.less
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2019 Adobe Systems Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+@cmp-clean-light-accordion-button-border-color: @cmp-clean-color-gray-300;
+@cmp-clean-light-accordion-button-color: @cmp-clean-color-gray-600;
+@cmp-clean-light-accordion-button-expanded-color: @cmp-clean-color-gray-900;
+@cmp-clean-light-accordion-button-hover-color: @cmp-clean-color-gray-900;
+
+.t-cmp-clean--light {
+    .cmp-accordion__button {
+        border-color: @cmp-clean-light-accordion-button-border-color;
+        color: @cmp-clean-light-accordion-button-color;
+
+        &--expanded {
+            color: @cmp-clean-light-accordion-button-expanded-color;
+        }
+
+        &:hover {
+            color: @cmp-clean-light-accordion-button-hover-color;
+        }
+    }
+}

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/base.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/base.less
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2019 Adobe Systems Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+.t-cmp-clean {
+    .cmp-breadcrumb {
+        display: inline-block;
+    }
+
+    .cmp-breadcrumb__list {
+        margin: 0;
+        padding: 0;
+
+        list-style: none;
+    }
+
+    .cmp-breadcrumb__item {
+        &:after {
+            content: 'chevron_right';
+
+            display: inline-block;
+            margin: 0 4*@px;
+            vertical-align: top;
+
+            font-family: 'Material Icons';
+            font-weight: normal;
+            font-style: normal;
+            font-size: 18*@px;
+
+            line-height: 21*@px;
+            text-transform: none;
+            letter-spacing: normal;
+            word-wrap: normal;
+            white-space: nowrap;
+            direction: ltr;
+
+            -webkit-font-smoothing: antialiased;
+            text-rendering: optimizeLegibility;
+            -moz-osx-font-smoothing: grayscale;
+            font-feature-settings: 'liga';
+        }
+
+        &:last-child {
+            &:after {
+                content: none;
+            }
+        }
+    }
+
+    .cmp-breadcrumb__item-link {
+        text-decoration: none;
+    }
+}

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/dark.skin.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/dark.skin.less
@@ -14,15 +14,22 @@
  *  limitations under the License.
  */
 
-@import 'accordion/index.less';
-@import 'breadcrumb/index.less';
-@import 'button/index.less';
-@import 'carousel/index.less';
-@import 'download/index.less';
-@import 'image/index.less';
-@import 'list/index.less';
-@import 'separator/index.less';
-@import 'tabs/index.less';
-@import 'teaser/index.less';
-@import 'text/index.less';
-@import 'title/index.less';
+@cmp-clean-dark-breadcrumb-separator-color: @cmp-clean-color-gray-400;
+@cmp-clean-dark-breadcrumb-item-link-color: @cmp-clean-color-gray-400;
+@cmp-clean-dark-breadcrumb-item-link-hover-color: @cmp-clean-color-gray-100;
+
+.t-cmp-clean--dark {
+    .cmp-breadcrumb__item {
+        &:after {
+            color: @cmp-clean-dark-breadcrumb-separator-color;
+        }
+    }
+
+    .cmp-breadcrumb__item-link {
+        color: @cmp-clean-dark-breadcrumb-item-link-color;
+
+        &:hover {
+            color: @cmp-clean-dark-breadcrumb-item-link-hover-color;
+        }
+    }
+}

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/index.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/index.less
@@ -14,15 +14,6 @@
  *  limitations under the License.
  */
 
-@import 'accordion/index.less';
-@import 'breadcrumb/index.less';
-@import 'button/index.less';
-@import 'carousel/index.less';
-@import 'download/index.less';
-@import 'image/index.less';
-@import 'list/index.less';
-@import 'separator/index.less';
-@import 'tabs/index.less';
-@import 'teaser/index.less';
-@import 'text/index.less';
-@import 'title/index.less';
+@import 'base.less';
+@import 'light.skin.less';
+@import 'dark.skin.less';

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/light.skin.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/light.skin.less
@@ -14,15 +14,24 @@
  *  limitations under the License.
  */
 
-@import 'accordion/index.less';
-@import 'breadcrumb/index.less';
-@import 'button/index.less';
-@import 'carousel/index.less';
-@import 'download/index.less';
-@import 'image/index.less';
-@import 'list/index.less';
-@import 'separator/index.less';
-@import 'tabs/index.less';
-@import 'teaser/index.less';
-@import 'text/index.less';
-@import 'title/index.less';
+@cmp-clean-light-breadcrumb-separator-color: @cmp-clean-color-gray-600;
+@cmp-clean-light-breadcrumb-item-link-color: @cmp-clean-color-gray-600;
+@cmp-clean-light-breadcrumb-item-link-hover-color: @cmp-clean-color-gray-900;
+
+.t-cmp-clean--light {
+    .cmp-breadcrumb__item {
+        &:after {
+            color: @cmp-clean-light-breadcrumb-separator-color;
+        }
+    }
+
+    .cmp-breadcrumb__item-link {
+        color: @cmp-clean-light-breadcrumb-item-link-color;
+
+        &:hover {
+            color: @cmp-clean-light-breadcrumb-item-link-hover-color;
+        }
+    }
+
+
+}

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/button/base.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/button/base.less
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2019 Adobe Systems Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+.t-cmp-clean {
+    .cmp-button {
+        display: inline-block;
+        padding: 5*@px 7*@px;
+        border: 2*@px solid;
+        border-radius: 3*@px;
+
+        font-size: 10*@px;
+        font-weight: bold;
+        text-transform: uppercase;
+        text-decoration: none;
+        cursor: pointer;
+        background: none;
+    }
+
+    .cmp-button__text {
+        display: inline-block;
+        vertical-align: top;
+        line-height: @cmp-clean-line-height;
+    }
+
+    .cmp-button__icon {
+        &:before {
+            display: inline-block;
+            margin-right: 6*@px;
+            vertical-align: top;
+
+            font-family: 'Material Icons';
+            font-weight: normal;
+            font-style: normal;
+            font-size: 15*@px;
+
+            line-height: 1;
+            text-transform: none;
+            letter-spacing: normal;
+            word-wrap: normal;
+            white-space: nowrap;
+            direction: ltr;
+
+            -webkit-font-smoothing: antialiased;
+            text-rendering: optimizeLegibility;
+            -moz-osx-font-smoothing: grayscale;
+            font-feature-settings: 'liga';
+        }
+    }
+
+    .cmp-button__icon--email {
+        &:before {
+            content: 'email';
+        }
+    }
+
+    @media @cmp-examples-screen-s-min {
+        .cmp-button {
+            padding: 8*@px 18*@px;
+            font-size: 12*@px;
+        }
+
+        .cmp-button__icon {
+            &:before {
+                font-size: 18*@px;
+            }
+        }
+    }
+}

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/button/dark.skin.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/button/dark.skin.less
@@ -14,15 +14,19 @@
  *  limitations under the License.
  */
 
-@import 'accordion/index.less';
-@import 'breadcrumb/index.less';
-@import 'button/index.less';
-@import 'carousel/index.less';
-@import 'download/index.less';
-@import 'image/index.less';
-@import 'list/index.less';
-@import 'separator/index.less';
-@import 'tabs/index.less';
-@import 'teaser/index.less';
-@import 'text/index.less';
-@import 'title/index.less';
+@cmp-clean-dark-button-border-color: @cmp-clean-color-gray-300;
+@cmp-clean-dark-button-color: @cmp-clean-color-gray-300;
+@cmp-clean-dark-button-hover-border-color: @cmp-clean-color-white;
+@cmp-clean-dark-button-hover-color: @cmp-clean-color-white;
+
+.t-cmp-clean--dark {
+    .cmp-button {
+        border-color: @cmp-clean-dark-button-border-color;
+        color: @cmp-clean-dark-button-color;
+
+        &:hover {
+            border-color: @cmp-clean-dark-button-hover-border-color;
+            color: @cmp-clean-dark-button-hover-color;
+        }
+    }
+}

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/button/index.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/button/index.less
@@ -14,15 +14,6 @@
  *  limitations under the License.
  */
 
-@import 'accordion/index.less';
-@import 'breadcrumb/index.less';
-@import 'button/index.less';
-@import 'carousel/index.less';
-@import 'download/index.less';
-@import 'image/index.less';
-@import 'list/index.less';
-@import 'separator/index.less';
-@import 'tabs/index.less';
-@import 'teaser/index.less';
-@import 'text/index.less';
-@import 'title/index.less';
+@import 'base.less';
+@import 'light.skin.less';
+@import 'dark.skin.less';

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/button/light.skin.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/button/light.skin.less
@@ -14,15 +14,19 @@
  *  limitations under the License.
  */
 
-@import 'accordion/index.less';
-@import 'breadcrumb/index.less';
-@import 'button/index.less';
-@import 'carousel/index.less';
-@import 'download/index.less';
-@import 'image/index.less';
-@import 'list/index.less';
-@import 'separator/index.less';
-@import 'tabs/index.less';
-@import 'teaser/index.less';
-@import 'text/index.less';
-@import 'title/index.less';
+@cmp-clean-light-button-border-color: @cmp-clean-color-gray-600;
+@cmp-clean-light-button-color: @cmp-clean-color-gray-600;
+@cmp-clean-light-button-hover-border-color: @cmp-clean-color-gray-900;
+@cmp-clean-light-button-hover-color: @cmp-clean-color-gray-900;
+
+.t-cmp-clean--light {
+    .cmp-button {
+        border-color: @cmp-clean-light-button-border-color;
+        color: @cmp-clean-light-button-color;
+
+        &:hover {
+            border-color: @cmp-clean-light-button-hover-border-color;
+            color: @cmp-clean-light-button-hover-color;
+        }
+    }
+}

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/download/base.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/download/base.less
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2019 Adobe Systems Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+.t-cmp-clean {
+    .cmp-download {
+        position: relative;
+
+        display: inline-block;
+        border: 1*@px solid;
+        border-radius: 3*@px;
+        padding: 18*@px;
+        overflow: hidden;
+    }
+
+    .cmp-download__title {
+        margin: 0 0 8*@px 0;
+    }
+
+    .cmp-download__title-link {
+        text-decoration: none;
+    }
+
+    .cmp-download__description {
+        margin: 0 0 18*@px 0;
+
+        p {
+            margin: 0;
+            padding: 0;
+        }
+    }
+
+    .cmp-download__properties {
+        margin: 0 0 18*@px 0;
+    }
+
+    .cmp-download__property {
+        display: inline-block;
+        margin-right: 4*@px;
+        border-radius: 3*@px;
+        padding: 4*@px 8*@px;
+    }
+
+    .cmp-download__property-label {
+        display: none;
+    }
+
+    .cmp-download__property-content {
+        margin: 0;
+    }
+
+    .cmp-download__action {
+        display: inline-block;
+        padding: 5*@px 7*@px;
+        border: 2*@px solid;
+        border-radius: 3*@px;
+
+        font-size: 10*@px;
+        font-weight: bold;
+        text-transform: uppercase;
+        text-decoration: none;
+        cursor: pointer;
+        background: none;
+    }
+
+    .cmp-button__action-text {
+        display: inline-block;
+        vertical-align: top;
+        line-height: @cmp-clean-line-height;
+    }
+
+    @media @cmp-examples-screen-s-min {
+        .cmp-download__action {
+            padding: 8*@px 18*@px;
+            font-size: 12*@px;
+        }
+    }
+}

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/download/index.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/download/index.less
@@ -14,15 +14,5 @@
  *  limitations under the License.
  */
 
-@import 'accordion/index.less';
-@import 'breadcrumb/index.less';
-@import 'button/index.less';
-@import 'carousel/index.less';
-@import 'download/index.less';
-@import 'image/index.less';
-@import 'list/index.less';
-@import 'separator/index.less';
-@import 'tabs/index.less';
-@import 'teaser/index.less';
-@import 'text/index.less';
-@import 'title/index.less';
+@import 'base.less';
+@import 'light.skin.less';

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/download/light.skin.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/download/light.skin.less
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2019 Adobe Systems Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+@cmp-clean-light-download-border-color: @cmp-clean-color-gray-300;
+@cmp-clean-light-download-property-color: @cmp-clean-color-gray-600;
+@cmp-clean-light-download-property-background-color: @cmp-clean-color-gray-200;
+@cmp-clean-light-download-action-border-color: @cmp-clean-color-gray-600;
+@cmp-clean-light-download-action-color: @cmp-clean-color-gray-600;
+@cmp-clean-light-download-action-hover-border-color: @cmp-clean-color-gray-900;
+@cmp-clean-light-download-action-hover-color: @cmp-clean-color-gray-900;
+
+
+.t-cmp-clean--light {
+    .cmp-download {
+        border-color: @cmp-clean-light-download-border-color;
+    }
+
+    .cmp-download__property {
+        color: @cmp-clean-light-download-property-color;
+        background-color: @cmp-clean-light-download-property-background-color;
+    }
+
+    .cmp-download__action {
+        border-color: @cmp-clean-light-download-action-border-color;
+        color: @cmp-clean-light-download-action-color;
+
+        &:hover {
+            border-color: @cmp-clean-light-download-action-hover-border-color;
+            color: @cmp-clean-light-download-action-hover-color;
+        }
+    }
+}

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/tabs/light.skin.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/tabs/light.skin.less
@@ -22,19 +22,19 @@
 
 .t-cmp-clean--light {
     .cmp-tabs__tablist {
-        border-color: @cmp-clean-color-gray-300;
+        border-color: @cmp-clean-light-tabs-tablist-border-color;
     }
 
     .cmp-tabs__tab {
-        color: @cmp-clean-color-gray-600;
+        color: @cmp-clean-light-tabs-tab-color;
 
         &--active {
-            border-color: @cmp-clean-color-gray-900;
-            color: @cmp-clean-color-gray-900;
+            border-color: @cmp-clean-light-tabs-tab-active-border-color;
+            color: @cmp-clean-light-tabs-tab-active-color;
         }
 
         &:hover {
-            color: @cmp-clean-color-gray-900;
+            color: @cmp-clean-light-tabs-tab-hover-color;
         }
     }
 }

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/teaser/base.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/teaser/base.less
@@ -65,7 +65,7 @@
 
     .cmp-teaser__action-link {
         display: inline-block;
-        margin: 10*@px 3*@px  0 0;
+        margin: 10*@px 3*@px 0 0;
         padding: 5*@px 7*@px;
         border: 2*@px solid;
         border-radius: 3*@px;

--- a/examples/src/content/jcr_root/content/core-components-examples/library/accordion/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/accordion/.content.xml
@@ -353,51 +353,39 @@
                             jcr:primaryType="nt:unstructured"
                             sling:resourceType="core/wcm/components/accordion/v1/accordion"
                             expandedItems="[item_617130698]">
-                            <item_617130698
+                            <text
                                 cq:panelTitle="Item 1"
+                                jcr:created="{Date}2018-12-07T13:12:23.990+01:00"
+                                jcr:createdBy="admin"
+                                jcr:lastModified="{Date}2019-01-22T12:45:56.367+01:00"
+                                jcr:lastModifiedBy="admin"
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Item 1"
-                                sling:resourceType="wcm/foundation/components/responsivegrid">
-                                <text
-                                    jcr:created="{Date}2018-12-07T13:12:23.990+01:00"
-                                    jcr:createdBy="admin"
-                                    jcr:lastModified="{Date}2019-01-22T12:45:56.367+01:00"
-                                    jcr:lastModifiedBy="admin"
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/text/v2/text"
-                                    text="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eu mi bibendum neque egestas congue quisque egestas. Varius morbi enim nunc faucibus a pellentesque. Scelerisque eleifend donec pretium vulputate sapien nec sagittis.&lt;/p>&#xa;"
-                                    textIsRich="true"/>
-                            </item_617130698>
-                            <item_779036566
+                                sling:resourceType="core/wcm/components/text/v2/text"
+                                text="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eu mi bibendum neque egestas congue quisque egestas. Varius morbi enim nunc faucibus a pellentesque. Scelerisque eleifend donec pretium vulputate sapien nec sagittis.&lt;/p>&#xa;"
+                                textIsRich="true"/>
+                            <text_397543178
                                 cq:panelTitle="Item 2"
+                                jcr:created="{Date}2018-12-07T13:13:32.541+01:00"
+                                jcr:createdBy="admin"
+                                jcr:lastModified="{Date}2019-01-22T12:46:55.365+01:00"
+                                jcr:lastModifiedBy="admin"
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Item 2"
-                                sling:resourceType="wcm/foundation/components/responsivegrid">
-                                <text
-                                    jcr:created="{Date}2018-12-07T13:13:32.541+01:00"
-                                    jcr:createdBy="admin"
-                                    jcr:lastModified="{Date}2019-01-22T12:46:55.365+01:00"
-                                    jcr:lastModifiedBy="admin"
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/text/v2/text"
-                                    text="&lt;p>Hac habitasse platea dictumst quisque sagittis purus. At risus viverra adipiscing at in tellus integer. Sit amet consectetur adipiscing elit duis tristique sollicitudin. Leo vel orci porta non pulvinar neque laoreet suspendisse. Volutpat diam ut venenatis tellus in metus vulputate eu.&lt;/p>&#xa;"
-                                    textIsRich="true"/>
-                            </item_779036566>
-                            <item_770673778
+                                sling:resourceType="core/wcm/components/text/v2/text"
+                                text="&lt;p>Hac habitasse platea dictumst quisque sagittis purus. At risus viverra adipiscing at in tellus integer. Sit amet consectetur adipiscing elit duis tristique sollicitudin. Leo vel orci porta non pulvinar neque laoreet suspendisse. Volutpat diam ut venenatis tellus in metus vulputate eu.&lt;/p>&#xa;"
+                                textIsRich="true"/>
+                            <text_397543177
                                 cq:panelTitle="Item 3"
+                                jcr:created="{Date}2018-12-07T13:13:55.658+01:00"
+                                jcr:createdBy="admin"
+                                jcr:lastModified="{Date}2019-01-22T12:47:15.841+01:00"
+                                jcr:lastModifiedBy="admin"
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Item 3"
-                                sling:resourceType="wcm/foundation/components/responsivegrid">
-                                <text
-                                    jcr:created="{Date}2018-12-07T13:13:55.658+01:00"
-                                    jcr:createdBy="admin"
-                                    jcr:lastModified="{Date}2019-01-22T12:47:15.841+01:00"
-                                    jcr:lastModifiedBy="admin"
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/text/v2/text"
-                                    text="&lt;p>Libero id faucibus nisl tincidunt eget nullam non nisi. Hac habitasse platea dictumst vestibulum. Viverra orci sagittis eu volutpat odio facilisis mauris. Velit aliquet sagittis id consectetur purus ut. Orci phasellus egestas tellus rutrum tellus pellentesque eu tincidunt.&lt;/p>&#xa;"
-                                    textIsRich="true"/>
-                            </item_770673778>
+                                sling:resourceType="core/wcm/components/text/v2/text"
+                                text="&lt;p>Libero id faucibus nisl tincidunt eget nullam non nisi. Hac habitasse platea dictumst vestibulum. Viverra orci sagittis eu volutpat odio facilisis mauris. Velit aliquet sagittis id consectetur purus ut. Orci phasellus egestas tellus rutrum tellus pellentesque eu tincidunt.&lt;/p>&#xa;"
+                                textIsRich="true"/>
                         </accordion>
                     </component>
                     <info
@@ -458,51 +446,39 @@
                             jcr:primaryType="nt:unstructured"
                             sling:resourceType="core/wcm/components/accordion/v1/accordion"
                             expandedItems="[item_617130698,item_779036566,item_770673778]">
-                            <item_617130698
+                            <text
                                 cq:panelTitle="Item 1"
-                                jcr:primaryType="nt:unstructured"
+                                jcr:created="{Date}2018-12-07T13:12:23.990+01:00"
+                                jcr:createdBy="admin"
+                                jcr:lastModified="{Date}2019-01-22T12:45:56.367+01:00"
+                                jcr:lastModifiedBy="admin"
                                 jcr:title="Item 1"
-                                sling:resourceType="wcm/foundation/components/responsivegrid">
-                                <text
-                                    jcr:created="{Date}2018-12-07T13:12:23.990+01:00"
-                                    jcr:createdBy="admin"
-                                    jcr:lastModified="{Date}2019-01-22T12:45:56.367+01:00"
-                                    jcr:lastModifiedBy="admin"
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/text/v2/text"
-                                    text="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eu mi bibendum neque egestas congue quisque egestas. Varius morbi enim nunc faucibus a pellentesque. Scelerisque eleifend donec pretium vulputate sapien nec sagittis.&lt;/p>&#xa;"
-                                    textIsRich="true"/>
-                            </item_617130698>
-                            <item_779036566
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="core/wcm/components/text/v2/text"
+                                text="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eu mi bibendum neque egestas congue quisque egestas. Varius morbi enim nunc faucibus a pellentesque. Scelerisque eleifend donec pretium vulputate sapien nec sagittis.&lt;/p>&#xa;"
+                                textIsRich="true"/>
+                            <text_397543155
                                 cq:panelTitle="Item 2"
+                                jcr:created="{Date}2018-12-07T13:13:32.541+01:00"
+                                jcr:createdBy="admin"
+                                jcr:lastModified="{Date}2019-01-22T12:46:55.365+01:00"
+                                jcr:lastModifiedBy="admin"
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Item 2"
-                                sling:resourceType="wcm/foundation/components/responsivegrid">
-                                <text
-                                    jcr:created="{Date}2018-12-07T13:13:32.541+01:00"
-                                    jcr:createdBy="admin"
-                                    jcr:lastModified="{Date}2019-01-22T12:46:55.365+01:00"
-                                    jcr:lastModifiedBy="admin"
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/text/v2/text"
-                                    text="&lt;p>Hac habitasse platea dictumst quisque sagittis purus. At risus viverra adipiscing at in tellus integer. Sit amet consectetur adipiscing elit duis tristique sollicitudin. Leo vel orci porta non pulvinar neque laoreet suspendisse. Volutpat diam ut venenatis tellus in metus vulputate eu.&lt;/p>&#xa;"
-                                    textIsRich="true"/>
-                            </item_779036566>
-                            <item_770673778
+                                sling:resourceType="core/wcm/components/text/v2/text"
+                                text="&lt;p>Hac habitasse platea dictumst quisque sagittis purus. At risus viverra adipiscing at in tellus integer. Sit amet consectetur adipiscing elit duis tristique sollicitudin. Leo vel orci porta non pulvinar neque laoreet suspendisse. Volutpat diam ut venenatis tellus in metus vulputate eu.&lt;/p>&#xa;"
+                                textIsRich="true"/>
+                            <text_397543156
                                 cq:panelTitle="Item 3"
+                                jcr:created="{Date}2018-12-07T13:13:55.658+01:00"
+                                jcr:createdBy="admin"
+                                jcr:lastModified="{Date}2019-01-22T12:47:15.841+01:00"
+                                jcr:lastModifiedBy="admin"
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Item 3"
-                                sling:resourceType="wcm/foundation/components/responsivegrid">
-                                <text
-                                    jcr:created="{Date}2018-12-07T13:13:55.658+01:00"
-                                    jcr:createdBy="admin"
-                                    jcr:lastModified="{Date}2019-01-22T12:47:15.841+01:00"
-                                    jcr:lastModifiedBy="admin"
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/text/v2/text"
-                                    text="&lt;p>Libero id faucibus nisl tincidunt eget nullam non nisi. Hac habitasse platea dictumst vestibulum. Viverra orci sagittis eu volutpat odio facilisis mauris. Velit aliquet sagittis id consectetur purus ut. Orci phasellus egestas tellus rutrum tellus pellentesque eu tincidunt.&lt;/p>&#xa;"
-                                    textIsRich="true"/>
-                            </item_770673778>
+                                sling:resourceType="core/wcm/components/text/v2/text"
+                                text="&lt;p>Libero id faucibus nisl tincidunt eget nullam non nisi. Hac habitasse platea dictumst vestibulum. Viverra orci sagittis eu volutpat odio facilisis mauris. Velit aliquet sagittis id consectetur purus ut. Orci phasellus egestas tellus rutrum tellus pellentesque eu tincidunt.&lt;/p>&#xa;"
+                                textIsRich="true"/>
                         </accordion>
                     </component>
                     <info
@@ -564,51 +540,39 @@
                             sling:resourceType="core/wcm/components/accordion/v1/accordion"
                             expandedItems="[item_617130698]"
                             singleExpansion="{Boolean}true">
-                            <item_617130698
+                            <text
                                 cq:panelTitle="Item 1"
+                                jcr:created="{Date}2018-12-07T13:12:23.990+01:00"
+                                jcr:createdBy="admin"
+                                jcr:lastModified="{Date}2019-01-22T12:45:56.367+01:00"
+                                jcr:lastModifiedBy="admin"
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Item 1"
-                                sling:resourceType="wcm/foundation/components/responsivegrid">
-                                <text
-                                    jcr:created="{Date}2018-12-07T13:12:23.990+01:00"
-                                    jcr:createdBy="admin"
-                                    jcr:lastModified="{Date}2019-01-22T12:45:56.367+01:00"
-                                    jcr:lastModifiedBy="admin"
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/text/v2/text"
-                                    text="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eu mi bibendum neque egestas congue quisque egestas. Varius morbi enim nunc faucibus a pellentesque. Scelerisque eleifend donec pretium vulputate sapien nec sagittis.&lt;/p>&#xa;"
-                                    textIsRich="true"/>
-                            </item_617130698>
-                            <item_779036566
+                                sling:resourceType="core/wcm/components/text/v2/text"
+                                text="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eu mi bibendum neque egestas congue quisque egestas. Varius morbi enim nunc faucibus a pellentesque. Scelerisque eleifend donec pretium vulputate sapien nec sagittis.&lt;/p>&#xa;"
+                                textIsRich="true"/>
+                            <text_397543144
                                 cq:panelTitle="Item 2"
+                                jcr:created="{Date}2018-12-07T13:13:32.541+01:00"
+                                jcr:createdBy="admin"
+                                jcr:lastModified="{Date}2019-01-22T12:46:55.365+01:00"
+                                jcr:lastModifiedBy="admin"
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Item 2"
-                                sling:resourceType="wcm/foundation/components/responsivegrid">
-                                <text
-                                    jcr:created="{Date}2018-12-07T13:13:32.541+01:00"
-                                    jcr:createdBy="admin"
-                                    jcr:lastModified="{Date}2019-01-22T12:46:55.365+01:00"
-                                    jcr:lastModifiedBy="admin"
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/text/v2/text"
-                                    text="&lt;p>Hac habitasse platea dictumst quisque sagittis purus. At risus viverra adipiscing at in tellus integer. Sit amet consectetur adipiscing elit duis tristique sollicitudin. Leo vel orci porta non pulvinar neque laoreet suspendisse. Volutpat diam ut venenatis tellus in metus vulputate eu.&lt;/p>&#xa;"
-                                    textIsRich="true"/>
-                            </item_779036566>
-                            <item_770673778
+                                sling:resourceType="core/wcm/components/text/v2/text"
+                                text="&lt;p>Hac habitasse platea dictumst quisque sagittis purus. At risus viverra adipiscing at in tellus integer. Sit amet consectetur adipiscing elit duis tristique sollicitudin. Leo vel orci porta non pulvinar neque laoreet suspendisse. Volutpat diam ut venenatis tellus in metus vulputate eu.&lt;/p>&#xa;"
+                                textIsRich="true"/>
+                            <text_397543145
                                 cq:panelTitle="Item 3"
+                                jcr:created="{Date}2018-12-07T13:13:55.658+01:00"
+                                jcr:createdBy="admin"
+                                jcr:lastModified="{Date}2019-01-22T12:47:15.841+01:00"
+                                jcr:lastModifiedBy="admin"
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Item 3"
-                                sling:resourceType="wcm/foundation/components/responsivegrid">
-                                <text
-                                    jcr:created="{Date}2018-12-07T13:13:55.658+01:00"
-                                    jcr:createdBy="admin"
-                                    jcr:lastModified="{Date}2019-01-22T12:47:15.841+01:00"
-                                    jcr:lastModifiedBy="admin"
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/text/v2/text"
-                                    text="&lt;p>Libero id faucibus nisl tincidunt eget nullam non nisi. Hac habitasse platea dictumst vestibulum. Viverra orci sagittis eu volutpat odio facilisis mauris. Velit aliquet sagittis id consectetur purus ut. Orci phasellus egestas tellus rutrum tellus pellentesque eu tincidunt.&lt;/p>&#xa;"
-                                    textIsRich="true"/>
-                            </item_770673778>
+                                sling:resourceType="core/wcm/components/text/v2/text"
+                                text="&lt;p>Libero id faucibus nisl tincidunt eget nullam non nisi. Hac habitasse platea dictumst vestibulum. Viverra orci sagittis eu volutpat odio facilisis mauris. Velit aliquet sagittis id consectetur purus ut. Orci phasellus egestas tellus rutrum tellus pellentesque eu tincidunt.&lt;/p>&#xa;"
+                                textIsRich="true"/>
                         </accordion>
                     </component>
                     <info

--- a/examples/src/content/jcr_root/content/core-components-examples/library/accordion/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/accordion/.content.xml
@@ -352,7 +352,7 @@
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
                             sling:resourceType="core/wcm/components/accordion/v1/accordion"
-                            expandedItems="[item_617130698]">
+                            expandedItems="[text]">
                             <text
                                 cq:panelTitle="Item 1"
                                 jcr:created="{Date}2018-12-07T13:12:23.990+01:00"
@@ -445,7 +445,7 @@
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
                             sling:resourceType="core/wcm/components/accordion/v1/accordion"
-                            expandedItems="[item_617130698,item_779036566,item_770673778]">
+                            expandedItems="[text,text_397543155,text_397543156]">
                             <text
                                 cq:panelTitle="Item 1"
                                 jcr:created="{Date}2018-12-07T13:12:23.990+01:00"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/download/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/download/.content.xml
@@ -249,7 +249,6 @@
                             actionText="Download"
                             descriptionFromAsset="false"
                             fileName="lava-into-ocean.jpg"
-                            inline="true"
                             textIsRich="true"
                             titleFromAsset="false">
                             <file/>


### PR DESCRIPTION
- adds simple styling for accordion, breadcrumb, button and download components.
- adds cmp-download__title-link element to download component and documents it.
- adds missing BEM modifier to breadcrumb docs.
- fixes download direct upload example, removing `inline` property.

### Button
<img width="179" alt="Screenshot 2019-06-18 at 15 17 56" src="https://user-images.githubusercontent.com/25616660/59685372-4f40f300-91dc-11e9-9b54-142b33739c71.png">

### Download
<img width="378" alt="Screenshot 2019-06-18 at 15 17 37" src="https://user-images.githubusercontent.com/25616660/59685373-4fd98980-91dc-11e9-8f29-0bd212c96003.png">

### Accordion
<img width="820" alt="Screenshot 2019-06-18 at 15 17 21" src="https://user-images.githubusercontent.com/25616660/59685388-57009780-91dc-11e9-9335-4ef0efd4dfa7.png">

### Breadcrumb
<img width="582" alt="Screenshot 2019-06-18 at 15 17 06" src="https://user-images.githubusercontent.com/25616660/59685389-57992e00-91dc-11e9-9a04-844d2878bf8f.png">
