### PR TITLE
@releng - Pre-release - Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To include the core components package into your own project's maven build using
      <groupId>com.adobe.cq</groupId>
      <artifactId>core.wcm.components.all</artifactId>
      <type>zip</type>
-     <version>2.4.0</version>
+     <version>2.5.0</version>
  </dependency>
  ```
 
@@ -148,7 +148,7 @@ To include the core components package into your own project using AEM Archetype
      <groupId>com.adobe.cq</groupId>
      <artifactId>core.wcm.components.all</artifactId>
      <type>zip</type>
-     <version>2.4.0</version>
+     <version>2.5.0</version>
  </dependency>
  ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The latest version of the Core Components, require the below system requirements
 
 Core Components | AEM 6.5 | AEM 6.4 | AEM 6.3 | Java
 ----------------|---------|---------|---------|------
-[2.4.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.4.0) | 6.5.0.0+ | 6.4.2.0+ | 6.3.3.0+ | 8, 11
+[2.5.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.5.0) | 6.5.0.0+ | 6.4.2.0+ | 6.3.3.0+ | 8, 11
 
 For a list of requirements for previous versions, see [Historical System Requirements](VERSIONS.md).
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@ See below for a full list of system requirements for historical versions of the 
 
 Core Components | Extension | AEM 6.5 | AEM 6.4 | AEM 6.3 | Java
 ----------------|-----------|---------|---------|---------|------
+[2.5.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.5.0) | - | 6.5.0.0+ | 6.4.2.0+ | 6.3.3.0+ | 8, 11
 [2.4.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.4.0) | - | 6.5.0.0+ | 6.4.2.0+ | 6.3.3.0+ | 8, 11
 [2.3.2](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.3.2) | 1.0.12 | 6.5.0.0+ | 6.4.2.0+ | 6.3.3.0+ | 8
 [2.3.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.3.0) | 1.0.10 | - | 6.4.2.0+ | 6.3.3.0+ | 8

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Accordion.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Accordion.java
@@ -36,7 +36,7 @@ public interface Accordion extends Container {
     /**
      * Indicates whether the accordion forces a single item to be expanded at a time or not.
      *
-     * @return true if the accordion forces a single item to be expanded at a time; false otherwise
+     * @return {@code true} if the accordion forces a single item to be expanded at a time; {@code false} otherwise
      * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default boolean isSingleExpansion() {
@@ -46,7 +46,7 @@ public interface Accordion extends Container {
     /**
      * Returns the items that are expanded by default.
      *
-     * @return The expanded items
+     * @return the expanded items
      * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default String[] getExpandedItems() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Button.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Button.java
@@ -51,7 +51,7 @@ public interface Button extends ComponentExporter {
     /**
      * Returns the button icon identifier.
      *
-     * @return the button icon
+     * @return the button icon identifier
      * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default String getIcon() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Download.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Download.java
@@ -21,27 +21,37 @@ import javax.annotation.Nonnull;
 import com.adobe.cq.export.json.ComponentExporter;
 
 /**
- * Defines the {@code Download} Sling Model for the {@code /apps/core/wcm/components/download} component.
+ * Defines the {@code Download} Sling Model used for the {@code /apps/core/wcm/components/download} component.
+ *
+ * @since com.adobe.cq.wcm.core.components.models 12.8.0
  */
 public interface Download extends ComponentExporter {
 
     /**
      * Name of the resource property that defines whether or not the title value is taken from the configured asset.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     String PN_TITLE_FROM_ASSET = "titleFromAsset";
 
     /**
      * Name of the resource property that defines whether or not the description value is taken from the configured asset.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     String PN_DESCRIPTION_FROM_ASSET = "descriptionFromAsset";
 
     /**
      * Name of the resource property that defines whether or not the download item should be displayed inline vs. attachment.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     String PN_INLINE = "inline";
 
     /**
      * Name of the policy property that defines the text to be displayed on the action.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     String PN_ACTION_TEXT = "actionText";
 
@@ -49,21 +59,28 @@ public interface Download extends ComponentExporter {
      * Name of the policy property that stores the value for this title's HTML element type.
      *
      * @see #getTitleType()
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     String PN_TITLE_TYPE = "titleType";
 
     /**
      * Name of the policy property that defines whether the file's size will be displayed.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     String PN_DISPLAY_SIZE = "displaySize";
 
     /**
      * Name of the policy property that defines whether the file's format will be displayed.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     String PN_DISPLAY_FORMAT = "displayFormat";
 
     /**
      * Name of the policy property that defines whether the filename will be displayed.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     String PN_DISPLAY_FILENAME = "displayFilename";
 
@@ -72,6 +89,7 @@ public interface Download extends ComponentExporter {
      * depending on the state of the titleFromAsset checkbox.
      *
      * @return the download title
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default String getTitle() {
         throw new UnsupportedOperationException();
@@ -82,6 +100,7 @@ public interface Download extends ComponentExporter {
      * depending on the state of the descriptionFromAsset checkbox.
      *
      * @return the download description
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default String getDescription() {
         throw new UnsupportedOperationException();
@@ -91,6 +110,7 @@ public interface Download extends ComponentExporter {
      * Returns the url to the asset.
      *
      * @return the asset url
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default String getUrl() {
         throw new UnsupportedOperationException();
@@ -101,6 +121,7 @@ public interface Download extends ComponentExporter {
      * component policy.
      *
      * @return the action text
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default String getActionText() {
         throw new UnsupportedOperationException();
@@ -110,6 +131,7 @@ public interface Download extends ComponentExporter {
      * Returns the HTML element to be used for the title as defined in the component policy.
      *
      * @return the title header element type
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default String getTitleType() {
         throw new UnsupportedOperationException();
@@ -119,6 +141,7 @@ public interface Download extends ComponentExporter {
      * Returns the size of the file to be downloaded.
      *
      * @return the size of download file
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default String getSize() {
         throw new UnsupportedOperationException();
@@ -128,7 +151,8 @@ public interface Download extends ComponentExporter {
      * Returns the extension of file to be downloaded. Extension is mapped with the {@link org.apache.sling.commons.mime.MimeTypeService}
      * . If no mapping can be found the extension is extracted from the filename.
      *
-     * @return the extesion of the download file
+     * @return the extension of the download file
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default String getExtension() {
         throw new UnsupportedOperationException();
@@ -138,6 +162,7 @@ public interface Download extends ComponentExporter {
      * Checks if the file size should be displayed.
      *
      * @return {@code true} if the size should be displayed, {@code false} otherwise
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default boolean displaySize() {
         throw new UnsupportedOperationException();
@@ -147,6 +172,7 @@ public interface Download extends ComponentExporter {
      * Returns the mime type of the file to be downloaded.
      *
      * @return the mime type of the download file
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default String getFormat() {
         throw new UnsupportedOperationException();
@@ -156,6 +182,7 @@ public interface Download extends ComponentExporter {
      * Checks if the file format should be displayed.
      *
      * @return {@code true} if the format should be displayed, {@code false} otherwise
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default boolean displayFormat() {
         throw new UnsupportedOperationException();
@@ -165,6 +192,7 @@ public interface Download extends ComponentExporter {
      * Returns the filename of the file to be downloaded.
      *
      * @return the filename of the download file
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default String getFilename() {
         throw new UnsupportedOperationException();
@@ -174,6 +202,7 @@ public interface Download extends ComponentExporter {
      * Checks if the filename should be displayed.
      *
      * @return {@code true} if the filename should be displayed, {@code false} otherwise
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     default boolean displayFilename() {
         throw new UnsupportedOperationException();
@@ -181,7 +210,7 @@ public interface Download extends ComponentExporter {
 
     /**
      * @see ComponentExporter#getExportedType()
-     * @since com.adobe.cq.wcm.core.components.models 12.2.0
+     * @since com.adobe.cq.wcm.core.components.models 12.8.0
      */
     @Nonnull
     @Override

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/README.md
@@ -24,7 +24,7 @@ Accordion component written in HTL.
 * Toggle accordion panels from accordion header controls.
 * Ability to force a single panel to be displayed.
 * Items expanded by default are configurable.
-* Item header HTML element is configurable (`h2` - `h6`).
+* Item header HTML element is configurable (`h2` - `h6`, `h1` is omitted for SEO reasons).
 * Editing features for accordion items (adding, removing, editing, re-ordering).
 
 ### Use Object
@@ -43,7 +43,7 @@ The following properties are written to JCR for this Accordion component and are
 
 1. `./singleExpansion` - `true` if one panel should be forced to be expanded at a time, `false` otherwise.
 1. `./expandedItems` - defines the names of the items that are expanded by default.
-2. `./headingElement` - defines the heading type to use for the accordion headers (`h2` - `h6`).
+2. `./headingElement` - defines the heading element to use for the accordion headers (`h2` - `h6`).
 
 The edit dialog also allows editing of Accordion items (adding, removing, naming, re-ordering).
 
@@ -65,6 +65,7 @@ BLOCK cmp-accordion
     ELEMENT cmp-accordion__icon
     ELEMENT cmp-accordion__panel
         MOD cmp-accordion__panel--expanded
+        MOD cmp-accordion__panel--hidden
 ```
 
 ## JavaScript Data Attribute Bindings
