### PR TITLE
[Page] Make head more customizable #685

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.custommetadata.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.custommetadata.html
@@ -1,0 +1,15 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2016 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.html
@@ -15,13 +15,9 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <template data-sly-template.head="${ @ page }"
           data-sly-use.headlibRenderer="headlibs.html"
-          data-sly-use.headResources="head.resources.html">
-    <meta charset="UTF-8">
-    <title>${page.title}</title>
-    <meta data-sly-test.keywords="${page.keywords}" name="keywords" content="${keywords}"/>
-    <meta data-sly-test.description="${properties['jcr:description']}" name="description" content="${description}"/>
-    <meta data-sly-test.templateName="${page.templateName}" name="template" content="${templateName}"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+          data-sly-use.headResources="head.resources.html"
+          data-sly-use.headMetadata="head.metadata.html">
+    <sly data-sly-call="${headMetadata.headMetadata @ page = page}"></sly>
     <sly data-sly-include="head.socialmedia.html"></sly>
     <sly data-sly-include="customheaderlibs.html"></sly>
     <sly data-sly-call="${headlibRenderer.headlibs @
@@ -30,5 +26,5 @@
                                 clientLibCategories       = page.clientLibCategories,
                                 clientLibCategoriesJsHead = page.clientLibCategoriesJsHead,
                                 hasCloudconfigSupport     = page.hasCloudconfigSupport}"></sly>
-    <sly data-sly-test.appResourcesPath=${page.appResourcesPath} data-sly-call="${headResources.favicons @ path = appResourcesPath}"></sly>
+    <sly data-sly-test.appResourcesPath="${page.appResourcesPath}" data-sly-call="${headResources.favicons @ path = appResourcesPath}"></sly>
 </template>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.metadata.description.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.metadata.description.html
@@ -1,0 +1,19 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2016 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<template data-sly-template.headMetadataDescription="${ @ page }">
+    <meta data-sly-test.keywords="${page.keywords}" name="keywords" content="${keywords}"/>
+    <meta data-sly-test.description="${page.properties['jcr:description']}" name="description" content="${description}"/>
+</template>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.metadata.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.metadata.html
@@ -1,0 +1,26 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2016 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<template data-sly-template.headMetadata="${ @ page ='The page component that provides page metadata'}"
+          data-sly-use.headMetadataTitle="head.metadata.title.html"
+          data-sly-use.headMetadataDescription="head.metadata.description.html"
+          data-sly-use.headCustomMetadata="head.custommetadata.html">
+    <meta charset="UTF-8">
+    <sly data-sly-call="${headMetadataTitle.headMetadataTitle @ page}"></sly>
+    <sly data-sly-call="${headMetadataDescription.headMetadataDescription @ page}"></sly>
+    <meta data-sly-test.templateName="${page.templateName}" name="template" content="${templateName}"/>
+    <sly data-sly-call="${headCustomMetadata.headCustomMetadata @ page}"></sly>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+</template>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.metadata.title.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.metadata.title.html
@@ -1,0 +1,18 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2016 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<template data-sly-template.headMetadataTitle="${ @ page }">
+    <title>${page.title}</title>
+</template>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #685 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | No
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Added various extension points in the head-logic of the page component. It is now possible to:
* Override the page title (title tag)
* Override the page description (keywords & description)
* Add custom metadata to the head-tag
* 