### PR TITLE
Allow empty content fragment in JSON

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
@@ -35,8 +35,6 @@ import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.apache.sling.models.factory.ModelFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.dam.cfm.content.FragmentRenderService;
 import com.adobe.cq.dam.cfm.converter.ContentTypeConverter;
@@ -60,8 +58,6 @@ import com.adobe.cq.wcm.core.components.models.contentfragment.DAMContentFragmen
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME,
           extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class ContentFragmentImpl implements ContentFragment {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ContentFragmentImpl.class);
 
     /**
      * The resource type of the component associated with this Sling model.
@@ -102,39 +98,34 @@ public class ContentFragmentImpl implements ContentFragment {
                    injectionStrategy = InjectionStrategy.OPTIONAL)
     private String displayMode;
 
-    private DAMContentFragment damContentFragment;
+    private DAMContentFragment damContentFragment = new EmptyContentFragment();
 
     @PostConstruct
     private void initModel() {
         if (StringUtils.isNotEmpty(fragmentPath)) {
-            // get fragment resource
             Resource fragmentResource = resourceResolver.getResource(fragmentPath);
-            if (fragmentResource == null) {
-                LOG.error("Content Fragment can not be initialized because the '{}' does not exist.", fragmentPath);
-            } else {
-                this.damContentFragment = new DAMContentFragmentImpl(fragmentResource, contentTypeConverter, variationName, elementNames);
+            if (fragmentResource != null) {
+                damContentFragment = new DAMContentFragmentImpl(fragmentResource, contentTypeConverter, variationName, elementNames);
             }
-        } else {
-            LOG.warn("Please provide a path for the content fragment component.");
         }
     }
 
     @Nullable
     @Override
     public String getTitle() {
-        return getDAMContentFragment().getTitle();
+        return damContentFragment.getTitle();
     }
 
     @Nullable
     @Override
     public String getDescription() {
-        return getDAMContentFragment().getDescription();
+        return damContentFragment.getDescription();
     }
 
     @Nullable
     @Override
     public String getType() {
-        return getDAMContentFragment().getType();
+        return damContentFragment.getType();
     }
 
     @NotNull
@@ -146,31 +137,31 @@ public class ContentFragmentImpl implements ContentFragment {
     @NotNull
     @Override
     public String getEditorJSON() {
-        return getDAMContentFragment().getEditorJSON();
+        return damContentFragment.getEditorJSON();
     }
 
     @NotNull
     @Override
     public Map<String, DAMContentElement> getExportedElements() {
-        return getDAMContentFragment().getExportedElements();
+        return damContentFragment.getExportedElements();
     }
 
     @NotNull
     @Override
     public String[] getExportedElementsOrder() {
-        return getDAMContentFragment().getExportedElementsOrder();
+        return damContentFragment.getExportedElementsOrder();
     }
 
     @Nullable
     @Override
     public List<DAMContentElement> getElements() {
-        return getDAMContentFragment().getElements();
+        return damContentFragment.getElements();
     }
 
     @Nullable
     @Override
     public List<Resource> getAssociatedContent() {
-        return getDAMContentFragment().getAssociatedContent();
+        return damContentFragment.getAssociatedContent();
     }
 
     @NotNull
@@ -195,46 +186,7 @@ public class ContentFragmentImpl implements ContentFragment {
      * Returns the delegate, i.e. the {@link DAMContentFragment content fragment}.
      */
     private DAMContentFragment getDAMContentFragment() {
-        if (damContentFragment != null) {
-            return damContentFragment;
-        } else {
-            return new DAMContentFragment() {
-                @Override
-                public @Nullable String getTitle() {
-                    return null;
-                }
-
-                @Override
-                public @Nullable String getDescription() {
-                    return null;
-                }
-
-                @Override
-                public @Nullable String getType() {
-                    return null;
-                }
-
-                @Override
-                public @Nullable List<DAMContentElement> getElements() {
-                    return null;
-                }
-
-                @Override
-                public @NotNull Map<String, DAMContentElement> getExportedElements() {
-                    return new HashMap<>();
-                }
-
-                @Override
-                public @NotNull String[] getExportedElementsOrder() {
-                    return new String[0];
-                }
-
-                @Override
-                public @Nullable List<Resource> getAssociatedContent() {
-                    return null;
-                }
-            };
-        }
+        return damContentFragment;
     }
 
     @Nullable
