### PR TITLE
[Text][Image][Teaser] In-place editing config path is not accessible for non-administrators #657

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_editConfig.xml
@@ -17,8 +17,9 @@
     <cq:inplaceEditing
         jcr:primaryType="cq:InplaceEditingConfig"
         active="{Boolean}true"
+        configPath="inplaceEditingConfig"
         editorType="image">
-        <config jcr:primaryType="nt:unstructured">
+        <inplaceEditingConfig jcr:primaryType="nt:unstructured">
             <plugins jcr:primaryType="nt:unstructured">
                 <crop
                     jcr:primaryType="nt:unstructured"
@@ -79,6 +80,6 @@
                     </replacementToolbars>
                 </fullscreen>
             </ui>
-        </config>
+        </inplaceEditingConfig>
     </cq:inplaceEditing>
 </jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_editConfig.xml
@@ -17,8 +17,9 @@
     <cq:inplaceEditing
         jcr:primaryType="cq:InplaceEditingConfig"
         active="{Boolean}true"
+        configPath="inplaceEditingConfig"
         editorType="image">
-        <config jcr:primaryType="nt:unstructured">
+        <inplaceEditingConfig jcr:primaryType="nt:unstructured">
             <plugins jcr:primaryType="nt:unstructured">
                 <crop
                     jcr:primaryType="nt:unstructured"
@@ -85,6 +86,6 @@
                     </replacementToolbars>
                 </fullscreen>
             </ui>
-        </config>
+        </inplaceEditingConfig>
     </cq:inplaceEditing>
 </jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_editConfig.xml
@@ -17,8 +17,9 @@
     <cq:inplaceEditing
         jcr:primaryType="cq:InplaceEditingConfig"
         active="{Boolean}true"
+        configPath="inplaceEditingConfig"
         editorType="image">
-        <config jcr:primaryType="nt:unstructured">
+        <inplaceEditingConfig jcr:primaryType="nt:unstructured">
             <plugins jcr:primaryType="nt:unstructured">
                 <crop
                     jcr:primaryType="nt:unstructured"
@@ -76,6 +77,6 @@
                     </replacementToolbars>
                 </fullscreen>
             </ui>
-        </config>
+        </inplaceEditingConfig>
     </cq:inplaceEditing>
 </jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/text/v1/text/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/text/v1/text/_cq_editConfig.xml
@@ -4,8 +4,9 @@
     <cq:inplaceEditing
         jcr:primaryType="cq:InplaceEditingConfig"
         active="{Boolean}true"
+        configPath="inplaceEditingConfig"
         editorType="text">
-        <config jcr:primaryType="nt:unstructured">
+        <inplaceEditingConfig jcr:primaryType="nt:unstructured">
             <rtePlugins jcr:primaryType="nt:unstructured">
                 <tracklinks
                     jcr:primaryType="nt:unstructured"
@@ -93,6 +94,6 @@
                     jcr:primaryType="nt:unstructured"
                     features="bold,italic"/>
             </rtePlugins>
-        </config>
+        </inplaceEditingConfig>
     </cq:inplaceEditing>
 </jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/_cq_editConfig.xml
@@ -4,8 +4,9 @@
     <cq:inplaceEditing
         jcr:primaryType="cq:InplaceEditingConfig"
         active="{Boolean}true"
+        configPath="inplaceEditingConfig"
         editorType="text">
-        <config jcr:primaryType="nt:unstructured">
+        <inplaceEditingConfig jcr:primaryType="nt:unstructured">
             <rtePlugins jcr:primaryType="nt:unstructured">
                 <tracklinks
                     jcr:primaryType="nt:unstructured"
@@ -93,6 +94,6 @@
                     jcr:primaryType="nt:unstructured"
                     features="bold,italic"/>
             </rtePlugins>
-        </config>
+        </inplaceEditingConfig>
     </cq:inplaceEditing>
 </jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v1/title/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v1/title/_cq_editConfig.xml
@@ -4,8 +4,9 @@
     <cq:inplaceEditing
         jcr:primaryType="cq:InplaceEditingConfig"
         active="{Boolean}true"
+        configPath="inplaceEditingConfig"
         editorType="title">
-        <config
+        <inplaceEditingConfig
             jcr:primaryType="nt:unstructured"
             titleTag="[h1,h2,h3,h4,h5,h6]"/>
     </cq:inplaceEditing>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_editConfig.xml
@@ -4,8 +4,9 @@
     <cq:inplaceEditing
         jcr:primaryType="cq:InplaceEditingConfig"
         active="{Boolean}true"
+        configPath="inplaceEditingConfig"
         editorType="title">
-        <config
+        <inplaceEditingConfig
             jcr:primaryType="nt:unstructured"
             titleTag="[h1,h2,h3,h4,h5,h6]"/>
     </cq:inplaceEditing>


### PR DESCRIPTION
* Moved `config` node to `inplaceEditingConfig`, referenced via `configPath` property

Fixes #657
