### PR TITLE
[Navigation][Tabs][Carousel] There's no possibility to add labels to the components

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
@@ -22,6 +22,7 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
@@ -38,6 +39,9 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
 
     @ScriptVariable
     protected ValueMap properties;
+
+    @ValueMapValue(optional = true)
+    protected String label;
 
     protected boolean autoplay;
     protected Long delay;
@@ -63,6 +67,11 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
     @Override
     public boolean getAutopauseDisabled() {
         return autopauseDisabled;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
     }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
@@ -41,7 +41,10 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
     protected ValueMap properties;
 
     @ValueMapValue(optional = true)
-    protected String label;
+    protected String carouselLabel;
+
+    @ValueMapValue(optional = true)
+    protected String indicatorsLabel;
 
     protected boolean autoplay;
     protected Long delay;
@@ -70,8 +73,13 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
     }
 
     @Override
-    public String getLabel() {
-        return label;
+    public String getCarouselLabel() {
+        return carouselLabel;
+    }
+
+    @Override
+    public String getIndicatorsLabel() {
+        return indicatorsLabel;
     }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
@@ -41,10 +41,7 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
     protected ValueMap properties;
 
     @ValueMapValue(optional = true)
-    protected String carouselLabel;
-
-    @ValueMapValue(optional = true)
-    protected String indicatorsLabel;
+    protected String label;
 
     protected boolean autoplay;
     protected Long delay;
@@ -73,13 +70,8 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
     }
 
     @Override
