### PR TITLE
[Download] Improved memory usage (fixes #700)

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/DownloadServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/DownloadServlet.java
@@ -15,6 +15,8 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.servlets;
 
+import static com.adobe.cq.wcm.core.components.internal.servlets.DownloadServlet.SELECTOR;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
@@ -22,8 +24,14 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.TimeZone;
+
 import javax.annotation.Nonnull;
+import javax.jcr.Binary;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
 import javax.servlet.Servlet;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
@@ -37,11 +45,11 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.dam.api.Asset;
-
-import static com.adobe.cq.wcm.core.components.internal.servlets.DownloadServlet.SELECTOR;
 
 @Component(
         service = Servlet.class,
@@ -55,6 +63,8 @@ import static com.adobe.cq.wcm.core.components.internal.servlets.DownloadServlet
 public class DownloadServlet extends SlingAllMethodsServlet {
 
     private static final long serialVersionUID = 1L;
+    
+    private static final Logger LOG = LoggerFactory.getLogger(DownloadServlet.class);
 
 
     public static final String SELECTOR = "coredownload";
@@ -71,86 +81,120 @@ public class DownloadServlet extends SlingAllMethodsServlet {
         if (asset == null) {
             String filename = request.getRequestPathInfo().getSuffix();
             Resource downloadDataResource = request.getResource().getChild(JcrConstants.JCR_CONTENT);
+            
             if (StringUtils.isNotEmpty(filename) && downloadDataResource != null) {
-                byte[] bytes = getByteArray(downloadDataResource);
-                if (bytes.length == 0) {
-                    response.sendError(HttpServletResponse.SC_NOT_FOUND);
-                    return;
-                }
-
-                ValueMap valueMap = downloadDataResource.adaptTo(ValueMap.class);
-                if (valueMap != null) {
-                    Calendar calendar = valueMap.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class);
-                    if (calendar != null) {
-                        if (checkLastModifiedAfter(calendar.getTimeInMillis(), request)) {
-                            response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
-                            return;
-                        }
-
-                        String mimeType = valueMap.get(JcrConstants.JCR_MIMETYPE, String.class);
-                        if (StringUtils.isNotEmpty(mimeType)) {
-                            sendResponse(bytes, mimeType, filename, calendar.getTimeInMillis(), response, checkForInlineSelector(request));
-                        } else {
-                            response.sendError(HttpServletResponse.SC_NOT_FOUND);
-                        }
-
-                    } else {
-                        response.sendError(HttpServletResponse.SC_NOT_FOUND);
-                    }
-                }
+                sendResource(request, response, filename, downloadDataResource);
             }
         } else {
-            byte[] bytes = getByteArray(asset);
-            if (bytes.length == 0) {
-                response.sendError(HttpServletResponse.SC_NOT_FOUND);
-                return;
-            }
-
+            
             if (checkLastModifiedAfter(asset.getLastModified(), request)) {
                 response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
                 return;
             }
-            sendResponse(bytes, asset.getMimeType(), asset.getName(), asset.getLastModified(), response, checkForInlineSelector(request));
+            Optional<InputStream> inputStream = null;
+            try {
+                inputStream = getInputStream(asset);
+                if (!inputStream.isPresent()) {
+                    response.sendError(HttpServletResponse.SC_NOT_FOUND);
+                    return;
+                }
+                sendResponse(inputStream.get(), asset.getOriginal().getSize(), asset.getMimeType(), asset.getName(), asset.getLastModified(), response, checkForInlineSelector(request));
+            } finally {
+                if (inputStream != null && inputStream.isPresent()) {
+                    inputStream.get().close();
+                }
+            }
         }
     }
 
+
+    private void sendResource(SlingHttpServletRequest request, SlingHttpServletResponse response, String filename,
+            Resource downloadDataResource) throws IOException {
+
+        ValueMap valueMap = downloadDataResource.adaptTo(ValueMap.class);
+        if (valueMap != null) {
+
+            Calendar calendar = valueMap.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class);
+            if (calendar != null) {
+                if (checkLastModifiedAfter(calendar.getTimeInMillis(), request)) {
+                    response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+                    return;
+                }
+            }
+            Optional<InputStream> inputStream = null;
+            try {
+                inputStream = getInputStream(downloadDataResource);
+                if (!inputStream.isPresent()) {
+                    response.sendError(HttpServletResponse.SC_NOT_FOUND);
+                    return;
+                }
+                long size = getResourceSize(downloadDataResource);
+                String mimeType = valueMap.get(JcrConstants.JCR_MIMETYPE, String.class);
+                if (StringUtils.isNotEmpty(mimeType)) {
+                    sendResponse(inputStream.get(), size, mimeType, filename, calendar.getTimeInMillis(), response, checkForInlineSelector(request));
+                } else {
+                    response.sendError(HttpServletResponse.SC_NOT_FOUND);
+                }
+            } finally {
+                if (inputStream != null && inputStream.isPresent()) {
+                    inputStream.get().close();
+                } 
+            }
+            
+        }
+    }
+
+    
+    /**
+     * Determine the size of a binary resource just by using the JCR API; this hopefully avoids to read
+     * the complete InputStream to determine the actual size of the binary.
+     * @param resource
+     * @return
+     */
+    private long getResourceSize (Resource resource) {
+        
+        Node node = resource.adaptTo(Node.class);
+        if (node != null) {
+            Property jcrData;
+            try {
+                jcrData = node.getProperty(JcrConstants.JCR_DATA);
+                if (jcrData != null) {
+                    Binary binary = jcrData.getBinary();
+                    if (binary != null) {
+                        return binary.getSize();
+                    }
+                }
+            } catch (RepositoryException e) {
+                LOG.info ("Cannot determine size of binary at {}", resource.getPath(),e);
+            }
+        }
+        return -1;
+    }
+        
     private boolean checkForInlineSelector(SlingHttpServletRequest request) {
         return Arrays.asList(request.getRequestPathInfo().getSelectors()).contains(INLINE_SELECTOR);
     }
 
-    private byte[] getByteArray(Asset asset) throws IOException {
-        byte[] bytes = new byte[]{};
-        Resource resource = asset.getOriginal();
-        if (resource != null) {
-            InputStream stream = resource.adaptTo(InputStream.class);
-            if (stream != null) {
-                try {
-                    bytes = IOUtils.toByteArray(stream);
-                } finally {
-                    stream.close();
-                }
-            }
-        }
-        return bytes;
+    
+    
+    private Optional<InputStream> getInputStream (Asset asset) {
+        return Optional.ofNullable(asset.getOriginal())
+                .map(r -> r.adaptTo(InputStream.class));
     }
-
-    private byte[] getByteArray(Resource fileResource) throws IOException {
-        byte[] bytes = new byte[]{};
-        InputStream stream = fileResource.getValueMap().get(JcrConstants.JCR_DATA, InputStream.class);
-        if (stream != null) {
-            try {
-                bytes = IOUtils.toByteArray(stream);
-            } finally {
-                stream.close();
-            }
-        }
-        return bytes;
+    
+    private Optional<InputStream> getInputStream (Resource fileResource) {
+        return Optional.ofNullable(fileResource.getValueMap().get(JcrConstants.JCR_DATA, InputStream.class));
     }
-
-    private void sendResponse(byte[] bytes, String mimeType, String filename, long lastModifiedDate, SlingHttpServletResponse response,
-                              boolean inline) throws IOException {
+    
+    
+    private void sendResponse(InputStream stream, long size, String mimeType, String filename, long lastModifiedDate, SlingHttpServletResponse response,
+            boolean inline) throws IOException {
         response.setContentType(mimeType);
-        response.setContentLength(bytes.length);
+        
+        // only set the size contentLength header if we have valid data
+        if (size != -1) {
+            response.setContentLength((int) size);
+        }
         if (inline) {
             response.setHeader(CONTENT_DISPOSITION_HEADER, "inline");
         } else {
@@ -158,7 +202,7 @@ public class DownloadServlet extends SlingAllMethodsServlet {
         }
         response.setHeader(HttpConstants.HEADER_LAST_MODIFIED, getLastModifiedDate(lastModifiedDate));
         ServletOutputStream outputStream = response.getOutputStream();
-        outputStream.write(bytes);
+        IOUtils.copy(stream, outputStream);
         outputStream.close();
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/DownloadServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/DownloadServlet.java
@@ -71,7 +71,7 @@ public class DownloadServlet extends SlingAllMethodsServlet {
     public static final String INLINE_SELECTOR = "inline";
 
     private static final String CONTENT_DISPOSITION_HEADER = "Content-Disposition";
-    private static final String RFC_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz";
+    protected static final String RFC_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz";
 
     @Override
     protected void doGet(@Nonnull SlingHttpServletRequest request, @Nonnull SlingHttpServletResponse response)
@@ -87,20 +87,21 @@ public class DownloadServlet extends SlingAllMethodsServlet {
             }
         } else {
             
-            if (checkLastModifiedAfter(asset.getLastModified(), request)) {
+            if (isUnchanged(asset.getLastModified(), request)) {
                 response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
                 return;
             }
-            Optional<InputStream> inputStream = null;
+            Optional<InputStream> inputStream = Optional.empty();
             try {
                 inputStream = getInputStream(asset);
                 if (!inputStream.isPresent()) {
                     response.sendError(HttpServletResponse.SC_NOT_FOUND);
                     return;
                 }
+                response.setStatus(HttpServletResponse.SC_OK);
                 sendResponse(inputStream.get(), asset.getOriginal().getSize(), asset.getMimeType(), asset.getName(), asset.getLastModified(), response, checkForInlineSelector(request));
             } finally {
-                if (inputStream != null && inputStream.isPresent()) {
+                if (inputStream.isPresent()) {
                     inputStream.get().close();
                 }
             }
@@ -116,12 +117,13 @@ public class DownloadServlet extends SlingAllMethodsServlet {
 
             Calendar calendar = valueMap.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class);
             if (calendar != null) {
-                if (checkLastModifiedAfter(calendar.getTimeInMillis(), request)) {
+                if (isUnchanged(calendar.getTimeInMillis(), request)) {
+                    LOG.info("sending SC_NOT_MODIFIED for {}", request.getResource().getPath());
                     response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
                     return;
                 }
             }
-            Optional<InputStream> inputStream = null;
+            Optional<InputStream> inputStream = Optional.empty();
             try {
                 inputStream = getInputStream(downloadDataResource);
                 if (!inputStream.isPresent()) {
@@ -129,14 +131,19 @@ public class DownloadServlet extends SlingAllMethodsServlet {
                     return;
                 }
                 long size = getResourceSize(downloadDataResource);
+                long timestamp = 0;
+                if (calendar != null) {
+                    timestamp = calendar.getTimeInMillis();
+                }
                 String mimeType = valueMap.get(JcrConstants.JCR_MIMETYPE, String.class);
                 if (StringUtils.isNotEmpty(mimeType)) {
-                    sendResponse(inputStream.get(), size, mimeType, filename, calendar.getTimeInMillis(), response, checkForInlineSelector(request));
+                    response.sendError(HttpServletResponse.SC_OK);
+                    sendResponse(inputStream.get(), size, mimeType, filename, timestamp, response, checkForInlineSelector(request));
                 } else {
                     response.sendError(HttpServletResponse.SC_NOT_FOUND);
                 }
             } finally {
-                if (inputStream != null && inputStream.isPresent()) {
+                if (inputStream.isPresent()) {
                     inputStream.get().close();
                 } 
             }
@@ -148,8 +155,8 @@ public class DownloadServlet extends SlingAllMethodsServlet {
     /**
      * Determine the size of a binary resource just by using the JCR API; this hopefully avoids to read
      * the complete InputStream to determine the actual size of the binary.
-     * @param resource
-     * @return
+     * @param resource the actual resource
+     * @return the size in byte, -1 if an error occurs, the resource is not backed by a JCR node, or if there is not JCR_DATA property
      */
     private long getResourceSize (Resource resource) {
         
@@ -200,10 +207,12 @@ public class DownloadServlet extends SlingAllMethodsServlet {
         } else {
             response.setHeader(CONTENT_DISPOSITION_HEADER, "attachment; filename=\"" + filename + "\"");
         }
-        response.setHeader(HttpConstants.HEADER_LAST_MODIFIED, getLastModifiedDate(lastModifiedDate));
-        ServletOutputStream outputStream = response.getOutputStream();
-        IOUtils.copy(stream, outputStream);
-        outputStream.close();
+        if (lastModifiedDate > 0) {
+            response.setHeader(HttpConstants.HEADER_LAST_MODIFIED, getLastModifiedDate(lastModifiedDate));
+        }
+        try (ServletOutputStream outputStream = response.getOutputStream()) {
+            IOUtils.copy(stream, outputStream);
+        }
     }
 
     private String getLastModifiedDate(long lastModifiedDate) {
@@ -212,7 +221,7 @@ public class DownloadServlet extends SlingAllMethodsServlet {
         return df.format(lastModifiedDate);
     }
 
-    private boolean checkLastModifiedAfter(long lastModifiedDate, SlingHttpServletRequest request) {
+    private boolean isUnchanged(long lastModifiedDate, SlingHttpServletRequest request) {
         boolean match = false;
         if (Collections.list(request.getHeaderNames()).contains(HttpConstants.HEADER_IF_MODIFIED_SINCE)) {
             String headerDate = request.getHeader(HttpConstants.HEADER_IF_MODIFIED_SINCE);

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/DownloadServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/DownloadServletTest.java
@@ -110,4 +110,12 @@ public class DownloadServletTest {
         downloadServlet.doGet(AEM_CONTEXT.request(), AEM_CONTEXT.response());
         assertEquals(304, AEM_CONTEXT.response().getStatus());
     }
+    
+    @Test
+    public void tesNotModifiedResponseForResource() throws Exception {
+        AEM_CONTEXT.currentResource(PDF_FILE_PATH + "/file");
+        AEM_CONTEXT.request().setHeader("If-Modified-Since", "Fri, 19 Oct 2018 19:24:07 GMT");
+        downloadServlet.doGet(AEM_CONTEXT.request(), AEM_CONTEXT.response());
+        assertEquals(304, AEM_CONTEXT.response().getStatus());
+    }
 }


### PR DESCRIPTION
* Do no longer store the complete binary in memory, but stream them
* Also do the checks for NOT_MODIFIED before opening the binary


