### PR TITLE
[Search] Results are not limited to specified directory #835

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/SearchResultServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/SearchResultServlet.java
@@ -65,13 +65,13 @@ import com.day.cq.wcm.msm.api.LiveRelationshipManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Component(
-    service = Servlet.class,
-    property = {
-        "sling.servlet.selectors=" + SearchResultServlet.DEFAULT_SELECTOR,
-        "sling.servlet.resourceTypes=cq/Page",
-        "sling.servlet.extensions=json",
-        "sling.servlet.methods=GET"
-    }
+        service = Servlet.class,
+        property = {
+                "sling.servlet.selectors=" + SearchResultServlet.DEFAULT_SELECTOR,
+                "sling.servlet.resourceTypes=cq/Page",
+                "sling.servlet.extensions=json",
+                "sling.servlet.methods=GET"
+        }
 )
 public class SearchResultServlet extends SlingSafeMethodsServlet {
 
@@ -99,7 +99,7 @@ public class SearchResultServlet extends SlingSafeMethodsServlet {
 
     @Override
     protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response)
-        throws IOException {
+            throws IOException {
         Page currentPage = getCurrentPage(request);
         if (currentPage != null) {
             Resource searchResource = getSearchContentResource(request, currentPage);
@@ -140,9 +140,9 @@ public class SearchResultServlet extends SlingSafeMethodsServlet {
         }
         if (StringUtils.isNotEmpty(relativeContentResource)) {
             searchContentResource = resource.getChild(relativeContentResource);
-            if(searchContentResource == null) {
-                searchContentResource = getSearchContentResourceFromFragments(resource.getChild(JCR_CONTENT),relativeContentResource);
-                if(searchContentResource == null) {
+            if (searchContentResource == null) {
+                searchContentResource = getSearchContentResourceFromFragments(resource.getChild(JCR_CONTENT), relativeContentResource);
+                if (searchContentResource == null) {
                     PageManager pageManager = resource.getResourceResolver().adaptTo(PageManager.class);
                     if (pageManager != null) {
                         Template template = currentPage.getTemplate();
@@ -156,7 +156,6 @@ public class SearchResultServlet extends SlingSafeMethodsServlet {
                 }
             }
         }
-
         return searchContentResource;
     }
 
@@ -197,9 +196,9 @@ public class SearchResultServlet extends SlingSafeMethodsServlet {
             ValueMap valueMap = searchResource.getValueMap();
             ValueMap contentPolicyMap = getContentPolicyProperties(searchResource, request.getResource());
             searchTermMinimumLength = valueMap.get(Search.PN_SEARCH_TERM_MINIMUM_LENGTH, contentPolicyMap.get(Search
-                .PN_SEARCH_TERM_MINIMUM_LENGTH, SearchImpl.PROP_SEARCH_TERM_MINIMUM_LENGTH_DEFAULT));
+                        .PN_SEARCH_TERM_MINIMUM_LENGTH, SearchImpl.PROP_SEARCH_TERM_MINIMUM_LENGTH_DEFAULT));
             resultsSize = valueMap.get(Search.PN_RESULTS_SIZE, contentPolicyMap.get(Search.PN_RESULTS_SIZE,
-                SearchImpl.PROP_RESULTS_SIZE_DEFAULT));
+                        SearchImpl.PROP_RESULTS_SIZE_DEFAULT));
             String searchRoot = valueMap.get(Search.PN_SEARCH_ROOT, contentPolicyMap.get(Search.PN_SEARCH_ROOT, SearchImpl.PROP_SEARCH_ROOT_DEFAULT));
             searchRootPagePath = getSearchRootPagePath(searchRoot, currentPage);
         } else {
@@ -265,10 +264,10 @@ public class SearchResultServlet extends SlingSafeMethodsServlet {
                     // ignore it
                 }
                 if (searchRootLanguageRoot != null && currentPageLanguageRoot != null && !searchRootLanguageRoot.equals
-                    (currentPageLanguageRoot)) {
+                        (currentPageLanguageRoot)) {
                     // check if there's a language copy of the search root
                     Page languageCopySearchRoot = pageManager.getPage(ResourceUtil.normalize(currentPageLanguageRoot.getPath() + "/" +
-                        getRelativePath(searchRootLanguageRoot, rootPage)));
+                            getRelativePath(searchRootLanguageRoot, rootPage)));
                     if (languageCopySearchRoot != null) {
                         rootPage = languageCopySearchRoot;
                     }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  #835
| Patch: Bug Fix?          | 👍 
| Minor: New Feature?      | 👍 
| Major: Breaking Change?  | 👍 
| Tests Added + Pass?      | 
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0


Extended the core Search component and authored the Search component in XF (Experience Fragment) configured the search component.
ex : 
Search Root * :  "/content/project/us/en/abc" 
Search component searches from "/Content/project/*"

Experience Fragment with Search component included in the page, Search results are different from configured "Search Root *".

Changes I have made in [0] finding the "fragmentPath" and passing the "relative content resource 
ex: [1]" to get the Search resource.

[0] : src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/SearchResultServlet.java
 [1] : jcr:content/root/search

Attached Images:

![search-in-XF](https://user-images.githubusercontent.com/43966833/64357575-8b893000-d022-11e9-9857-619c6a94b54b.JPG)
![Search-in-PAGE](https://user-images.githubusercontent.com/43966833/64357577-8b893000-d022-11e9-8e06-0667c063a629.JPG)