@@ -263,5 +215,46 @@ public class ContentFragmentImpl implements ContentFragment {
 
         // split into paragraphs
         return content.split("(?=(<p>|<h1>|<h2>|<h3>|<h4>|<h5>|<h6>))");
+    }
+
+
+    /**
+     * Empty placeholder content fragment.
+     */
+    public static class EmptyContentFragment implements DAMContentFragment {
+        @Override
+        public @Nullable String getTitle() {
+            return null;
+        }
+
+        @Override
+        public @Nullable String getDescription() {
+            return null;
+        }
+
+        @Override
+        public @Nullable String getType() {
+            return null;
+        }
+
+        @Override
+        public @Nullable List<DAMContentElement> getElements() {
+            return null;
+        }
+
+        @Override
+        public @NotNull Map<String, DAMContentElement> getExportedElements() {
+            return new HashMap<>();
+        }
+
+        @Override
+        public @NotNull String[] getExportedElementsOrder() {
+            return new String[0];
+        }
+
+        @Override
+        public @Nullable List<Resource> getAssociatedContent() {
+            return null;
+        }
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
@@ -15,9 +15,9 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
@@ -57,7 +57,8 @@ import com.adobe.cq.wcm.core.components.models.contentfragment.DAMContentFragmen
         },
         resourceType = ContentFragmentImpl.RESOURCE_TYPE
 )
