### PR TITLE
[Breadcrumb] Missing aria-label="Breadcrumb" on nav element

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/breadcrumb.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/breadcrumb.html
@@ -14,6 +14,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <nav class="cmp-breadcrumb"
+     aria-label="Breadcrumb"
      data-sly-use.breadcrumb="com.adobe.cq.wcm.core.components.models.Breadcrumb"
      data-sly-use.template="core/wcm/components/commons/v1/templates.html"
      data-sly-test="${breadcrumb.items.size > 0}">


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #581
| Patch: Bug Fix?          | Bugfix
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

Added aria-label to breadcrumbs markup
