### PR TITLE
@releng Save Test Results and Dumps, Create Test Summary in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,34 @@ shared: &shared
     # run tests!
     - run: mvn clean verify -B -U
 
+    # store any dumps
+    - run:
+        name: save any dumps
+        command: |
+            mkdir -p ~/dumps
+            find . -type f -regex ".*/.*\.dump" -exec cp {} ~/dumps \;
+            find . -type f -regex ".*/.*\.dumpstream" -exec cp {} ~/dumps \;
+        when:
+            on_fail
+
+    - store_artifacts:
+        path: ~/dumps
+
+    # save test results
+    - run:
+        name: Save test results
+        command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/surefire-reports/.*" -exec cp {} ~/test-results/junit/ \;
+        when: always
+
+    - store_artifacts:
+        path: ~/test-results/junit
+
+    # generate test summary
+    - store_test_results:
+        path: ~/test-results
+
     - save_cache: # saves the project dependencies
         paths:
           - ~/.m2


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | -
| Patch: Bug Fix?          | -
| Minor: New Feature?      | -
| Major: Breaking Change?  | -
| Tests Added + Pass?      | -
| Documentation Provided   | Yes
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Extending circleCI config.yaml to:
- store the junit test results as artifacts
- store an *.dump or *.dumpstream files in case of failure as artifacts
- create the test summary 