-@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME,
+          extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class ContentFragmentImpl implements ContentFragment {
 
     private static final Logger LOG = LoggerFactory.getLogger(ContentFragmentImpl.class);
@@ -85,16 +86,20 @@ public class ContentFragmentImpl implements ContentFragment {
     @ScriptVariable
     private Resource resource;
 
-    @ValueMapValue(name = ContentFragment.PN_PATH, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @ValueMapValue(name = ContentFragment.PN_PATH,
+                   injectionStrategy = InjectionStrategy.OPTIONAL)
     private String fragmentPath;
 
-    @ValueMapValue(name = ContentFragment.PN_ELEMENT_NAMES, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @ValueMapValue(name = ContentFragment.PN_ELEMENT_NAMES,
+                   injectionStrategy = InjectionStrategy.OPTIONAL)
     private String[] elementNames;
 
-    @ValueMapValue(name = ContentFragment.PN_VARIATION_NAME, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @ValueMapValue(name = ContentFragment.PN_VARIATION_NAME,
+                   injectionStrategy = InjectionStrategy.OPTIONAL)
     private String variationName;
 
-    @ValueMapValue(name = ContentFragment.PN_DISPLAY_MODE, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @ValueMapValue(name = ContentFragment.PN_DISPLAY_MODE,
+                   injectionStrategy = InjectionStrategy.OPTIONAL)
     private String displayMode;
 
     private DAMContentFragment damContentFragment;
@@ -190,10 +195,46 @@ public class ContentFragmentImpl implements ContentFragment {
      * Returns the delegate, i.e. the {@link DAMContentFragment content fragment}.
      */
     private DAMContentFragment getDAMContentFragment() {
-        if (damContentFragment == null) {
-            throw new IllegalStateException("There is no content fragment available to delegate to");
+        if (damContentFragment != null) {
+            return damContentFragment;
+        } else {
+            return new DAMContentFragment() {
+                @Override
+                public @Nullable String getTitle() {
+                    return null;
+                }
+
+                @Override
+                public @Nullable String getDescription() {
+                    return null;
+                }
+
+                @Override
+                public @Nullable String getType() {
+                    return null;
+                }
+
+                @Override
+                public @Nullable List<DAMContentElement> getElements() {
+                    return null;
+                }
+
+                @Override
+                public @NotNull Map<String, DAMContentElement> getExportedElements() {
+                    return new HashMap<>();
+                }
+
+                @Override
+                public @NotNull String[] getExportedElementsOrder() {
+                    return new String[0];
+                }
+
+                @Override
+                public @Nullable List<Resource> getAssociatedContent() {
+                    return null;
+                }
+            };
         }
-        return damContentFragment;
     }
 
     @Nullable

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
@@ -182,13 +182,6 @@ public class ContentFragmentImpl implements ContentFragment {
         return ContentFragmentUtils.getItemsOrder(getExportedItems());
     }
 
-    /**
-     * Returns the delegate, i.e. the {@link DAMContentFragment content fragment}.
-     */
-    private DAMContentFragment getDAMContentFragment() {
-        return damContentFragment;
-    }
-
     @Nullable
     @Override
     public String[] getParagraphs() {
@@ -196,11 +189,11 @@ public class ContentFragmentImpl implements ContentFragment {
             return null;
         }
 
-        if (getDAMContentFragment().getElements() == null || getDAMContentFragment().getElements().isEmpty()) {
+        if (damContentFragment.getElements() == null || damContentFragment.getElements().isEmpty()) {
             return null;
         }
 
-        DAMContentElement damContentElement = getDAMContentFragment().getElements().get(0);
+        DAMContentElement damContentElement = damContentFragment.getElements().get(0);
 
         // restrict this method to text elements
         if (!damContentElement.isMultiLine()) {
@@ -221,7 +214,7 @@ public class ContentFragmentImpl implements ContentFragment {
     /**
      * Empty placeholder content fragment.
      */
-    public static class EmptyContentFragment implements DAMContentFragment {
+    private static class EmptyContentFragment implements DAMContentFragment {
         @Override
         public @Nullable String getTitle() {
             return null;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
@@ -116,7 +116,6 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
         assertNull(fragment.getAssociatedContent());
         assertTrue(fragment.getExportedElements().isEmpty());
         assertEquals(0, fragment.getExportedElementsOrder().length);
-
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
@@ -135,6 +135,14 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     void structuredNonExistingPath() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_NON_EXISTING_PATH);
         assertNotNull("Model shouldn't be null when the path does not exist", fragment);
+        assertNull(fragment.getTitle());
+        assertNull(fragment.getDescription());
+        assertNull(fragment.getType());
+        assertNull(fragment.getElements());
+        assertNull(fragment.getAssociatedContent());
+        assertTrue(fragment.getExportedElements().isEmpty());
+        assertEquals(0, fragment.getExportedElementsOrder().length);
+
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
@@ -24,8 +24,6 @@ import org.apache.sling.api.resource.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.wcm.core.components.Utils;
@@ -36,7 +34,6 @@ import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(AemContextExtension.class)
@@ -44,9 +41,6 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
 
     private static final String MAIN_CONTENT = "<p>Main content</p>";
     private static final String TEST_BASE = "/contentfragment";
-
-    private Logger cfmLogger;
-    private Logger modelLogger;
 
     @Override
     protected String getTestResourcesParentPath() {
@@ -61,31 +55,11 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     @BeforeEach
     void setUp() throws NoSuchFieldException, IllegalAccessException {
         super.setUp();
-        cfmLogger = spy(LoggerFactory.getLogger("FakeLoggerCFM"));
-        setFakeLoggerOnClass(DAMContentFragmentImpl.class, cfmLogger);
-
-        modelLogger = spy(LoggerFactory.getLogger("FakeLoggerModel"));
-        setFakeLoggerOnClass(ContentFragmentImpl.class, modelLogger);
-    }
-
-    @Test
-    void textOnlyNoPath() {
-        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_NO_PATH);
-        verify(modelLogger).warn("Please provide a path for the content fragment component.");
-        assertNotNull("Model shouldn't be null when no path is set", fragment);
-    }
-
-    @Test
-    void textOnlyNonExistingPath() {
-        ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_NON_EXISTING_PATH);
-        verify(modelLogger).error("Content Fragment can not be initialized because the '{}' does not exist.", "/content/dam/contentfragments/non-existing");
-        assertNotNull("Model shouldn't be null when the path does not exist", fragment);
     }
 
     @Test
     void textOnlyInvalidPath() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_INVALID_PATH);
-        verify(cfmLogger).error("Content Fragment can not be initialized because '{}' is not a content fragment.", "/content/dam/contentfragments");
         assertNotNull("Model shouldn't be null when the path is not a content fragment", fragment);
     }
 
@@ -219,8 +193,8 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
         final Map<String, DAMContentFragment.DAMContentElement> elements = fragment.getExportedElements();
         assertNotNull(elements);
         assertEquals(2, elements.size());
-        assertEquals(true, elements.containsKey("main"));
-        assertEquals(true, elements.containsKey("second"));
+        assertTrue(elements.containsKey("main"));
+        assertTrue(elements.containsKey("second"));
     }
 
     @Test


### PR DESCRIPTION
- return an empty content fragment in case the path to the content fragment is empty or not valid.

fixes #720 