### PR TITLE
[Download][Accessibility] Duplicate links, can't add information to link text #737

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
@@ -55,8 +55,8 @@ The following JCR properties are used:
 ## BEM Description
 ```
 BLOCK cmp-download
+    ELEMENT cmp-download__link
     ELEMENT cmp-download__title
-    ELEMENT cmp-download__title-link
     ELEMENT cmp-download__description
     ELEMENT cmp-download__properties
     ELEMENT cmp-download__property
@@ -64,7 +64,6 @@ BLOCK cmp-download
     ELEMENT cmp-download__property-label
     ELEMENT cmp-download__property-content
     ELEMENT cmp-download__action
-    ELEMENT cmp-download__action-text
 ```
 
 ## Information

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
@@ -17,26 +17,34 @@
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      data-sly-test.hasContent="${download.filename}"
      class="cmp-download${!wcmmode.disabled ? ' cq-dd-file' : ''}">
-    <h3 class="cmp-download__title" data-sly-test.title="${download.title}" data-sly-element="${download.titleType}">
-        <a data-sly-unwrap="${!download.url}" class="cmp-download__title-link" href="${download.url}">${title}</a>
-    </h3>
-    <div class="cmp-download__description" data-sly-test.description="${download.description}">${description @ context="html"}</div>
-    <dl data-sly-test="${(download.displayFilename && download.filename) || (download.displaySize && download.size) || (download.displayFormat && download.format)}" class="cmp-download__properties">
-        <div data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__property cmp-download__property--filename">
+    <a data-sly-unwrap="${!download.url}"
+      class="cmp-download__link"
+      href="${download.url}">
+        <h3 class="cmp-download__title" data-sly-test.title="${download.title}" data-sly-element="${download.titleType}">
+          ${download.title}
+        </h3>
+        <div class="cmp-download__description" data-sly-test.description="${download.description}">
+          ${description @ context='html'}
+        </div>
+        <dl data-sly-test="${(download.displayFilename && download.filename) || (download.displaySize && download.size) || (download.displayFormat && download.format)}"
+            class="cmp-download__properties"
+            role="group">
+          <div data-sly-test="${download.displayFilename && download.filename}" class="cmp-download__property cmp-download__property--filename">
             <dt class="cmp-download__property-label">${'Filename' @ i18n}</dt>
             <dd class="cmp-download__property-content">${download.filename}</dd>
-        </div>
-        <div data-sly-test="${download.displaySize && download.size}" class="cmp-download__property cmp-download__property--size">
-            <dt class="cmp-download__property-label">${'Size' @ i18n}</dt>
-            <dd class="cmp-download__property-content">${download.size}</dd>
-        </div>
-        <div data-sly-test="${download.displayFormat && download.format}" class="cmp-download__property cmp-download__property--format">
+          </div>
+          <div data-sly-test="${download.displayFormat && download.format}" class="cmp-download__property cmp-download__property--format">
             <dt class="cmp-download__property-label">${'Format' @ i18n}</dt>
             <dd class="cmp-download__property-content">${download.format}</dd>
-        </div>
-    </dl>
-    <a data-sly-test="${download.url && download.actionText}" class="cmp-download__action" href="${download.url}">
-        <span class="cmp-download__action-text">${download.actionText}</span>
+          </div>
+          <div data-sly-test="${download.displaySize && download.size}" class="cmp-download__property cmp-download__property--size">
+            <dt class="cmp-download__property-label">${'Size' @ i18n}</dt>
+            <dd class="cmp-download__property-content">${download.size}</dd>
+          </div>
+        </dl>
+        <sly data-sly-test="${download.actionText}">
+          <span class="cmp-download__action" aria-hidden="true">${download.actionText}</span>
+        </sly>
     </a>
 </div>
 <sly data-sly-call="${templates.placeholder @ isEmpty=!hasContent, classAppend='cmp-download cq-dd-file'}"></sly>

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/download/base.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/download/base.less
@@ -19,18 +19,26 @@
         position: relative;
 
         display: inline-block;
+    }
+
+    .cmp-download__link {
+        display: inline-block;
+        padding: 18*@px;
         border: 1*@px solid;
         border-radius: 3*@px;
-        padding: 18*@px;
+
+        color: @cmp-clean-light-color-text;
         overflow: hidden;
+        text-decoration: none;
     }
 
     .cmp-download__title {
         margin: 0 0 8*@px 0;
-    }
+        color: @cmp-clean-color-link;
 
-    .cmp-download__title-link {
-        text-decoration: none;
+        &:hover {
+            color: @cmp-clean-color-link-hover;
+        }
     }
 
     .cmp-download__description {
@@ -73,10 +81,6 @@
         text-decoration: none;
         cursor: pointer;
         background: none;
-    }
-
-    .cmp-button__action-text {
-        display: inline-block;
         vertical-align: top;
         line-height: @cmp-clean-line-height;
     }

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/download/light.skin.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/download/light.skin.less
@@ -24,10 +24,6 @@
 
 
 .t-cmp-clean--light {
-    .cmp-download {
-        border-color: @cmp-clean-light-download-border-color;
-    }
-
     .cmp-download__property {
         color: @cmp-clean-light-download-property-color;
         background-color: @cmp-clean-light-download-property-background-color;
@@ -36,8 +32,12 @@
     .cmp-download__action {
         border-color: @cmp-clean-light-download-action-border-color;
         color: @cmp-clean-light-download-action-color;
+    }
+    
+    .cmp-download__link {
+        border-color: @cmp-clean-light-download-border-color;
 
-        &:hover {
+        &:hover .cmp-download__action {
             border-color: @cmp-clean-light-download-action-hover-border-color;
             color: @cmp-clean-light-download-action-hover-color;
         }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #737 
| Patch: Bug Fix?          | Enhancement
| Minor: New Feature?      |
| Major: Breaking Change?  | Markup changes
| Tests Added + Pass?      | -
| Documentation Provided   | Changed existing one
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

Changed Download component markup to meet accessibility standards. Now the whole component is a link which prevents link duplication that occurred in previous markup. Treating the whole content as a link allows authors to provide all the required information inside the link (like format and size of the file). Changed css to match the new structure.

This allows the component to be configured and styled in accessible way. Core Components example page styling and design prevents the instances of component used there from being accessible (missing outline on link, hidden labels of properties)