@@ -114,3 +115,4 @@ that the UI component is updated when the active item is switched in the editor 
 * **Compatibility**: AEM 6.3
 * **Status**: production-ready
 * **Documentation**: [https://www.adobe.com/go/aem\_cmp\_accordion\_v1](https://www.adobe.com/go/aem_cmp_accordion_v1)
+* **Component Library**: [https://www.adobe.com/go/aem\_cmp\_library\_accordion](https://www.adobe.com/go/aem_cmp_library_accordion)

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
@@ -234,7 +234,7 @@
         }
 
         /**
-         * Handles keydown events.
+         * Handles button keydown events.
          *
          * @private
          * @param {Object} event The keydown event

--- a/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/README.md
@@ -58,4 +58,4 @@ BLOCK cmp-breadcrumb
 * **Compatibility**: AEM 6.3
 * **Status**: production-ready
 * **Documentation**: [https://www.adobe.com/go/aem\_cmp\_breadcrumb\_v2](https://www.adobe.com/go/aem_cmp_breadcrumb_v2)
-
+* **Component Library**: [https://www.adobe.com/go/aem\_cmp\_library\_breadcrumb](https://www.adobe.com/go/aem_cmp_library_breadcrumb)

--- a/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v1/languagenavigation/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v1/languagenavigation/README.md
@@ -53,4 +53,4 @@ BLOCK cmp-languagenavigation
 * **Compatibility**: AEM 6.3
 * **Status**: production-ready
 * **Documentation**: [https://www.adobe.com/go/aem\_cmp\_languagenavigation\_v1](https://www.adobe.com/go/aem_cmp_languagenavigation_v1)
-
+* **Component Library**: [https://www.adobe.com/go/aem\_cmp\_library\_langnav](https://www.adobe.com/go/aem_cmp_library_langnav)

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/README.md
@@ -63,4 +63,4 @@ BLOCK cmp-navigation
 * **Compatibility**: AEM 6.3
 * **Status**: production-ready
 * **Documentation**: [https://www.adobe.com/go/aem\_cmp\_navigation\_v1](https://www.adobe.com/go/aem_cmp_navigation_v1)
-
+* **Component Library**: [https://www.adobe.com/go/aem\_cmp\_library\_navigation](https://www.adobe.com/go/aem_cmp_library_navigation)

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/navigation.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/navigation.less
@@ -19,6 +19,7 @@
     .cmp-navigation {
         margin-top: @cmp-examples-spacing-1;
         padding-right: @cmp-examples-spacing-5;
+        padding-bottom: @cmp-examples-spacing-1;
 
         @media @cmp-examples-screen-s-min {
             padding-right: @cmp-examples-spacing-8;

--- a/examples/src/content/jcr_root/conf/core-components-examples/settings/wcm/templates/content-page/structure/.content.xml
+++ b/examples/src/content/jcr_root/conf/core-components-examples/settings/wcm/templates/content-page/structure/.content.xml
@@ -109,7 +109,7 @@
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/text/v2/text"
-                    text="&lt;p>Built with &lt;a href=&quot;https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.4.0&quot;>Core Components 2.4.0&lt;/a>.&lt;/p>&#xa;"
+                    text="&lt;p>Built with &lt;a href=&quot;https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.5.0&quot;>Core Components 2.5.0&lt;/a>.&lt;/p>&#xa;"
                     textIsRich="true"/>
             </responsivegrid_2176569853>
         </root>

--- a/examples/src/content/jcr_root/content/core-components-examples/library/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/.content.xml
@@ -26,7 +26,7 @@
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/text/v2/text"
-                    text="&lt;h1>Component Library &lt;a href=&quot;https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.4.0&quot;>2.4.0&lt;/a>&lt;/h1>&#xa;"
+                    text="&lt;h1>Component Library &lt;a href=&quot;https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.5.0&quot;>2.5.0&lt;/a>&lt;/h1>&#xa;"
                     textIsRich="true"/>
                 <text
                     cq:styleIds="[1544762734201]"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/accordion/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/accordion/.content.xml
@@ -352,8 +352,8 @@
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
                             sling:resourceType="core/wcm/components/accordion/v1/accordion"
-                            expandedItems="[text]">
-                            <text
+                            expandedItems="[item_1]">
+                            <item_1
                                 cq:panelTitle="Item 1"
                                 jcr:created="{Date}2018-12-07T13:12:23.990+01:00"
                                 jcr:createdBy="admin"
@@ -364,7 +364,7 @@
                                 sling:resourceType="core/wcm/components/text/v2/text"
                                 text="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eu mi bibendum neque egestas congue quisque egestas. Varius morbi enim nunc faucibus a pellentesque. Scelerisque eleifend donec pretium vulputate sapien nec sagittis.&lt;/p>&#xa;"
                                 textIsRich="true"/>
-                            <text_397543178
+                            <item_2
                                 cq:panelTitle="Item 2"
                                 jcr:created="{Date}2018-12-07T13:13:32.541+01:00"
                                 jcr:createdBy="admin"
@@ -375,7 +375,7 @@
                                 sling:resourceType="core/wcm/components/text/v2/text"
                                 text="&lt;p>Hac habitasse platea dictumst quisque sagittis purus. At risus viverra adipiscing at in tellus integer. Sit amet consectetur adipiscing elit duis tristique sollicitudin. Leo vel orci porta non pulvinar neque laoreet suspendisse. Volutpat diam ut venenatis tellus in metus vulputate eu.&lt;/p>&#xa;"
                                 textIsRich="true"/>
-                            <text_397543177
+                            <item_3
                                 cq:panelTitle="Item 3"
                                 jcr:created="{Date}2018-12-07T13:13:55.658+01:00"
                                 jcr:createdBy="admin"
@@ -445,8 +445,8 @@
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
                             sling:resourceType="core/wcm/components/accordion/v1/accordion"
-                            expandedItems="[text,text_397543155,text_397543156]">
-                            <text
+                            expandedItems="[item_1,item_2,item_3]">
+                            <item_1
                                 cq:panelTitle="Item 1"
                                 jcr:created="{Date}2018-12-07T13:12:23.990+01:00"
                                 jcr:createdBy="admin"
@@ -457,7 +457,7 @@
                                 sling:resourceType="core/wcm/components/text/v2/text"
                                 text="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eu mi bibendum neque egestas congue quisque egestas. Varius morbi enim nunc faucibus a pellentesque. Scelerisque eleifend donec pretium vulputate sapien nec sagittis.&lt;/p>&#xa;"
                                 textIsRich="true"/>
-                            <text_397543155
+                            <item_2
                                 cq:panelTitle="Item 2"
                                 jcr:created="{Date}2018-12-07T13:13:32.541+01:00"
                                 jcr:createdBy="admin"
@@ -468,7 +468,7 @@
                                 sling:resourceType="core/wcm/components/text/v2/text"
                                 text="&lt;p>Hac habitasse platea dictumst quisque sagittis purus. At risus viverra adipiscing at in tellus integer. Sit amet consectetur adipiscing elit duis tristique sollicitudin. Leo vel orci porta non pulvinar neque laoreet suspendisse. Volutpat diam ut venenatis tellus in metus vulputate eu.&lt;/p>&#xa;"
                                 textIsRich="true"/>
-                            <text_397543156
+                            <item_3
                                 cq:panelTitle="Item 3"
                                 jcr:created="{Date}2018-12-07T13:13:55.658+01:00"
                                 jcr:createdBy="admin"
@@ -538,9 +538,9 @@
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
                             sling:resourceType="core/wcm/components/accordion/v1/accordion"
-                            expandedItems="[item_617130698]"
+                            expandedItems="[item_1]"
                             singleExpansion="{Boolean}true">
-                            <text
+                            <item_1
                                 cq:panelTitle="Item 1"
                                 jcr:created="{Date}2018-12-07T13:12:23.990+01:00"
                                 jcr:createdBy="admin"
@@ -551,7 +551,7 @@
                                 sling:resourceType="core/wcm/components/text/v2/text"
                                 text="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eu mi bibendum neque egestas congue quisque egestas. Varius morbi enim nunc faucibus a pellentesque. Scelerisque eleifend donec pretium vulputate sapien nec sagittis.&lt;/p>&#xa;"
                                 textIsRich="true"/>
-                            <text_397543144
+                            <item_2
                                 cq:panelTitle="Item 2"
                                 jcr:created="{Date}2018-12-07T13:13:32.541+01:00"
                                 jcr:createdBy="admin"
@@ -562,7 +562,7 @@
                                 sling:resourceType="core/wcm/components/text/v2/text"
                                 text="&lt;p>Hac habitasse platea dictumst quisque sagittis purus. At risus viverra adipiscing at in tellus integer. Sit amet consectetur adipiscing elit duis tristique sollicitudin. Leo vel orci porta non pulvinar neque laoreet suspendisse. Volutpat diam ut venenatis tellus in metus vulputate eu.&lt;/p>&#xa;"
                                 textIsRich="true"/>
-                            <text_397543145
+                            <item_3
                                 cq:panelTitle="Item 3"
                                 jcr:created="{Date}2018-12-07T13:13:55.658+01:00"
                                 jcr:createdBy="admin"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/button/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/button/.content.xml
@@ -173,7 +173,7 @@
                             jcr:primaryType="nt:unstructured"
                             jcr:title="Anchor Button"
                             sling:resourceType="core/wcm/components/button/v1/button"
-                            link="https://adobe.com"/>
+                            link="http://opensource.adobe.com/aem-core-wcm-components"/>
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/download/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/download/.content.xml
@@ -309,7 +309,7 @@
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
                             sling:resourceType="core/wcm/components/download/v1/download"
-                            actionText="Download"
+                            actionText="View"
                             descriptionFromAsset="true"
                             fileReference="/content/dam/core-components-examples/library/sample-assets/lava-into-ocean.jpg"
                             inline="true"


### PR DESCRIPTION
- adds 2.5.0 release to main readme and historical version documents.
- updates maven dependency version documentation for 2.5.0 release.
- updates component library versions.
- accordion - adds missing BEM modifier.
- accordion - minor readme fixes.
- accordion - clearer expanded items in library examples.
- accordion - minor JS docs fix.
- button - link to library home rather than adobe home.
- download - switch action text for inline example to “View”.
- adds component library links for new components in the library.
- improves JavaDocs.
- fixes spacing at base of the navigation in the component library.