### PR TITLE
Ensure download component has a valid asset reference or file upload

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
@@ -15,7 +15,7 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.download="com.adobe.cq.wcm.core.components.models.Download"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-     data-sly-test.hasContent="${download.title || download.description || download.actionText}"
+     data-sly-test.hasContent="${download.filename}"
      class="cmp-download${!wcmmode.disabled ? ' cq-dd-file' : ''}">
     <h3 class="cmp-download__title" data-sly-test.title="${download.title}" data-sly-element="${download.titleType}">
         <a data-sly-unwrap="${!download.url}" class="cmp-download__title-link" href="${download.url}">${title}</a>


### PR DESCRIPTION
evaluate if download has content by checking the "filename" property - it contains only a value if an asset reference or upload is present and valid
eliminate the checks for title, description and action text - a download component without any of these is fine, but any of these without a valid download does not make sense

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | 
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0