-    public String getCarouselLabel() {
-        return carouselLabel;
-    }
-
-    @Override
-    public String getIndicatorsLabel() {
-        return indicatorsLabel;
+    public String getLabel() {
+        return label;
     }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
@@ -34,6 +34,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -79,6 +80,9 @@ public class NavigationImpl implements Navigation {
 
     @OSGiService
     private LiveRelationshipManager relationshipManager;
+
+    @ValueMapValue(optional = true)
+    private String label;
 
     private int structureDepth;
     private String navigationRootPage;
@@ -149,6 +153,11 @@ public class NavigationImpl implements Navigation {
     @Override
     public String getExportedType() {
         return request.getResource().getResourceType();
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
     }
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
@@ -35,6 +35,9 @@ public class TabsImpl extends PanelContainerImpl implements Tabs {
     @ValueMapValue(optional = true)
     private String activeItem;
 
+    @ValueMapValue(optional = true)
+    private String label;
+
     private String activeItemName;
 
     @Override
@@ -46,5 +49,10 @@ public class TabsImpl extends PanelContainerImpl implements Tabs {
             }
         }
         return activeItemName;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
@@ -82,17 +82,7 @@ public interface Carousel extends Container {
      * @return The value of label for Carousel component
      * @since com.adobe.cq.wcm.core.components.models 12.9.0
      */
-    default String getCarouselLabel() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Returns an accessible label that describes carousel indicators.
-     *
-     * @return The value of label for indicators wrapper
-     * @since com.adobe.cq.wcm.core.components.models 12.9.0
-     */
-    default String getIndicatorsLabel() {
+    default String getLabel() {
         throw new UnsupportedOperationException();
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
@@ -79,7 +79,7 @@ public interface Carousel extends Container {
     /**
      * Returns an accessible label that describes the carousel.
      *
-     * @return The value of label for Carousel component
+     * @return an accessible label for carousel
      * @since com.adobe.cq.wcm.core.components.models 12.9.0
      */
     default String getLabel() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
@@ -77,8 +77,7 @@ public interface Carousel extends Container {
     }
 
     /**
-     * Returns the value of aria-label for Carousel component.
-     * Improves accessibility of component.
+     * Returns an accessible label that describes the carousel.
      *
      * @return The value of label for Carousel component
      * @since com.adobe.cq.wcm.core.components.models 12.9.0
@@ -88,8 +87,7 @@ public interface Carousel extends Container {
     }
 
     /**
-     * Returns the value of aria-label for Carousel indicators.
-     * Improves accessibility of component.
+     * Returns an accessible label that describes carousel indicators.
      *
      * @return The value of label for indicators wrapper
      * @since com.adobe.cq.wcm.core.components.models 12.9.0

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
@@ -77,12 +77,22 @@ public interface Carousel extends Container {
     }
 
     /**
-     * Returns the value of label
+     * Returns the value of label for Carousel component
      *
-     * @return The value of label
+     * @return The value of label for Carousel component
      * @since com.adobe.cq.wcm.core.components.models 12.9.0
      */
-    default String getLabel() {
+    default String getCarouselLabel() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the value of label for indicators wrapper
+     *
+     * @return The value of label for indicators wrapper
+     * @since com.adobe.cq.wcm.core.components.models 12.9.0
+     */
+    default String getIndicatorsLabel() {
         throw new UnsupportedOperationException();
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
@@ -76,4 +76,14 @@ public interface Carousel extends Container {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Returns the value of label
+     *
+     * @return The value of label
+     * @since com.adobe.cq.wcm.core.components.models 12.9.0
+     */
+    default String getLabel() {
+        throw new UnsupportedOperationException();
+    }
+
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
@@ -77,7 +77,8 @@ public interface Carousel extends Container {
     }
 
     /**
-     * Returns the value of label for Carousel component
+     * Returns the value of aria-label for Carousel component.
+     * Improves accessibility of component.
      *
      * @return The value of label for Carousel component
      * @since com.adobe.cq.wcm.core.components.models 12.9.0
@@ -87,7 +88,8 @@ public interface Carousel extends Container {
     }
 
     /**
-     * Returns the value of label for indicators wrapper
+     * Returns the value of aria-label for Carousel indicators.
+     * Improves accessibility of component.
      *
      * @return The value of label for indicators wrapper
      * @since com.adobe.cq.wcm.core.components.models 12.9.0

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Navigation.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Navigation.java
@@ -85,7 +85,7 @@ public interface Navigation extends ComponentExporter {
     /**
      * Retrieves an accessible label that describes the navigation.
      *
-     * @return the value of label for navigation
+     * @return an accessible label for navigation
      * @since com.adobe.cq.wcm.core.components.models 12.9.0
      */
     default String getLabel() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Navigation.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Navigation.java
@@ -82,4 +82,14 @@ public interface Navigation extends ComponentExporter {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Retrieves the value of label for navigation.
+     *
+     * @return the value of label for navigation
+     * @since com.adobe.cq.wcm.core.components.models 12.9.0
+     */
+    default String getLabel() {
+        throw new UnsupportedOperationException();
+    }
+
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Navigation.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Navigation.java
@@ -83,7 +83,8 @@ public interface Navigation extends ComponentExporter {
     }
 
     /**
-     * Retrieves the value of label for navigation.
+     * Retrieves the value of aria-label for navigation.
+     * Improves accessibility of component.
      *
      * @return the value of label for navigation
      * @since com.adobe.cq.wcm.core.components.models 12.9.0

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Navigation.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Navigation.java
@@ -83,8 +83,7 @@ public interface Navigation extends ComponentExporter {
     }
 
     /**
-     * Retrieves the value of aria-label for navigation.
-     * Improves accessibility of component.
+     * Retrieves an accessible label that describes the navigation.
      *
      * @return the value of label for navigation
      * @since com.adobe.cq.wcm.core.components.models 12.9.0

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
@@ -38,7 +38,7 @@ public interface Tabs extends Container {
     /**
      * Returns an accessible label that describes the tabs.
      *
-     * @return The value of label
+     * @return an accessible label for tabs
      * @since com.adobe.cq.wcm.core.components.models 12.9.0
      */
     default String getLabel() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
@@ -36,8 +36,7 @@ public interface Tabs extends Container {
     }
     
     /**
-     * Returns the value of aria-label for tabs.
-     * Improves accessibility of component.
+     * Returns an accessible label that describes the tabs.
      *
      * @return The value of label
      * @since com.adobe.cq.wcm.core.components.models 12.9.0

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
@@ -34,4 +34,14 @@ public interface Tabs extends Container {
     default String getActiveItem() {
         throw new UnsupportedOperationException();
     }
+    
+    /**
+     * Returns the value of label
+     *
+     * @return The value of label
+     * @since com.adobe.cq.wcm.core.components.models 12.9.0
+     */
+    default String getLabel() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
@@ -36,7 +36,8 @@ public interface Tabs extends Container {
     }
     
     /**
-     * Returns the value of label
+     * Returns the value of aria-label for tabs.
+     * Improves accessibility of component.
      *
      * @return The value of label
      * @since com.adobe.cq.wcm.core.components.models 12.9.0

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
@@ -34,7 +34,7 @@ public interface Tabs extends Container {
     default String getActiveItem() {
         throw new UnsupportedOperationException();
     }
-    
+
     /**
      * Returns an accessible label that describes the tabs.
      *

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.8.0")
+@Version("12.9.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/breadcrumb.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/breadcrumb.html
@@ -14,6 +14,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <nav class="cmp-breadcrumb"
+     aria-label="Breadcrumb"
      data-sly-use.breadcrumb="com.adobe.cq.wcm.core.components.models.Breadcrumb"
      data-sly-use.template="core/wcm/components/commons/v1/templates.html"
      data-sly-test="${breadcrumb.items.size > 0}">

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -149,10 +149,10 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
-                                            <carouselLabel
+                                            <label
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="Value of an aria-label attribute for carousel wrapper which describes content inside carousel."
+                                                fieldDescription="Value of an aria-label attribute for the carousel, which describes the carousel content."
                                                 fieldLabel="Label"
                                                 name="./label"
                                                 value=""/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -72,15 +72,6 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
-                                            <label
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="Value of aria-label attribute, which describes purpose of the carousel indicators."
-                                                fieldLabel="Indicators Label"
-                                                name="./label"
-                                                value=""
-                                                emptyText="Enter value of label."
-                                                required="{Boolean}false"/>
                                             <autoplay
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -72,6 +72,15 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
+                                            <label
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="Value of aria-label attribute, which describes purpose of the carousel indicators."
+                                                fieldLabel="Indicators Label"
+                                                name="./label"
+                                                value=""
+                                                emptyText="Enter value of label."
+                                                required="{Boolean}false"/>
                                             <autoplay
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -152,21 +152,17 @@
                                             <carouselLabel
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="Label for carousel wrapper which describes content inside carousel."
-                                                fieldLabel="Carousel Label"
+                                                fieldDescription="Value of an aria-label attribute for carousel wrapper which describes content inside carousel."
+                                                fieldLabel="Carousel label"
                                                 name="./carouselLabel"
-                                                value=""
-                                                emptyText="Enter value of carousel label."
-                                                required="{Boolean}false"/>
+                                                value=""/>
                                             <indicatorsLabel
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="Label for carousel indicators which will be read by screen readers e.g 'Choose slide to display'"
-                                                fieldLabel="Indicators Label"
+                                                fieldDescription="Value of an aria-label attribute for carousel indicators which will be read by screen readers e.g 'Choose slide to display'"
+                                                fieldLabel="Indicators label"
                                                 name="./indicatorsLabel"
-                                                value=""
-                                                emptyText="Enter value of indicators label"
-                                                required="{Boolean}false"/>
+                                                value=""/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -153,15 +153,8 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="Value of an aria-label attribute for carousel wrapper which describes content inside carousel."
-                                                fieldLabel="Carousel label"
-                                                name="./carouselLabel"
-                                                value=""/>
-                                            <indicatorsLabel
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="Value of an aria-label attribute for carousel indicators which will be read by screen readers e.g 'Choose slide to display'"
-                                                fieldLabel="Indicators label"
-                                                name="./indicatorsLabel"
+                                                fieldLabel="Label"
+                                                name="./label"
                                                 value=""/>
                                         </items>
                                     </column>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -72,15 +72,6 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
-                                            <label
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="Value of aria-label attribute, which describes purpose of the carousel indicators."
-                                                fieldLabel="Indicators Label"
-                                                name="./label"
-                                                value=""
-                                                emptyText="Enter value of label."
-                                                required="{Boolean}false"/>
                                             <autoplay
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
@@ -143,6 +134,45 @@
                             </columns>
                         </items>
                     </properties>
+                    <accessibility
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Accessibility"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <carouselLabel
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="Label for carousel wrapper which describes content inside carousel."
+                                                fieldLabel="Carousel Label"
+                                                name="./carouselLabel"
+                                                value=""
+                                                emptyText="Enter value of carousel label."
+                                                required="{Boolean}false"/>
+                                            <indicatorsLabel
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="Label for carousel indicators which will be read by screen readers e.g 'Choose slide to display'"
+                                                fieldLabel="Indicators Label"
+                                                name="./indicatorsLabel"
+                                                value=""
+                                                emptyText="Enter value of indicators label"
+                                                required="{Boolean}false"/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </accessibility>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -17,7 +17,7 @@
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      class="cmp-carousel"
      role="group"
-     aria-label="${carousel.carouselLabel}"
+     aria-label="${carousel.label}"
      aria-roledescription="carousel"
      data-cmp-is="carousel"
      data-cmp-autoplay="${(wcmmode.edit || wcmmode.preview) ? '' : carousel.autoplay}"
@@ -65,7 +65,7 @@
         </div>
         <ol class="cmp-carousel__indicators"
             role="tablist"
-            aria-label="${carousel.indicatorsLabel}"
+            aria-label="${'Choose a slide to display' @ i18n}"
             data-cmp-hook-carousel="indicators">
             <li data-sly-repeat.item="${carousel.items}"
                 class="cmp-carousel__indicator${itemList.first ? ' cmp-carousel__indicator--active' : ''}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -15,8 +15,8 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.carousel="com.adobe.cq.wcm.core.components.models.Carousel"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-     role="group"
      class="cmp-carousel"
+     role="group"
      aria-label="${carousel.carouselLabel}"
      aria-roledescription="carousel"
      data-cmp-is="carousel"
@@ -27,45 +27,49 @@
          class="cmp-carousel__content">
         <div data-sly-repeat.item="${carousel.items}"
              data-sly-resource="${item.name @ decorationTagName='div'}"
-             role="tabpanel"
              class="cmp-carousel__item${itemList.first ? ' cmp-carousel__item--active' : ''}"
+             role="tabpanel"
              aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.items.size], i18n}"
              data-cmp-hook-carousel="item"></div>
         <div class="cmp-carousel__actions">
-            <button role="button"
-                    class="cmp-carousel__action cmp-carousel__action--previous"
-                    data-cmp-hook-carousel="previous" aria-label="${'Previous' @ i18n}">
+            <button class="cmp-carousel__action cmp-carousel__action--previous"
+                    role="button"
+                    aria-label="${'Previous' @ i18n}"
+                    data-cmp-hook-carousel="previous">
                 <span class="cmp-carousel__action-icon"></span>
                 <span class="cmp-carousel__action-text">${'Previous' @ i18n}</span>
             </button>
-            <button role="button"
-                    class="cmp-carousel__action cmp-carousel__action--next"
-                    data-cmp-hook-carousel="next" aria-label="${'Next' @ i18n}">
+            <button class="cmp-carousel__action cmp-carousel__action--next"
+                    role="button"
+                    aria-label="${'Next' @ i18n}"
+                    data-cmp-hook-carousel="next">
                 <span class="cmp-carousel__action-icon"></span>
                 <span class="cmp-carousel__action-text">${'Next' @ i18n}</span>
             </button>
             <button data-sly-test="${carousel.autoplay}"
-                    role="button"
                     class="cmp-carousel__action cmp-carousel__action--pause"
-                    data-cmp-hook-carousel="pause" aria-label="${'Pause' @ i18n}">
+                    role="button"
+                    aria-label="${'Pause' @ i18n}"
+                    data-cmp-hook-carousel="pause">
                 <span class="cmp-carousel__action-icon"></span>
                 <span class="cmp-carousel__action-text">${'Pause' @ i18n}</span>
             </button>
             <button data-sly-test="${carousel.autoplay}"
-                    role="button"
                     class="cmp-carousel__action cmp-carousel__action--play cmp-carousel__action--disabled"
-                    data-cmp-hook-carousel="play" aria-label="${'Play' @ i18n}">
+                    role="button"
+                    aria-label="${'Play' @ i18n}"
+                    data-cmp-hook-carousel="play">
                 <span class="cmp-carousel__action-icon"></span>
                 <span class="cmp-carousel__action-text">${'Play' @ i18n}</span>
             </button>
         </div>
-        <ol role="tablist"
-            class="cmp-carousel__indicators"
+        <ol class="cmp-carousel__indicators"
+            role="tablist"
             aria-label="${carousel.indicatorsLabel}"
             data-cmp-hook-carousel="indicators">
             <li data-sly-repeat.item="${carousel.items}"
-                role="tab"
                 class="cmp-carousel__indicator${itemList.first ? ' cmp-carousel__indicator--active' : ''}"
+                role="tab"
                 aria-label="${'Slide {0}' @ format=[itemList.count], i18n}"
                 data-cmp-hook-carousel="indicator">${item.title}</li>
         </ol>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -18,7 +18,7 @@
      aria-label="${carousel.carouselLabel}"
      aria-roledescription="carousel"
      class="cmp-carousel"
-     role="region"
+     role="group"
      data-cmp-is="carousel"
      data-cmp-autoplay="${(wcmmode.edit || wcmmode.preview) ? '' : carousel.autoplay}"
      data-cmp-delay="${carousel.delay}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -15,10 +15,10 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.carousel="com.adobe.cq.wcm.core.components.models.Carousel"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+     role="group"
+     class="cmp-carousel"
      aria-label="${carousel.carouselLabel}"
      aria-roledescription="carousel"
-     class="cmp-carousel"
-     role="group"
      data-cmp-is="carousel"
      data-cmp-autoplay="${(wcmmode.edit || wcmmode.preview) ? '' : carousel.autoplay}"
      data-cmp-delay="${carousel.delay}"
@@ -27,9 +27,9 @@
          class="cmp-carousel__content">
         <div data-sly-repeat.item="${carousel.items}"
              data-sly-resource="${item.name @ decorationTagName='div'}"
-             aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.items.size], i18n}"
              role="tabpanel"
              class="cmp-carousel__item${itemList.first ? ' cmp-carousel__item--active' : ''}"
+             aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.items.size], i18n}"
              data-cmp-hook-carousel="item"></div>
         <div class="cmp-carousel__actions">
             <button role="button"
@@ -61,12 +61,12 @@
         </div>
         <ol role="tablist"
             class="cmp-carousel__indicators"
-            data-cmp-hook-carousel="indicators"
-            aria-label="${carousel.indicatorsLabel}">
+            aria-label="${carousel.indicatorsLabel}"
+            data-cmp-hook-carousel="indicators">
             <li data-sly-repeat.item="${carousel.items}"
-                aria-label="${'Slide {0}' @ format=[itemList.count], i18n}"
                 role="tab"
                 class="cmp-carousel__indicator${itemList.first ? ' cmp-carousel__indicator--active' : ''}"
+                aria-label="${'Slide {0}' @ format=[itemList.count], i18n}"
                 data-cmp-hook-carousel="indicator">${item.title}</li>
         </ol>
     </div>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -54,7 +54,10 @@
                 <span class="cmp-carousel__action-text">${'Play' @ i18n}</span>
             </button>
         </div>
-        <ol role="tablist" class="cmp-carousel__indicators" data-cmp-hook-carousel="indicators">
+        <ol role="tablist"
+            class="cmp-carousel__indicators"
+            data-cmp-hook-carousel="indicators"
+            aria-label="${carousel.label}">
             <li data-sly-repeat.item="${carousel.items}"
                 role="tab"
                 class="cmp-carousel__indicator${itemList.first ? ' cmp-carousel__indicator--active' : ''}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -15,14 +15,19 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.carousel="com.adobe.cq.wcm.core.components.models.Carousel"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+     aria-label="${carousel.carouselLabel}"
+     aria-roledescription="carousel"
      class="cmp-carousel"
+     role="region"
      data-cmp-is="carousel"
      data-cmp-autoplay="${(wcmmode.edit || wcmmode.preview) ? '' : carousel.autoplay}"
      data-cmp-delay="${carousel.delay}"
      data-cmp-autopause-disabled="${carousel.autopauseDisabled}">
-    <div class="cmp-carousel__content" data-sly-test="${carousel.items && carousel.items.size > 0}" >
+    <div data-sly-test="${carousel.items && carousel.items.size > 0}"
+         class="cmp-carousel__content">
         <div data-sly-repeat.item="${carousel.items}"
              data-sly-resource="${item.name @ decorationTagName='div'}"
+             aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.items.size], i18n}"
              role="tabpanel"
              class="cmp-carousel__item${itemList.first ? ' cmp-carousel__item--active' : ''}"
              data-cmp-hook-carousel="item"></div>
@@ -57,8 +62,9 @@
         <ol role="tablist"
             class="cmp-carousel__indicators"
             data-cmp-hook-carousel="indicators"
-            aria-label="${carousel.label}">
+            aria-label="${carousel.indicatorsLabel}">
             <li data-sly-repeat.item="${carousel.items}"
+                aria-label="${'Slide {0}' @ format=[itemList.count], i18n}"
                 role="tab"
                 class="cmp-carousel__indicator${itemList.first ? ' cmp-carousel__indicator--active' : ''}"
                 data-cmp-hook-carousel="indicator">${item.title}</li>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
@@ -51,11 +51,11 @@
                                             <label
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="Value of aria-label for the navigation. Should be specified if more than one naviagtion is used on a page."
+                                                fieldDescription="Value of aria-label attribute for the navigation. Should be specified if more than one naviagtion is used on a page."
                                                 fieldLabel="Navigation Label"
                                                 name="./label"
                                                 value=""
-                                                emptyText="Enter value of aria-label for the navigation."
+                                                emptyText="Enter value of label."
                                                 required="{Boolean}false"/>
                                             <navigationRoot
                                                 jcr:primaryType="nt:unstructured"

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
@@ -48,6 +48,15 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
+                                            <label
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="Value of aria-label for the navigation. Should be specified if more than one naviagtion is used on a page."
+                                                fieldLabel="Navigation Label"
+                                                name="./label"
+                                                value=""
+                                                emptyText="Enter value of aria-label for the navigation."
+                                                required="{Boolean}false"/>
                                             <navigationRoot
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
@@ -48,15 +48,6 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
-                                            <label
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="Value of aria-label attribute for the navigation. Should be specified if more than one naviagtion is used on a page."
-                                                fieldLabel="Navigation Label"
-                                                name="./label"
-                                                value=""
-                                                emptyText="Enter value of label."
-                                                required="{Boolean}false"/>
                                             <navigationRoot
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
@@ -101,6 +92,34 @@
                             </columns>
                         </items>
                     </properties>
+                    <accessibility
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Accessibility"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <label
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="Value of an aria-label attribute for the navigation. Should be added if there is more than one naviagtion on the page."
+                                                fieldLabel="Label"
+                                                name="./label"
+                                                value=""/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </accessibility>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
@@ -110,7 +110,7 @@
                                             <label
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="Value of an aria-label attribute for the navigation. Should be added if there is more than one naviagtion on the page."
+                                                fieldDescription="Value of an aria-label attribute for the navigation. Should be added if there is more than one navigation on the page."
                                                 fieldLabel="Label"
                                                 name="./label"
                                                 value=""/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/navigation.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/navigation.html
@@ -20,6 +20,7 @@
      data-sly-use.navigation="com.adobe.cq.wcm.core.components.models.Navigation"
      data-sly-test.hasContent="${navigation.items.size > 0}"
      data-sly-use.groupTemplate="group.html"
-     data-sly-call="${groupTemplate.group @ items=navigation.items}">
+     data-sly-call="${groupTemplate.group @ items=navigation.items}"
+     aria-label="${navigation.label}">
 </nav>
 <sly data-sly-call="${template.placeholder @ isEmpty=!hasContent, classAppend='cmp-navigation'}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/_cq_dialog/.content.xml
@@ -72,6 +72,15 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
+                                            <label
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="Value of aria-label attribute, which describes purpose of the set of tabs."
+                                                fieldLabel="Tabs Label"
+                                                name="./label"
+                                                value=""
+                                                emptyText="Enter value of label."
+                                                required="{Boolean}false"/>
                                             <activeItem
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="/libs/granite/ui/components/coral/foundation/form/hidden"

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/_cq_dialog/.content.xml
@@ -72,15 +72,6 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
-                                            <label
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="Value of aria-label attribute, which describes purpose of the set of tabs."
-                                                fieldLabel="Tabs Label"
-                                                name="./label"
-                                                value=""
-                                                emptyText="Enter value of label."
-                                                required="{Boolean}false"/>
                                             <activeItem
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="/libs/granite/ui/components/coral/foundation/form/hidden"
@@ -110,6 +101,34 @@
                             </columns>
                         </items>
                     </properties>
+                    <accessibility
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Accessibility"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <label
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="Value of an aria-label attribute, which describes the purpose of the set of tabs."
+                                                fieldLabel="Label"
+                                                name="./label"
+                                                value=""/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </accessibility>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
@@ -18,17 +18,20 @@
      class="cmp-tabs"
      data-cmp-is="tabs">
     <ol data-sly-test="${tabs.items && tabs.items.size > 0}"
+        data-sly-list.tab="${tabs.items}"
         role="tablist"
         class="cmp-tabs__tablist"
         aria-multiselectable="false">
-        <li data-sly-repeat.item="${tabs.items}"
-            role="tab"
-            class="cmp-tabs__tab${item.name == tabs.activeItem ? ' cmp-tabs__tab--active' : ''}"
-            data-cmp-hook-tabs="tab">${item.title}</li>
+        <sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
+        <li role="tab"
+            class="cmp-tabs__tab${isActive ? ' cmp-tabs__tab--active' : ''}"
+            tabindex="${isActive ? '0' : '-1'}"
+            data-cmp-hook-tabs="tab">${tab.title}</li>
     </ol>
     <div data-sly-repeat.item="${tabs.items}"
          data-sly-resource="${item.name @ decorationTagName='div'}"
          role="tabpanel"
+         tabindex="0"
          class="cmp-tabs__tabpanel${item.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
          data-cmp-hook-tabs="tabpanel"></div>
     <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
@@ -21,6 +21,7 @@
         data-sly-list.tab="${tabs.items}"
         role="tablist"
         class="cmp-tabs__tablist"
+        aria-label="${tabs.label}"
         aria-multiselectable="false">
         <sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
         <li role="tab"

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -612,19 +612,19 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.8.4</version>
+                <version>2.9.5</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.8.4</version>
+                <version>2.9.5</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.8.4</version>
+                <version>2.9.5</version>
                 <scope>provided</scope>
             </dependency>
 


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes: #586 
| Patch: Bug Fix?          | Bugfix
| Minor: New Feature?      | -
| Major: Breaking Change?  | -
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes 
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Added additional property in dialogs of Navigation, Tabs and Carousel components that allows author to specify aria-label for the component