### PR TITLE
Remove image/webp media type - 

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/_cq_dialog/.content.xml
@@ -103,7 +103,7 @@
                                                 fieldLabel="Background Image"
                                                 fileNameParameter="./fileName"
                                                 fileReferenceParameter="./backgroundImageReference"
-                                                mimeTypes="[image/gif,image/jpeg,image/png,image/webp,image/tiff]"
+                                                mimeTypes="[image/gif,image/jpeg,image/png,image/tiff]"
                                                 multiple="{Boolean}false"
                                                 name="./file"
                                                 title="Upload Image Asset"

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_dialog/.content.xml
@@ -27,7 +27,7 @@
                                 fieldLabel="Image asset"
                                 fileNameParameter="./fileName"
                                 fileReferenceParameter="./fileReference"
-                                mimeTypes="[image/gif,image/jpeg,image/png,image/webp,image/tiff,image/svg+xml]"
+                                mimeTypes="[image/gif,image/jpeg,image/png,image/tiff,image/svg+xml]"
                                 multiple="{Boolean}false"
                                 name="./file"
                                 title="Upload Image Asset"

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_editConfig.xml
@@ -4,7 +4,7 @@
     <cq:dropTargets jcr:primaryType="nt:unstructured">
         <image
             jcr:primaryType="cq:DropTargetConfig"
-            accept="[image/gif,image/jpeg,image/png,image/webp,image/tiff,image/svg+xml]"
+            accept="[image/gif,image/jpeg,image/png,image/tiff,image/svg+xml]"
             groups="[media]"
             propertyName="./fileReference">
             <parameters
@@ -24,7 +24,7 @@
                 <crop
                     jcr:primaryType="nt:unstructured"
                     features="*"
-                    supportedMimeTypes="[image/gif,image/jpeg,image/png,image/webp,image/tiff]">
+                    supportedMimeTypes="[image/gif,image/jpeg,image/png,image/tiff]">
                     <aspectRatios jcr:primaryType="nt:unstructured">
                         <wideLandscape
                             jcr:primaryType="nt:unstructured"
@@ -47,14 +47,14 @@
                 <flip
                     jcr:primaryType="nt:unstructured"
                     features="-"
-                    supportedMimeTypes="[image/gif,image/jpeg,image/png,image/webp,image/tiff]"/>
+                    supportedMimeTypes="[image/gif,image/jpeg,image/png,image/tiff]"/>
                 <map
                     jcr:primaryType="nt:unstructured"
                     features="*"/>
                 <rotate
                     jcr:primaryType="nt:unstructured"
                     features="*"
-                    supportedMimeTypes="[image/gif,image/jpeg,image/png,image/webp,image/tiff]"/>
+                    supportedMimeTypes="[image/gif,image/jpeg,image/png,image/tiff]"/>
                 <zoom
                     jcr:primaryType="nt:unstructured"
                     features="*"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_dialog/.content.xml
@@ -55,7 +55,7 @@
                                                 class="cq-droptarget"
                                                 fileNameParameter="./fileName"
                                                 fileReferenceParameter="./fileReference"
-                                                mimeTypes="[image/gif,image/jpeg,image/png,image/webp,image/tiff,image/svg+xml]"
+                                                mimeTypes="[image/gif,image/jpeg,image/png,image/tiff,image/svg+xml]"
                                                 multiple="{Boolean}false"
                                                 name="./file"
                                                 title="Upload Image Asset"

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_editConfig.xml
@@ -4,7 +4,7 @@
     <cq:dropTargets jcr:primaryType="nt:unstructured">
         <image
             jcr:primaryType="cq:DropTargetConfig"
-            accept="[image/gif,image/jpeg,image/png,image/webp,image/tiff,image/svg+xml]"
+            accept="[image/gif,image/jpeg,image/png,image/tiff,image/svg+xml]"
             groups="[media]"
             propertyName="./fileReference">
             <parameters
@@ -23,7 +23,7 @@
             <plugins jcr:primaryType="nt:unstructured">
                 <crop
                     jcr:primaryType="nt:unstructured"
-                    supportedMimeTypes="[image/jpeg,image/png,image/webp,image/tiff]"
+                    supportedMimeTypes="[image/jpeg,image/png,image/tiff]"
                     features="*">
                     <aspectRatios jcr:primaryType="nt:unstructured">
                         <wideLandscape
@@ -46,19 +46,19 @@
                 </crop>
                 <flip
                     jcr:primaryType="nt:unstructured"
-                    supportedMimeTypes="[image/jpeg,image/png,image/webp,image/tiff]"
+                    supportedMimeTypes="[image/jpeg,image/png,image/tiff]"
                     features="-"/>
                 <map
                     jcr:primaryType="nt:unstructured"
-                    supportedMimeTypes="[image/jpeg,image/png,image/webp,image/tiff,image/svg+xml]"
+                    supportedMimeTypes="[image/jpeg,image/png,image/tiff,image/svg+xml]"
                     features="*"/>
                 <rotate
                     jcr:primaryType="nt:unstructured"
-                    supportedMimeTypes="[image/jpeg,image/png,image/webp,image/tiff]"
+                    supportedMimeTypes="[image/jpeg,image/png,image/tiff]"
                     features="*"/>
                 <zoom
                     jcr:primaryType="nt:unstructured"
-                    supportedMimeTypes="[image/jpeg,image/png,image/webp,image/tiff,image/svg+xml]"
+                    supportedMimeTypes="[image/jpeg,image/png,image/tiff,image/svg+xml]"
                     features="*"/>
             </plugins>
             <ui jcr:primaryType="nt:unstructured">

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -40,7 +40,7 @@
                                                 fieldLabel="Image Asset"
                                                 fileNameParameter="./fileName"
                                                 fileReferenceParameter="./fileReference"
-                                                mimeTypes="[image/gif,image/jpeg,image/png,image/webp,image/tiff]"
+                                                mimeTypes="[image/gif,image/jpeg,image/png,image/tiff]"
                                                 multiple="{Boolean}false"
                                                 name="./file"
                                                 title="Upload Image Asset"

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_editConfig.xml
@@ -4,7 +4,7 @@
     <cq:dropTargets jcr:primaryType="nt:unstructured">
         <image
             jcr:primaryType="cq:DropTargetConfig"
-            accept="[image/gif,image/jpeg,image/png,image/webp,image/tiff]"
+            accept="[image/gif,image/jpeg,image/png,image/tiff]"
             groups="[media]"
             propertyName="./fileReference">
             <parameters


### PR DESCRIPTION
it's supported neither by AEM Assets nor by the Core Component Image component.
i think this was introduced (probably accidentally) in #32 and copied from there to the other places.

| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | 
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0
