### PR TITLE
[Content Fragment] Order content fragments in asc of node - Fixes #698

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentListImpl.java
@@ -130,6 +130,9 @@ public class ContentFragmentListImpl implements ContentFragmentList {
         queryParameterMap.put("p.limit", Integer.toString(maxItems));
         queryParameterMap.put("1_property", JcrConstants.JCR_CONTENT + "/data/cq:model");
         queryParameterMap.put("1_property.value", modelPath);
+        queryParameterMap.put("orderby", "@jcr:created");
+        queryParameterMap.put("orderby.sort", "asc");
+        
 
         ArrayList<String> allTags = new ArrayList<>();
         if (tagNames != null && tagNames.length > 0) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtilsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtilsTest.java
@@ -210,7 +210,7 @@ public class ContentFragmentUtilsTest {
                 new String[]{"foo", "bar"});
 
         // THEN
-        Assert.assertThat(expectedJsonOutput.replaceAll("[\n\t ]", ""), CoreMatchers.is(json));
+        Assert.assertThat(expectedJsonOutput.replaceAll("[\n\t\r ]", ""), CoreMatchers.is(json));
     }
 
     @Test

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -151,12 +151,9 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.21.0</version>
+                    <version>2.22.1</version>
                     <configuration>
                         <useSystemClassLoader>false</useSystemClassLoader>
-                        <skipTests>false</skipTests>
-		                <testFailureIgnore>true</testFailureIgnore>
-		                <forkMode>once</forkMode>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -354,8 +351,6 @@
                             <exclude>**/node_modules/**</exclude>
                             <!-- Ignore github templates -->
                             <exclude>**/.github/**</exclude>
-                            <!-- Ignore jacoco.exec file -->
-                            <exclude>**/jacoco.exec/**</exclude>
                         </excludes>
                     </configuration>
                     <executions>
@@ -791,7 +786,7 @@
       NOTE: To use these dav: URLs, the WebDAV extension to Maven Wagon must
       be declared in the build section above.
     -->
-    <distributionManagement>
+  <distributionManagement>
         <repository>
             <id>${releaseRepository-Id}</id>
             <url>${releaseRepository-URL}</url>
@@ -802,5 +797,4 @@
             <uniqueVersion>false</uniqueVersion>
         </snapshotRepository>
     </distributionManagement>
-
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -154,6 +154,9 @@
                     <version>2.21.0</version>
                     <configuration>
                         <useSystemClassLoader>false</useSystemClassLoader>
+                        <skipTests>false</skipTests>
+		                <testFailureIgnore>true</testFailureIgnore>
+		                <forkMode>once</forkMode>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -351,6 +354,8 @@
                             <exclude>**/node_modules/**</exclude>
                             <!-- Ignore github templates -->
                             <exclude>**/.github/**</exclude>
+                            <!-- Ignore jacoco.exec file -->
+                            <exclude>**/jacoco.exec/**</exclude>
                         </excludes>
                     </configuration>
                     <executions>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -151,7 +151,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.1</version>
+                    <version>2.22.2</version>
                     <configuration>
                         <useSystemClassLoader>false</useSystemClassLoader>
                     </configuration>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Content fragments will be displayed in a predictable order inside "Content fragment list" (first created will be displayed first) #698 
| Patch: Bug Fix?          | No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | No
| Any Dependency Changes?  | Yes, surefire version upgraded to make the build successful 
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

Current Behaviour: "Content fragments" inside "content fragment list" displayed based on "last modified- desc order" (recently updated content fragment will go to the bottom). which will keep on changing when the author updated the content.

To maintain the consistent JSON format, have added "orderby" predicate to query which is creating content fragments.
