### PR TITLE
Ensure proper encoding of Google Font URL - avoid LinkChecker warning

### DIFF
--- a/examples/src/content/jcr_root/apps/core-components-examples/components/page/head.html
+++ b/examples/src/content/jcr_root/apps/core-components-examples/components/page/head.html
@@ -22,7 +22,7 @@
     <meta data-sly-test.description="${properties['jcr:description']}" name="description" content="${description}"/>
     <meta data-sly-test.templateName="${page.templateName}" name="template" content="${templateName}"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Slab|Source+Code+Pro|Source+Sans+Pro:400,400i,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Roboto%7CRoboto%2BSlab%7CSource%2BCode%2BPro%7CSource%2BSans%2BPro%3A400%2C400i%2C700" rel="stylesheet">
     <sly data-sly-include="head.socialmedia.html"></sly>
     <sly data-sly-include="customheaderlibs.html"></sly>
     <sly data-sly-call="${headlibRenderer.headlibs @


### PR DESCRIPTION
Avoid LinkChecker log warnings for Google Font URL:

```
15.08.2019 00:02:45.050 *WARN* [0:0:0:0:0:0:0:1 [1565820164860] GET /content/core-components-examples/library/button.html HTTP/1.1] com.day.cq.rewriter.linkchecker.impl.LinkCheckerImpl Ignoring malformed URI: java.net.URISyntaxException: Illegal character in query at index 46: https://fonts.googleapis.com/
```
by escaping it properly.

| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | n/a
| Documentation Provided   | n/a
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

