### PR TITLE
Canonical url and meta attributes

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -340,6 +340,11 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.10</version>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/PageUtils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/PageUtils.java
@@ -1,0 +1,52 @@
+package com.adobe.cq.wcm.core.components.internal;
+
+import org.apache.http.conn.util.InetAddressUtils;
+
+public final class PageUtils {
+
+    /* Hide the constructor of PageUtils class */
+    private PageUtils() {
+    }
+
+    /**
+     * Checks if serverName is a valid IPv4 address
+     *
+     * @param serverName from the current request
+     * @return true if serverName is an valid IPv4 addres
+     */
+    public static boolean isServerNameAnIpAddress(String serverName) {
+        return InetAddressUtils.isIPv4Address(serverName);
+    }
+
+    /**
+     * Checks if serverName is localhost
+     *
+     * @param serverName from the current request
+     * @return true if serverName is equal to localhost
+     */
+    public static boolean isServerNameLocalhost(String serverName) {
+        return "localhost".equals(serverName);
+    }
+
+    /**
+     * Removes selectors and suffixes from the URL
+     *
+     * @param url from the current request
+     * @param selectors of the url from the current request
+     * @param suffixes of the url from the current request
+     * @return cleanerUrl without selectors and suffixes as the canonical url
+     */
+    public static String removeSelectorsAndSuffixesFromURL(String url, String selectors, String suffixes) {
+        String cleanedUrl = url;
+
+        if (selectors != null) {
+            cleanedUrl = cleanedUrl.replace("." + selectors, "");
+        }
+
+        if (suffixes != null) {
+            cleanedUrl = cleanedUrl.replace(suffixes, "");
+        }
+        return cleanedUrl;
+    }
+
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/SocialMediaHelperImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/SocialMediaHelperImpl.java
@@ -109,7 +109,7 @@ public class SocialMediaHelperImpl implements SocialMediaHelper {
     @OSGiService
     private Externalizer externalizer = null;
 
-    @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @ScriptVariable
     protected Style currentStyle;
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
@@ -198,6 +198,7 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
         return hasCloudconfigSupport;
     }
 
+    @Override
     public String getCanonicalURLOfPage() {
         String serverName = request.getServerName();
         String requestSelectors = request.getRequestPathInfo().getSelectorString();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
@@ -37,6 +37,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.Version;
 
+import com.adobe.cq.wcm.core.components.internal.PageUtils;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.export.json.ExporterConstants;
@@ -74,7 +75,7 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     private ComponentContext componentContext;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL,
-                   name = PN_REDIRECT_TARGET)
+        name = PN_REDIRECT_TARGET)
     private String redirectTargetValue;
 
     private String appResourcesPath;
