### PR TITLE
[Embed] Invalid Pinterest ID makes component uneditable

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/processors/pinterest.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/processors/pinterest.html
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <sly data-sly-template.render="${@ options}">
-    <a data-pin-do="embedPin" href="${'https://www.pinterest.com/pin/{0}/' @ format=options['pinId']}"></a>
+    <a data-pin-do="embedPin" href="${'https://www.pinterest.com/pin/{0}/' @ format=options['pinId']}">${'https://www.pinterest.com/pin/{0}/' @ format=options['pinId']}</a>
     <script>
         var pinterestScript = "https://assets.pinterest.com/js/pinit.js";
         var scripts = document.getElementsByTagName("script");


### PR DESCRIPTION
- Adds Pinterest URL as anchor content by default, to ensure it still renders. Gets replaced by the Pinterest script for valid URLs.

<img width="872" alt="Screenshot 2019-09-19 at 15 45 34" src="https://user-images.githubusercontent.com/25616660/65265633-ab841d80-db11-11e9-8e9f-0383258f8ccb.png">
