### PR TITLE
[Tabs] Can't focus tabpanel via keyboard if it doesn't contain focusable items 

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
@@ -18,10 +18,10 @@
      class="cmp-tabs"
      data-cmp-is="tabs">
     <ol data-sly-test="${tabs.items && tabs.items.size > 0}"
+        data-sly-list.tab="${tabs.items}"
         role="tablist"
         class="cmp-tabs__tablist"
-        aria-multiselectable="false"
-        data-sly-list.tab=${tabs.items}>
+        aria-multiselectable="false">
         <sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
         <li role="tab"
             class="cmp-tabs__tab${isActive ? ' cmp-tabs__tab--active' : ''}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
@@ -20,15 +20,18 @@
     <ol data-sly-test="${tabs.items && tabs.items.size > 0}"
         role="tablist"
         class="cmp-tabs__tablist"
-        aria-multiselectable="false">
-        <li data-sly-repeat.item="${tabs.items}"
-            role="tab"
-            class="cmp-tabs__tab${item.name == tabs.activeItem ? ' cmp-tabs__tab--active' : ''}"
-            data-cmp-hook-tabs="tab">${item.title}</li>
+        aria-multiselectable="false"
+        data-sly-list.tab=${tabs.items}>
+        <sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
+        <li role="tab"
+            class="cmp-tabs__tab${isActive ? ' cmp-tabs__tab--active' : ''}"
+            tabindex="${isActive ? '0' : '-1'}"
+            data-cmp-hook-tabs="tab">${tab.title}</li>
     </ol>
     <div data-sly-repeat.item="${tabs.items}"
          data-sly-resource="${item.name @ decorationTagName='div'}"
          role="tabpanel"
+         tabindex="0"
          class="cmp-tabs__tabpanel${item.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
          data-cmp-hook-tabs="tabpanel"></div>
     <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #591
| Patch: Bug Fix?          | Bugfix
| Minor: New Feature?      | 
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

Changed tabs component markup - added tabindex="0" on tabpanel and initial tabindex state for tab (0 or -1 depending on whether the items is active or not)