@@ -89,7 +90,7 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
         String resourcesClientLibrary = currentStyle.get(PN_APP_RESOURCES_CLIENTLIB, String.class);
         if (resourcesClientLibrary != null) {
             Collection<ClientLibrary> clientLibraries =
-                    htmlLibraryManager.getLibraries(new String[]{resourcesClientLibrary}, LibraryType.CSS, true, true);
+                htmlLibraryManager.getLibraries(new String[]{resourcesClientLibrary}, LibraryType.CSS, true, true);
             ArrayList<ClientLibrary> clientLibraryList = Lists.newArrayList(clientLibraries.iterator());
             if (!clientLibraryList.isEmpty()) {
                 appResourcesPath = getProxyPath(clientLibraryList.get(0));
@@ -188,7 +189,7 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     public boolean hasCloudconfigSupport() {
         if (hasCloudconfigSupport == null) {
             if (productInfoProvider == null || productInfoProvider.getProductInfo() == null ||
-                    productInfoProvider.getProductInfo().getVersion() == null) {
+                productInfoProvider.getProductInfo().getVersion() == null) {
                 hasCloudconfigSupport = false;
             } else {
                 hasCloudconfigSupport = productInfoProvider.getProductInfo().getVersion().compareTo(new Version("6.4.0")) >= 0;
@@ -196,4 +197,19 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
         }
         return hasCloudconfigSupport;
     }
+
+    public String getCanonicalURLOfPage() {
+        String serverName = request.getServerName();
+        String requestSelectors = request.getRequestPathInfo().getSelectorString();
+        String requestSuffixes = request.getRequestPathInfo().getSuffix();
+        String url;
+
+        if (PageUtils.isServerNameAnIpAddress(serverName) || PageUtils.isServerNameLocalhost(serverName)) {
+            url = request.getRequestURI();
+        } else {
+            url = request.getRequestURL().toString();
+        }
+        return PageUtils.removeSelectorsAndSuffixesFromURL(url, requestSelectors, requestSuffixes);
+    }
+
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
@@ -347,4 +347,14 @@ public interface Page extends ContainerExporter {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     *
+     * Returns the canonical URL of page in the <head></head> section of HTML markup
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.10.0
+     */
+    default String getCanonicalURLOfPage()  {
+        throw new UnsupportedOperationException();
+    }
+
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/SocialMediaHelper.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/SocialMediaHelper.java
@@ -61,6 +61,14 @@ public interface SocialMediaHelper extends ComponentExporter {
     String PV_PINTEREST = "pinterest";
 
     /**
+     * Possible value of the {@link #PN_SOCIAL_MEDIA} resource property.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.10.0
+     */
+    String PV_TWITTER = "twitter";
+
+
+    /**
      * Returns {@code true} if Facebook sharing is enabled in page configuration, {@code false} otherwise.
      *
      * @return {@code true} if Facebook sharing is enabled in page configuration, {@code false} otherwise
@@ -77,6 +85,16 @@ public interface SocialMediaHelper extends ComponentExporter {
      * @since com.adobe.cq.wcm.core.components.models 11.0.0; marked <code>default</code> in 12.1.0
      */
     default boolean isPinterestEnabled() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns {@code true} if Twitter sharing is enabled in page configuration, {@code false} otherwise.
+     *
+     * @return {@code true} if Twitter sharing is enabled in page configuration, {@code false} otherwise
+     * @since com.adobe.cq.wcm.core.components.models 12.10.0
+     */
+    default boolean isTwitterEnabled() {
         throw new UnsupportedOperationException();
     }
 
@@ -115,12 +133,34 @@ public interface SocialMediaHelper extends ComponentExporter {
     }
 
     /**
+     * Returns {@code true} if Twitter sharing is enabled in page configuration and the page contains the sharing component, {@code
+     * false} otherwise
+     *
+     * @return {@code true} if Twitter sharing is enabled in page configuration and the page contains the sharing component, {@code
+     * false} otherwise
+     * @since com.adobe.cq.wcm.core.components.models 12.10.0
+     */
+    default boolean hasTwitterSharing() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Returns the social media metadata for the current page.
      *
      * @return the social media metadata for the current page; the {@link Map} can be empty if there's no social media configuration
-     * @since com.adobe.cq.wcm.core.components.models 11.0.0; marked <code>default</code> in 12.1.0
+     * @since com.adobe.cq.wcm.core.components.models 12.10.0
      */
-    default Map<String, String> getMetadata() {
+    default Map<String, String> getMetadataProperties() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the social media metadata for the current page.
+     *
+     * @return the social media metadata for the current page; the {@link Map} can be empty if there's no social media configuration
+     * @since com.adobe.cq.wcm.core.components.models 12.10.0
+     */
+    default Map<String, String> getMetadataNames() {
         throw new UnsupportedOperationException();
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.9.0")
+@Version("12.10.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImplTest.java
@@ -143,6 +143,8 @@ public class PageImplTest {
         Resource resource = context.currentResource(pagePath + "/" + JcrConstants.JCR_CONTENT);
         MockSlingHttpServletRequest request = context.request();
         context.request().setContextPath("/core");
+        context.requestPathInfo().setResourcePath(pagePath);
+        context.requestPathInfo().setExtension("html");
 
         if (resource != null && !propertyMap.isEmpty()) {
             if (propertyMap.containsKey(DESIGN_PATH_KEY)) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/SocialMediaHelperImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/SocialMediaHelperImplTest.java
@@ -15,21 +15,9 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
-import java.util.HashMap;
-import java.util.Map;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-import org.apache.sling.api.adapter.AdapterFactory;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.scripting.SlingBindings;
-import org.apache.sling.testing.mock.sling.servlet.MockRequestPathInfo;
-import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
-import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import com.adobe.cq.sightly.WCMBindings;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.SocialMediaHelper;
 import com.adobe.cq.wcm.core.components.testing.MockCommerceFactory;
@@ -39,9 +27,14 @@ import com.day.cq.commons.Externalizer;
 import com.day.cq.wcm.api.Page;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.adapter.AdapterFactory;
+import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(AemContextExtension.class)
 class SocialMediaHelperImplTest {
@@ -71,72 +64,86 @@ class SocialMediaHelperImplTest {
         context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, CONTENT_ROOT);
         context.registerService(Externalizer.class, MockExternalizerFactory.getExternalizerService());
         context.registerService(AdapterFactory.class, new AdapterFactory() {
-                    @Override
-                    @SuppressWarnings("unchecked")
-                    public <AdapterType> AdapterType getAdapter(@NotNull Object o, @NotNull Class<AdapterType> clazz) {
-                        Object result = null;
-                        switch (clazz.getName()) {
-                            case CLASS_PRODUCT:
-                                if (o instanceof Resource) {
-                                    result = MockCommerceFactory.getProduct((Resource) o);
-                                }
-                                break;
-                            case CLASS_COMMERCE_SERVICE:
-                                if (o instanceof Resource) {
-                                    result = MockCommerceFactory.getCommerceService((Resource) o);
-                                }
-                                break;
-                            case CLASS_XF_SOCIAL_VARIATION:
-                                if (o instanceof Page) {
-                                    result = MockXFFactory.getExperienceFragmentSocialVariation((Page) o);
-                                }
-                        }
-
-                        return (AdapterType) result;
+                @Override
+                @SuppressWarnings("unchecked")
+                public <AdapterType> AdapterType getAdapter(@NotNull Object o, @NotNull Class<AdapterType> clazz) {
+                    Object result = null;
+                    switch (clazz.getName()) {
+                        case CLASS_PRODUCT:
+                            if (o instanceof Resource) {
+                                result = MockCommerceFactory.getProduct((Resource) o);
+                            }
+                            break;
+                        case CLASS_COMMERCE_SERVICE:
+                            if (o instanceof Resource) {
+                                result = MockCommerceFactory.getCommerceService((Resource) o);
+                            }
+                            break;
+                        case CLASS_XF_SOCIAL_VARIATION:
+                            if (o instanceof Page) {
+                                result = MockXFFactory.getExperienceFragmentSocialVariation((Page) o);
+                            }
                     }
-                },
-            new HashMap<String, Object>(){{
-                put(AdapterFactory.ADAPTABLE_CLASSES, new String[] {
-                        CLASS_RESOURCE,
-                        CLASS_PAGE
+
+                    return (AdapterType) result;
+                }
+            },
+            new HashMap<String, Object>() {{
+                put(AdapterFactory.ADAPTABLE_CLASSES, new String[]{
+                    CLASS_RESOURCE,
+                    CLASS_PAGE
                 });
-                put(AdapterFactory.ADAPTER_CLASSES, new String[] {
-                        CLASS_PRODUCT,
-                        CLASS_COMMERCE_SERVICE,
-                        CLASS_XF_SOCIAL_VARIATION
+                put(AdapterFactory.ADAPTER_CLASSES, new String[]{
+                    CLASS_PRODUCT,
+                    CLASS_COMMERCE_SERVICE,
+                    CLASS_XF_SOCIAL_VARIATION
                 });
             }}
         );
     }
 
     @Test
-    void testWebsiteProvider() {
+    void testWebsiteProvider_BasicSharingPage_1() {
         SocialMediaHelper socialMediaHelper = getSocialMediaHelperUnderTest(BASIC_SHARING_PAGE_1);
         assertTrue(socialMediaHelper.isSocialMediaEnabled());
         assertTrue(socialMediaHelper.isFacebookEnabled());
         assertTrue(socialMediaHelper.isPinterestEnabled());
         assertTrue(socialMediaHelper.hasFacebookSharing());
         assertTrue(socialMediaHelper.hasPinterestSharing());
-        Map<String, String> metadata = socialMediaHelper.getMetadata();
-        assertEquals("About Us", metadata.get(SocialMediaHelperImpl.OG_TITLE));
-        assertEquals("About Us Page", metadata.get(SocialMediaHelperImpl.OG_DESCRIPTION));
-        assertEquals(MockExternalizerFactory.ROOT + BASIC_SHARING_PAGE_1 + "." + EXTENSION, metadata.get(SocialMediaHelperImpl
-                .OG_URL));
-        assertEquals("website", metadata.get(SocialMediaHelperImpl.OG_TYPE));
-        assertEquals("About Us", metadata.get(SocialMediaHelperImpl.OG_SITE_NAME));
+        Map<String, String> metadataProperties = socialMediaHelper.getMetadataProperties();
+        assertEquals("About Us", metadataProperties.get(SocialMediaHelperImpl.OG_TITLE));
+        assertEquals("About Us Page", metadataProperties.get(SocialMediaHelperImpl.OG_DESCRIPTION));
+        assertEquals(MockExternalizerFactory.ROOT + BASIC_SHARING_PAGE_1 + "." + EXTENSION, metadataProperties.get(SocialMediaHelperImpl
+            .OG_URL));
+        assertEquals("website", metadataProperties.get(SocialMediaHelperImpl.OG_TYPE));
+        assertEquals("About Us", metadataProperties.get(SocialMediaHelperImpl.OG_SITE_NAME));
         assertEquals(MockExternalizerFactory.ROOT + BASIC_SHARING_PAGE_1 + ".thumb.800.480.png?ck=1495097346",
-                metadata.get(SocialMediaHelperImpl.OG_IMAGE));
-
-        socialMediaHelper = getSocialMediaHelperUnderTest(BASIC_SHARING_PAGE_2);
-        metadata = socialMediaHelper.getMetadata();
-        assertEquals(MockExternalizerFactory.ROOT + BASIC_SHARING_PAGE_2 + ".thumb.800.480.png?ck=1495097341",
-                metadata.get(SocialMediaHelperImpl.OG_IMAGE));
-
-        socialMediaHelper = getSocialMediaHelperUnderTest(BASIC_SHARING_PAGE_3);
-        metadata = socialMediaHelper.getMetadata();
-        assertEquals(MockExternalizerFactory.ROOT + BASIC_SHARING_PAGE_3 + ".thumb.800.480.png?ck=1495097341",
-                metadata.get(SocialMediaHelperImpl.OG_IMAGE));
+            metadataProperties.get(SocialMediaHelperImpl.OG_IMAGE));
     }
+
+    @Test
+    void testWebsiteProvider_BasicSharingPage_2() {
+        SocialMediaHelper socialMediaHelper = getSocialMediaHelperUnderTest(BASIC_SHARING_PAGE_2);
+        Map<String, String> metadataProperties = socialMediaHelper.getMetadataProperties();
+        assertEquals(MockExternalizerFactory.ROOT + BASIC_SHARING_PAGE_2 + ".thumb.800.480.png?ck=1495097341",
+            metadataProperties.get(SocialMediaHelperImpl.OG_IMAGE));
+        assertEquals("PAGE_ID", metadataProperties.get(SocialMediaHelperImpl.FB_PAGE_ID));
+        assertEquals("TWITTER_ACC_ID", metadataProperties.get(SocialMediaHelperImpl.TWITTER_ACCOUNT_ID));
+
+        Map<String, String> metadataNames = socialMediaHelper.getMetadataNames();
+        assertEquals("About Us", metadataNames.get(SocialMediaHelperImpl.TWITTER_TITLE));
+        assertEquals("summary", metadataNames.get(SocialMediaHelperImpl.TWITTER_CARD));
+        assertEquals("TWITTER_USERNAME", metadataNames.get(SocialMediaHelperImpl.TWITTER_SITE));
+    }
+
+    @Test
+    void testWebsiteProvider_BasicSharingPage_3() {
+        SocialMediaHelper socialMediaHelper = getSocialMediaHelperUnderTest(BASIC_SHARING_PAGE_3);
+        Map<String, String> metadataProperties = socialMediaHelper.getMetadataProperties();
+        assertEquals(MockExternalizerFactory.ROOT + BASIC_SHARING_PAGE_3 + ".thumb.800.480.png?ck=1495097341",
+            metadataProperties.get(SocialMediaHelperImpl.OG_IMAGE));
+    }
+
 
     @Test
     void testCommerceProvider() {
@@ -146,19 +153,19 @@ class SocialMediaHelperImplTest {
         assertTrue(socialMediaHelper.isPinterestEnabled());
         assertTrue(socialMediaHelper.hasFacebookSharing());
         assertTrue(socialMediaHelper.hasPinterestSharing());
-        Map<String, String> metadata = socialMediaHelper.getMetadata();
-        assertEquals("Eton Short-Sleeve Shirt", metadata.get(SocialMediaHelperImpl.OG_TITLE));
+        Map<String, String> metadataProperties = socialMediaHelper.getMetadataProperties();
+        assertEquals("Eton Short-Sleeve Shirt", metadataProperties.get(SocialMediaHelperImpl.OG_TITLE));
         assertEquals("Express yourself around town or at play with our rugby-inspired Eton shirt.",
-                metadata.get(SocialMediaHelperImpl.OG_DESCRIPTION));
-        assertEquals(MockExternalizerFactory.ROOT + PRODUCT_SHARING_PAGE +"." + EXTENSION, metadata.get(SocialMediaHelperImpl
-                .OG_URL));
-        assertEquals("product", metadata.get(SocialMediaHelperImpl.OG_TYPE));
-        assertEquals("Eton Short-Sleeve Shirt", metadata.get(SocialMediaHelperImpl.OG_SITE_NAME));
-        assertEquals(MockExternalizerFactory.ROOT + "/content/dam/we-retail/en/products/apparel/shirts/Eton.jpg", metadata.get
-                (SocialMediaHelperImpl.OG_IMAGE));
+            metadataProperties.get(SocialMediaHelperImpl.OG_DESCRIPTION));
+        assertEquals(MockExternalizerFactory.ROOT + PRODUCT_SHARING_PAGE + "." + EXTENSION, metadataProperties.get(SocialMediaHelperImpl
+            .OG_URL));
+        assertEquals("product", metadataProperties.get(SocialMediaHelperImpl.OG_TYPE));
+        assertEquals("Eton Short-Sleeve Shirt", metadataProperties.get(SocialMediaHelperImpl.OG_SITE_NAME));
+        assertEquals(MockExternalizerFactory.ROOT + "/content/dam/we-retail/en/products/apparel/shirts/Eton.jpg", metadataProperties.get
+            (SocialMediaHelperImpl.OG_IMAGE));
         assertEquals(MockCommerceFactory.UNIVERSAL_PRICE.toBigInteger().toString(),
-                metadata.get(SocialMediaHelperImpl.OG_PRODUCT_PRICE_AMOUNT));
-        assertEquals("USD", metadata.get(SocialMediaHelperImpl.OG_PRODUCT_PRICE_CURRENCY));
+            metadataProperties.get(SocialMediaHelperImpl.OG_PRODUCT_PRICE_AMOUNT));
+        assertEquals("USD", metadataProperties.get(SocialMediaHelperImpl.OG_PRODUCT_PRICE_CURRENCY));
     }
 
     @Test
@@ -169,15 +176,15 @@ class SocialMediaHelperImplTest {
         assertTrue(socialMediaHelper.isPinterestEnabled());
         assertTrue(socialMediaHelper.hasFacebookSharing());
         assertTrue(socialMediaHelper.hasPinterestSharing());
-        Map<String, String> metadata = socialMediaHelper.getMetadata();
-        assertEquals("About Us", metadata.get(SocialMediaHelperImpl.OG_TITLE));
-        assertEquals("<p>About Us XF description</p>", metadata.get(SocialMediaHelperImpl.OG_DESCRIPTION));
-        assertEquals(MockExternalizerFactory.ROOT + XF_SHARING_PAGE + "." + EXTENSION, metadata.get(SocialMediaHelperImpl
-                .OG_URL));
-        assertEquals("website", metadata.get(SocialMediaHelperImpl.OG_TYPE));
-        assertEquals("About Us", metadata.get(SocialMediaHelperImpl.OG_SITE_NAME));
+        Map<String, String> metadataProperties = socialMediaHelper.getMetadataProperties();
+        assertEquals("About Us", metadataProperties.get(SocialMediaHelperImpl.OG_TITLE));
+        assertEquals("<p>About Us XF description</p>", metadataProperties.get(SocialMediaHelperImpl.OG_DESCRIPTION));
+        assertEquals(MockExternalizerFactory.ROOT + XF_SHARING_PAGE + "." + EXTENSION, metadataProperties.get(SocialMediaHelperImpl
+            .OG_URL));
+        assertEquals("website", metadataProperties.get(SocialMediaHelperImpl.OG_TYPE));
+        assertEquals("About Us", metadataProperties.get(SocialMediaHelperImpl.OG_SITE_NAME));
         assertEquals(MockExternalizerFactory.ROOT + "/content/dam/we-retail/en/activities/hiking-camping/trekker-khumbu-valley.jpg",
-                metadata.get(SocialMediaHelperImpl.OG_IMAGE));
+            metadataProperties.get(SocialMediaHelperImpl.OG_IMAGE));
     }
 
     @Test
@@ -188,33 +195,27 @@ class SocialMediaHelperImplTest {
         assertTrue(socialMediaHelper.isPinterestEnabled());
         assertTrue(socialMediaHelper.hasFacebookSharing());
         assertTrue(socialMediaHelper.hasPinterestSharing());
-        Map<String, String> metadata = socialMediaHelper.getMetadata();
-        assertEquals("Eton Short-Sleeve Shirt", metadata.get(SocialMediaHelperImpl.OG_TITLE));
-        assertEquals("<p>Blue Polo T-Shirt</p>", metadata.get(SocialMediaHelperImpl.OG_DESCRIPTION));
-        assertEquals(MockExternalizerFactory.ROOT + XF_PRODUCT_SHARING_PAGE + "." + EXTENSION, metadata.get(SocialMediaHelperImpl
-                .OG_URL));
-        assertEquals("product", metadata.get(SocialMediaHelperImpl.OG_TYPE));
-        assertEquals("Eton Short-Sleeve Shirt", metadata.get(SocialMediaHelperImpl.OG_SITE_NAME));
+        Map<String, String> metadataProperties = socialMediaHelper.getMetadataProperties();
+        assertEquals("Eton Short-Sleeve Shirt", metadataProperties.get(SocialMediaHelperImpl.OG_TITLE));
+        assertEquals("<p>Blue Polo T-Shirt</p>", metadataProperties.get(SocialMediaHelperImpl.OG_DESCRIPTION));
+        assertEquals(MockExternalizerFactory.ROOT + XF_PRODUCT_SHARING_PAGE + "." + EXTENSION, metadataProperties.get(SocialMediaHelperImpl
+            .OG_URL));
+        assertEquals("product", metadataProperties.get(SocialMediaHelperImpl.OG_TYPE));
+        assertEquals("Eton Short-Sleeve Shirt", metadataProperties.get(SocialMediaHelperImpl.OG_SITE_NAME));
         assertEquals(MockExternalizerFactory.ROOT + "/content/dam/we-retail/en/products/apparel/shirts/Eton.jpg",
-                metadata.get(SocialMediaHelperImpl.OG_IMAGE));
+            metadataProperties.get(SocialMediaHelperImpl.OG_IMAGE));
     }
 
     private SocialMediaHelper getSocialMediaHelperUnderTest(String pagePath) {
-        Resource currentResource = context.resourceResolver().getResource(pagePath);
-        Page currentPage = currentResource.adaptTo(Page.class);
-        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver(), context.bundleContext());
-        MockSlingHttpServletResponse response = new MockSlingHttpServletResponse();
-        request.setContextPath(CONTEXT_PATH);
-        request.setResource(currentResource);
-        MockRequestPathInfo requestPathInfo = (MockRequestPathInfo) request.getRequestPathInfo();
-        requestPathInfo.setExtension(EXTENSION);
-        requestPathInfo.setResourcePath(currentResource.getPath());
-        SlingBindings slingBindings = new SlingBindings();
-        slingBindings.put(WCMBindings.CURRENT_PAGE, currentPage);
-        slingBindings.put(SlingBindings.RESOLVER, context.resourceResolver());
-        slingBindings.put(SlingBindings.RESPONSE, response);
-        request.setAttribute(SlingBindings.class.getName(), slingBindings);
-        return request.adaptTo(SocialMediaHelper.class);
-    }
+        Resource resource = context.currentResource(pagePath);
+        context.request().setContextPath(CONTEXT_PATH);
+        context.requestPathInfo().setExtension(EXTENSION);
+        context.requestPathInfo().setResourcePath(resource.getPath());
+        context.contentPolicyMapping(resource.getResourceType(),
+            "fb_page_id", "PAGE_ID",
+            "twitter_account_id", "TWITTER_ACC_ID",
+            "twitter_site", "TWITTER_USERNAME");
 
+        return context.request().adaptTo(SocialMediaHelper.class);
+    }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImplTest.java
@@ -65,10 +65,10 @@ class PageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.P
     @Test
     void testPage() throws ParseException {
         Page page = getPageUnderTest(PAGE, DESIGN_PATH_KEY, DESIGN_PATH, PageImpl.PN_CLIENTLIBS_JS_HEAD,
-                new String[]{"coretest.product-page-js-head"}, PN_CLIENT_LIBS,
-                new String[]{"coretest.product-page","coretest.product-page-js-head"}, Page.PN_APP_RESOURCES_CLIENTLIB,
-                "coretest.product-page.appResources",
-                CSS_CLASS_NAMES_KEY, new String[]{"class1", "class2"});
+            new String[]{"coretest.product-page-js-head"}, PN_CLIENT_LIBS,
+            new String[]{"coretest.product-page", "coretest.product-page-js-head"}, Page.PN_APP_RESOURCES_CLIENTLIB,
+            "coretest.product-page.appResources",
+            CSS_CLASS_NAMES_KEY, new String[]{"class1", "class2"});
         Calendar calendar = Calendar.getInstance();
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
         calendar.setTime(sdf.parse("2016-01-20T10:33:36.000+0100"));
@@ -82,9 +82,9 @@ class PageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.P
         Set<String> keywords = new HashSet<>(keywordsArray.length);
         keywords.addAll(Arrays.asList(keywordsArray));
         assertTrue(keywords.contains("one") && keywords.contains("two") && keywords.contains("three"));
-        assertArrayEquals(new String[] {"coretest.product-page", "coretest.product-page-js-head"}, page.getClientLibCategories());
-        assertArrayEquals(new String[] {"coretest.product-page-js-head"}, page.getClientLibCategoriesJsHead());
-        assertArrayEquals(new String[] {"coretest.product-page"}, page.getClientLibCategoriesJsBody());
+        assertArrayEquals(new String[]{"coretest.product-page", "coretest.product-page-js-head"}, page.getClientLibCategories());
+        assertArrayEquals(new String[]{"coretest.product-page-js-head"}, page.getClientLibCategoriesJsHead());
+        assertArrayEquals(new String[]{"coretest.product-page"}, page.getClientLibCategoriesJsBody());
         assertEquals("product-page", page.getTemplateName());
         testJSONExport(page, getTestExporterJSONPath(TEST_BASE, PAGE));
     }
@@ -92,14 +92,15 @@ class PageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.P
     @Test
     void testFavicons() {
         Page page = getPageUnderTest(PAGE);
-            assertThrows(UnsupportedOperationException.class, () -> { page.getFavicons();
+        assertThrows(UnsupportedOperationException.class, () -> {
+            page.getFavicons();
         });
     }
 
     @Test
     void testGetFaviconClientLibPath() throws Exception {
         Page page = getPageUnderTest(PAGE, Page.PN_APP_RESOURCES_CLIENTLIB,
-                "coretest.product-page.appResources");
+            "coretest.product-page.appResources");
         String faviconClientLibPath = page.getAppResourcesPath();
         assertEquals(CONTEXT_PATH + "/etc.clientlibs/wcm/core/page/clientlibs/favicon/resources", faviconClientLibPath);
     }
@@ -130,9 +131,91 @@ class PageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.P
         assertFalse("Expected no cloudconfig support if product version < 6.4.0", page.hasCloudconfigSupport());
 
         // reset cached value
-        Utils.setInternalState(page, "hasCloudconfigSupport", (Boolean)null);
+        Utils.setInternalState(page, "hasCloudconfigSupport", (Boolean) null);
         mockProductInfoProvider.setVersion(new Version("6.4.0"));
         assertTrue("Expected cloudconfig support if product version >= 6.4.0", page.hasCloudconfigSupport());
+    }
+
+    @Test
+    void testIPv4AddressPage_withoutSelectorsAndSuffixes() {
+        Page page = new PageImpl();
+        page = getPageUnderTest(PAGE);
+        context.request().setServerName("192.168.1.1");
+        context.request().setServerPort(4503);
+
+        assertEquals("http://192.168.1.1:4503/content/page/templated-page.html", context.request().getRequestURL().toString());
+        assertEquals("/content/page/templated-page.html", page.getCanonicalURLOfPage());
+    }
+
+    @Test
+    void testLocalhostPage_withoutSelectorsAndSuffixes() {
+        Page page = new PageImpl();
+        page = getPageUnderTest(PAGE);
+        context.request().setServerName("localhost");
+        context.request().setServerPort(4503);
+
+        assertEquals("http://localhost:4503/content/page/templated-page.html", context.request().getRequestURL().toString());
+        assertEquals("/content/page/templated-page.html", page.getCanonicalURLOfPage());
+    }
+
+    @Test
+    void testExternalPage_withoutSelectorsAndSuffixes() {
+        Page page = new PageImpl();
+        page = getPageUnderTest(PAGE);
+        context.request().setServerName("adobe.com");
+
+        assertEquals("http://adobe.com/content/page/templated-page.html", page.getCanonicalURLOfPage());
+    }
+
+    @Test
+    void testIPAddressPage_withSelectorsAndSuffixes() {
+        Page page = new PageImpl();
+        page = getPageUnderTest(PAGE);
+        context.request().setServerName("192.168.1.1");
+        context.request().setServerPort(4503);
+        context.requestPathInfo().setSelectorString("s1.s2.s3.s4");
+        context.requestPathInfo().setSuffix("/a/b/3/a/2");
+
+        assertEquals("http://192.168.1.1:4503/content/page/templated-page.s1.s2.s3.s4.html/a/b/3/a/2",
+            context.request().getRequestURL().toString());
+        assertEquals("/content/page/templated-page.html", page.getCanonicalURLOfPage());
+    }
+
+    @Test
+    void testLocalhostPage_withSelectorsAndSuffixes() {
+        Page page = new PageImpl();
+        page = getPageUnderTest(PAGE);
+        context.request().setServerName("localhost");
+        context.request().setServerPort(4503);
+        context.requestPathInfo().setSelectorString("s1.s2.s3.s4");
+        context.requestPathInfo().setSuffix("/a/b/3/a/2");
+
+        assertEquals("http://localhost:4503/content/page/templated-page.s1.s2.s3.s4.html/a/b/3/a/2",
+            context.request().getRequestURL().toString());
+        assertEquals("/content/page/templated-page.html", page.getCanonicalURLOfPage());
+    }
+
+    @Test
+    void testExternalPage_withSelectorsAndSuffixes() {
+        Page page = new PageImpl();
+        page = getPageUnderTest(PAGE);
+        context.request().setServerName("adobe.com");
+        context.requestPathInfo().setSelectorString("s1.s2.s3.s4");
+        context.requestPathInfo().setSuffix("/a/b/3/a/2");
+
+        assertEquals("http://adobe.com/content/page/templated-page.html", page.getCanonicalURLOfPage());
+    }
+
+    @Test
+    void testExternalPageSubdomain_withSelectorsAndSuffixes() {
+        Page page = new PageImpl();
+        page = getPageUnderTest(PAGE);
+        context.request().setServerName("subdomain.adobe.com");
+        context.requestPathInfo().setSelectorString("s1.s2.s3.s4");
+        context.requestPathInfo().setSuffix("/a/b/3/a/2");
+
+        assertEquals("http://subdomain.adobe.com/content/page/templated-page.html",
+            page.getCanonicalURLOfPage());
     }
 
 //    private Page getPageUnderTest(String pagePath) {

--- a/bundles/core/src/test/resources/sharing/test-content.json
+++ b/bundles/core/src/test/resources/sharing/test-content.json
@@ -203,7 +203,8 @@
                 "jcr:createdBy"         : "admin",
                 "socialMedia"           : [
                     "facebook",
-                    "pinterest"
+                    "pinterest",
+                    "twitter"
                 ],
                 "jcr:title"             : "About Us",
                 "jcr:description"       : "About Us Page",
@@ -293,6 +294,7 @@
                 "jcr:createdBy"         : "admin",
                 "socialMedia"           : [
                     "facebook",
+                    "twitter",
                     "pinterest"
                 ],
                 "jcr:title"             : "About Us",

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/README.md
@@ -53,6 +53,9 @@ The following configuration properties are used:
 2. `./clientlibsJsHead` - allows definition of client libraries for which JavaScript is specifically intended to be loaded
 in the document head (JavaScript only) of pages associated with this policy configuration
 3. `./appResourcesClientlib` - allows definition of the client library that is used to serve web resources such as favicons
+4. `./fb_page_id` - allows definition of Facebook page ID that is used to generate OG meta tags
+5. `./twitter_account_id` - allows definition of Twitter account ID that is used to generate Twitter meta tag
+6. `./twitter_site` - allows definition of Twitter username that is used to generate Twitter meta tag
 
 ## Edit Dialog Properties
 The following properties are written to JCR for this Page component and are expected to be available as `Resource` properties:

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -118,6 +118,34 @@
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="granite/ui/components/coral/foundation/include"
                         path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_design/styletab"/>
+                <social_media
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Social Media"
+                    sling:resourceType="granite/ui/components/coral/foundation/container"
+                    margin="{Boolean}true">
+                    <items
+                        jcr:primaryType="nt:unstructured"
+                        sling:hideChildren="[heading,well]">
+                        <facebook_page_id
+                            cq:showOnCreate="{Boolean}true"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                            fieldLabel="Facebook Page ID"
+                            name="./fb_page_id"/>
+                        <twitter_account_id
+                            cq:showOnCreate="{Boolean}true"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                            fieldLabel="Twitter Account ID"
+                            name="./twitter_account_id"/>
+                        <twitter_username
+                            cq:showOnCreate="{Boolean}true"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                            fieldLabel="Twitter Username"
+                            name="./twitter_site"/>
+                    </items>
+                </social_media>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_dialog/.content.xml
@@ -72,6 +72,30 @@
                                                             jcr:primaryType="nt:unstructured"
                                                             cq-msm-lockable="socialMedia"/>
                                                     </facebook>
+                                                    <facebook
+                                                        cq:showOnCreate="{Boolean}true"
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                        name="./socialMedia"
+                                                        renderReadOnly="{Boolean}true"
+                                                        text="Facebook"
+                                                        value="facebook">
+                                                        <granite:data
+                                                            jcr:primaryType="nt:unstructured"
+                                                            cq-msm-lockable="socialMedia"/>
+                                                    </facebook>
+                                                    <twitter
+                                                        cq:showOnCreate="{Boolean}true"
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                        name="./socialMedia"
+                                                        renderReadOnly="{Boolean}true"
+                                                        text="Twitter"
+                                                        value="twitter">
+                                                        <granite:data
+                                                            jcr:primaryType="nt:unstructured"
+                                                            cq-msm-lockable="socialMedia"/>
+                                                    </twitter>
                                                     <pinterest
                                                         cq:showOnCreate="{Boolean}true"
                                                         jcr:primaryType="nt:unstructured"

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.html
@@ -22,6 +22,8 @@
     <meta data-sly-test.description="${properties['jcr:description']}" name="description" content="${description}"/>
     <meta data-sly-test.templateName="${page.templateName}" name="template" content="${templateName}"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="canonical" data-sly-use.model="com.adobe.cq.wcm.core.components.models.Page"
+          href="${model.canonicalURLOfPage}">
     <sly data-sly-include="head.socialmedia.html"></sly>
     <sly data-sly-include="customheaderlibs.html"></sly>
     <sly data-sly-call="${headlibRenderer.headlibs @

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.socialmedia.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.socialmedia.html
@@ -13,6 +13,11 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<meta property="${key}" data-sly-use.socialMedia="com.adobe.cq.wcm.core.components.models.SocialMediaHelper"
-      data-sly-repeat.key="${socialMedia.metadata.keySet}"
-      content="${socialMedia.metadata[key]}"/>
+<sly data-sly-use.socialMedia="com.adobe.cq.wcm.core.components.models.SocialMediaHelper"/>
+    <meta property="${key}"
+          data-sly-repeat.key="${socialMedia.metadataProperties.keySet}"
+          content="${socialMedia.metadataProperties[key]}"/>
+
+    <meta name="${key}"
+          data-sly-repeat.key="${socialMedia.metadataNames.keySet}"
+          content="${socialMedia.metadataNames[key]}"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/sharing/v1/sharing/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/sharing/v1/sharing/README.md
@@ -19,6 +19,7 @@ Social media sharing component, written in HTL.
 
 ## Features
 * Social media sharing for pages, currently via Facebook and Pinterest
+* Facebook and Twitter meta tags generation
 
 ### Use Object
 The Social Media Sharing component uses the `com.adobe.cq.wcm.core.components.models.SocialMediaHelper` Sling Model for its


### PR DESCRIPTION

| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | Fixes #663
| Patch: Bug Fix?          | Some Sonarlint fixes like deleted redundant throws.
| Minor: New Feature?      | Yes - OG, Facebook, Twitter meta tags generation, Canonical URL
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | Yes, added Apache dependency to Core pom.xml
| License                  | Apache License, Version 2.0

- Extended meta tags attributes - they are configurable on Page policy and can be enabled by checkbox in Properties of page (Social Media tab).
- Added Canonical URL feature for pages that use Page component (for rendition).
