### PR TITLE
Issue/703: [Navigation] Fix NPE if navigation root page is missing jcr:content

### DIFF
--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImplTest.java
@@ -78,6 +78,9 @@ public class NavigationImplTest {
     private static final String NAV_COMPONENT_9 = TEST_ROOT + "/jcr:content/root/navigation-component-9";
     // points to the nav component used for invalidRedirectTest()
     private static final String NAV_COMPONENT_10 = TEST_ROOT + "/jcr:content/root/navigation-component-10";
+    // points to the nav component used for when the nav root has no jcr:content child
+    private static final String NAV_COMPONENT_11 = TEST_ROOT + "/jcr:content/root/navigation-component-11";
+
 
     private static final ContentPolicyManager contentPolicyManager = mock(ContentPolicyManager.class);
 
@@ -162,6 +165,20 @@ public class NavigationImplTest {
         Navigation navigation = getNavigationUnderTest(NAV_COMPONENT_2);
         assertEquals("Didn't expect any navigation items.", 0, navigation.getItems().size());
         Utils.testJSONExport(navigation, Utils.getTestExporterJSONPath(TEST_BASE, "navigation4"));
+    }
+
+    /**
+     * Demonstrates the ability to construct a {@link NavigationImpl} where the navigation root page does not have a
+     * jcr:content node, but does have legitimate sub-pages.
+     */
+    @Test
+    public void testNavigationRootMissingJCRContent() {
+        Navigation navigation = getNavigationUnderTest(NAV_COMPONENT_11);
+        Object[][] expectedPages = {
+            {"/content/navigation-missing-jcr-content/navigation-1", 0, false, "/content/navigation-missing-jcr-content/navigation-1.html"},
+            {"/content/navigation-missing-jcr-content/navigation-2", 0, false, "/content/navigation-missing-jcr-content/navigation-2.html"}
+        };
+        verifyNavigationItems(expectedPages, navigation.getItems());
     }
 
     @Test

--- a/bundles/core/src/test/resources/navigation/test-content.json
+++ b/bundles/core/src/test/resources/navigation/test-content.json
@@ -24,6 +24,12 @@
                     "sling:resourceType": "core/wcm/components/navigation/v1/navigation",
                     "navigationRoot"    : "/content/navigation-invalid-redirect",
                     "skipNavigationRoot": false
+                },
+                "navigation-component-11": {
+                    "jcr:primaryType"   : "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/navigation/v1/navigation",
+                    "navigationRoot"    : "/content/navigation-missing-jcr-content",
+                    "skipNavigationRoot": true
                 }
             }
         },
@@ -470,6 +476,25 @@
                         "skipNavigationRoot": false
                     }
                 }
+            }
+        }
+    },
+    "navigation-missing-jcr-content"         : {
+        "jcr:primaryType": "cq:Page",
+        "navigation-1"   : {
+            "jcr:primaryType": "cq:Page",
+            "jcr:content"    : {
+                "jcr:primaryType" : "cq:PageContent",
+                "jcr:title"       : "Navigation 1",
+                "jcr:created"     : "Thu Jun 29 2017 12:13:52 GMT+0200"
+            }
+        },
+        "navigation-2"   : {
+            "jcr:primaryType": "cq:Page",
+            "jcr:content"    : {
+                "jcr:primaryType": "cq:PageContent",
+                "jcr:title"      : "Navigation 2",
+                "jcr:created"    : "Thu Jun 29 2017 12:13:52 GMT+0200"
             }
         }
     }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #703 
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | 👍
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

Fixed #703 wherein a NPE is thrown when a page - that is designated as the navigation root for Navigation component - does not have a jcr:content resource.

There is no need for the page to have a jcr:content resource to serve as the navigation root.
The NPE is caused in the LanguageManager (see #703 for stacktrace). 

Likely the content resource of the page was used because the LanguageManager API requires a resource, and using Page#getContentResource() is the easiest way to convert from the Page API to the Resource API. 

There is, however, no guarantee that any page will have a content resource, thus relying on the (assumed) existence of this resource leads to a NPE.

The change introduced tests that assumption, and if the content resource does not exist then the resource that is located at the same path as the page is used. 

Except in the most extreme edge cases, the following statement will return a non-null value:
`resourceResolver.getResource(page.getPath()).

In the unlikely event that the resource can not be resolved this way, then "navigationRootLanguageRoot" is set to null, which is later checked before being dereferenced. 
