### PR TITLE
@releng - 2.7.0 Pre-release - Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The latest version of the Core Components, require the below system requirements
 
 Core Components | AEM 6.5 | AEM 6.4 | AEM 6.3 | Java
 ----------------|---------|---------|---------|------
-[2.6.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.6.0) | 6.5.0.0+ | 6.4.4.0+ | 6.3.3.4+ | 8, 11
+[2.7.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.7.0) | 6.5.0.0+ | 6.4.4.0+ | 6.3.3.4+ | 8, 11
 
 For a list of requirements for previous versions, see [Historical System Requirements](VERSIONS.md).
 
@@ -134,7 +134,7 @@ To include the core components package into your own project's maven build using
      <groupId>com.adobe.cq</groupId>
      <artifactId>core.wcm.components.all</artifactId>
      <type>zip</type>
-     <version>2.6.0</version>
+     <version>2.7.0</version>
  </dependency>
  ```
 
@@ -159,7 +159,7 @@ To include the core components package into your own project using AEM Archetype
      <groupId>com.adobe.cq</groupId>
      <artifactId>core.wcm.components.all</artifactId>
      <type>zip</type>
-     <version>2.6.0</version>
+     <version>2.7.0</version>
  </dependency>
  ```
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@ See below for a full list of system requirements for historical versions of the 
 
 Core Components | Extension | AEM 6.5 | AEM 6.4 | AEM 6.3 | Java
 ----------------|-----------|---------|---------|---------|------
+[2.7.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.7.0) | - | 6.5.0.0+ | 6.4.4.0+ | 6.3.3.4+ | 8, 11
 [2.6.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.6.0) | - | 6.5.0.0+ | 6.4.4.0+ | 6.3.3.4+ | 8, 11
 [2.5.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.5.0) | - | 6.5.0.0+ | 6.4.2.0+ | 6.3.3.0+ | 8, 11
 [2.4.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.4.0) | - | 6.5.0.0+ | 6.4.2.0+ | 6.3.3.0+ | 8, 11

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -478,7 +478,6 @@
             <artifactId>slf4j-test</artifactId>
         </dependency>
 
-
         <!-- Only required for junit 4 -->
         <dependency>
             <groupId>io.wcm</groupId>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
@@ -210,7 +210,6 @@ public class ContentFragmentImpl implements ContentFragment {
         return content.split("(?=(<p>|<h1>|<h2>|<h3>|<h4>|<h5>|<h6>))");
     }
 
-
     /**
      * Empty placeholder content fragment.
      */

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -615,10 +615,11 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
     }
 
     /**
-     * Create a List from the given selector string. A valid selector can be:
+     * Create a {@link List} from the given selector string. A valid selector can be:
      *      * handler or
      *      * handler.width or
      *      * handler.quality.width
+     *
      * @param selector string to create the List from
      * @return {@link List} of selector items
      * @throws IllegalArgumentException in case the selector is not valid
@@ -638,7 +639,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
      * Create a image transformation map from the given selector items.
      *
      * @param selectorList to get the parameter from
-     * @return Map with quality and width transformation parameter
+     * @return {@link Map} with quality and width transformation parameter
      */
     private Map<String, Integer> getTransformationMap(List<String> selectorList, Resource component) throws IllegalArgumentException {
         Map<String, Integer> selectorParameterMap = new HashMap<>();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -615,7 +615,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
     }
 
     /**
-     * Create a {@link List} from the given selector string. A valid selector can be:
+     * Creates a {@link List} from the given selector string. A valid selector can be:
      *      * handler or
      *      * handler.width or
      *      * handler.quality.width
@@ -636,7 +636,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
     }
 
     /**
-     * Create a image transformation map from the given selector items.
+     * Creates an image transformation map from the given selector items.
      *
      * @param selectorList to get the parameter from
      * @return {@link Map} with quality and width transformation parameter

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/DownloadServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/DownloadServlet.java
@@ -72,7 +72,6 @@ public class DownloadServlet extends SlingAllMethodsServlet {
     @Override
     protected void doGet(@Nonnull SlingHttpServletRequest request, @Nonnull SlingHttpServletResponse response)
             throws IOException {
-
         Asset asset = request.getResource().adaptTo(Asset.class);
         if (asset == null) {
             String filename = request.getRequestPathInfo().getSuffix();
@@ -104,13 +103,10 @@ public class DownloadServlet extends SlingAllMethodsServlet {
         }
     }
 
-
     private void sendResource(SlingHttpServletRequest request, SlingHttpServletResponse response, String filename,
             Resource downloadDataResource) throws IOException {
-
         ValueMap valueMap = downloadDataResource.adaptTo(ValueMap.class);
         if (valueMap != null) {
-
             Calendar calendar = valueMap.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class);
             if (calendar != null) {
                 if (isUnchanged(calendar.getTimeInMillis(), request)) {
@@ -147,13 +143,13 @@ public class DownloadServlet extends SlingAllMethodsServlet {
     }
 
     /**
-     * Determines the size of a binary resource just by using the JCR API; this hopefully avoids to read
-     * the complete InputStream to determine the actual size of the binary.
+     * Determines the size of a binary resource just by using the JCR API; this hopefully avoids having to read
+     * the complete {@code InputStream} to determine the actual size of the binary.
+     *
      * @param resource the actual resource
-     * @return the size in byte, -1 if an error occurs, the resource is not backed by a JCR node, or if there is not JCR_DATA property
+     * @return the size in bytes, -1 if an error occurs, the resource is not backed by a JCR node, or if there is not a {@code JCR_DATA} property
      */
     private long getResourceSize (Resource resource) {
-
         Node node = resource.adaptTo(Node.class);
         if (node != null) {
             Property jcrData;
@@ -176,8 +172,6 @@ public class DownloadServlet extends SlingAllMethodsServlet {
         return Arrays.asList(request.getRequestPathInfo().getSelectors()).contains(INLINE_SELECTOR);
     }
 
-
-
     private Optional<InputStream> getInputStream (Asset asset) {
         return Optional.ofNullable(asset.getOriginal())
                 .map(r -> r.adaptTo(InputStream.class));
@@ -186,7 +180,6 @@ public class DownloadServlet extends SlingAllMethodsServlet {
     private Optional<InputStream> getInputStream (Resource fileResource) {
         return Optional.ofNullable(fileResource.getValueMap().get(JcrConstants.JCR_DATA, InputStream.class));
     }
-
 
     private void sendResponse(InputStream stream, long size, String mimeType, String filename, long lastModifiedDate, SlingHttpServletResponse response,
             boolean inline) throws IOException {

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
@@ -51,7 +51,7 @@ The following properties are written to JCR for this Carousel component and are 
 
 The edit dialog also allows editing of Carousel items (adding, removing, naming, re-ordering).
 
-Note: automatic transitioning only works on a publish instance or on an author instance with the URL parameter `wcmmode=disabled`.
+Note: on author instances automatic transitioning only works with the `wcmmode=disabled` URL parameter.
 
 ## Client Libraries
 The component provides a `core.wcm.components.carousel.v1` client library category that contains a recommended base

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/README.md
@@ -21,6 +21,7 @@ Content Fragment List component written in HTL that renders a list of Content Fr
 * Displays a list of a Content Fragment assets based on a Content Fragment model
 * The parent path for asset lookup is configurable
 * The list can be filtered by tag
+* The list can be ordered by an element or property - ascending or descending
 * A subset of elements in the data model can be displayed
 
 ### Use Object
@@ -32,8 +33,10 @@ The following properties are written to JCR for the Content Fragment List compon
 1. `./modelPath` - path to the Content Fragment Model on which the list is based.
 2. `./parentPath` - parent path from which the list should be built.
 3. `./tagNames` - tag names for filtering the list.
-4. `./maxItems` - defines the maximum number of items rendered by the list. If not defined, all fragments matching the query criteria are returned.
-5. `./elementNames` - element names for limiting the model data displayed in the result.
+4. `./orderBy` - an element or property to order the list by.
+5. `./sortOrder` - sort order ascending or descending.
+6. `./maxItems` - defines the maximum number of items rendered by the list. If not defined, all fragments matching the query criteria are returned.
+7. `./elementNames` - element names for limiting the model data displayed in the result.
 
 ## Client Libraries
 The component provides a `core.wcm.components.contentfragmentlist.v1.editor` editor client library category that includes JavaScript

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/_cq_dialog/.content.xml
@@ -70,7 +70,7 @@
                                     <sortOrder
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/select"
-                                        fieldDescription="Sort order ascending or descending"
+                                        fieldDescription="Sort order ascending or descending."
                                         fieldLabel="Sort Order"
                                         name="./sortOrder"
                                         type="editable">

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/README.md
@@ -20,7 +20,7 @@ Embed component written in HTL that allows third-party widgets (e.g. chatbots, l
 ## Features
 * The following input types are supported:
     * **URL** - an author is able to paste a URL of a widget to embed. URLs are checked against registered processors for a match. The following URL processors are provided:
-        * **oEmbed** - generic oEmbed URL processor with out-of-the-box configurations for Facebook Post, Instagram, SoundCloud, Twitter and YouTube.
+        * **oEmbed** - generic oEmbed URL processor with out-of-the-box configurations for Facebook Post, Facebook Video, Flickr, Instagram, SoundCloud, Twitter and YouTube.
         * **Pinterest** - processes Pinterest URLs. 
     * **Embeddable** - an author is able to select from pre-configured trusted embeddables. Embeddables can be parameterized and may include unsafe tags.
     * **HTML** - an author is able to enter free-form HTML. HTML is restricted to safe tags only.

--- a/examples/src/content/jcr_root/conf/core-components-examples/settings/wcm/templates/content-page/structure/.content.xml
+++ b/examples/src/content/jcr_root/conf/core-components-examples/settings/wcm/templates/content-page/structure/.content.xml
@@ -109,7 +109,7 @@
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/text/v2/text"
-                    text="&lt;p>Built with &lt;a href=&quot;https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.6.0&quot;>Core Components 2.6.0&lt;/a>.&lt;/p>&#xa;"
+                    text="&lt;p>Built with &lt;a href=&quot;https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.7.0&quot;>Core Components 2.7.0&lt;/a>.&lt;/p>&#xa;"
                     textIsRich="true"/>
             </responsivegrid_2176569853>
         </root>

--- a/examples/src/content/jcr_root/content/core-components-examples/library/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/.content.xml
@@ -26,7 +26,7 @@
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/text/v2/text"
-                    text="&lt;h1>Component Library &lt;a href=&quot;https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.6.0&quot;>2.6.0&lt;/a>&lt;/h1>&#xa;"
+                    text="&lt;h1>Component Library &lt;a href=&quot;https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.7.0&quot;>2.7.0&lt;/a>&lt;/h1>&#xa;"
                     textIsRich="true"/>
                 <text
                     cq:styleIds="[1544762734201]"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/content-fragment-list/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/content-fragment-list/.content.xml
@@ -198,6 +198,67 @@
                             reference="../../component"/>
                     </info>
                 </demo>
+                <title_219202191
+                    cq:styleIds="[1544759676459]"
+                    jcr:created="{Date}2019-01-15T15:16:04.933+01:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2019-04-01T16:38:26.765+02:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Order By and Sort Order"
+                    sling:resourceType="core/wcm/components/title/v2/title"/>
+                <text_1424864181
+                    jcr:created="{Date}2019-01-15T15:16:13.958+01:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2019-04-01T16:41:35.465+02:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core/wcm/components/text/v2/text"
+                    text="&lt;p>The list can be ordered by element or property, ascending or descending. In this example, we order the offices by &lt;i>City&lt;/i>, ascending.&lt;/p>&#xa;"
+                    textIsRich="true"/>
+                <demo_1424864177
+                    jcr:created="{Date}2019-01-15T15:24:16.176+01:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2019-01-15T15:24:16.176+01:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/demo"
+                    fullWidth="{Boolean}true">
+                    <component
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/demo/component">
+                        <contentfragmentlist
+                            jcr:created="{Date}2019-04-01T16:27:02.259+02:00"
+                            jcr:createdBy="admin"
+                            jcr:lastModified="{Date}2019-04-01T16:40:45.872+02:00"
+                            jcr:lastModifiedBy="admin"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core/wcm/components/contentfragmentlist/v1/contentfragmentlist"
+                            modelPath="/conf/core-components-examples/settings/dam/cfm/models/office"
+                            orderBy="jcr:content/data/master/city"
+                            parentPath="/content/dam/core-components-examples/library/sample-assets"
+                            sortOrder="asc"/>
+                    </component>
+                    <info
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        <properties
+                            cq:panelTitle="Properties"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/properties"
+                            reference="../../component"/>
+                        <markup
+                            cq:panelTitle="Markup"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/markup"
+                            reference="../../component"/>
+                        <json
+                            cq:panelTitle="JSON"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/json"
+                            reference="../../component"/>
+                    </info>
+                </demo_1424864177>
                 <title_219202184_copy_101761062
                     cq:styleIds="[1544759676459]"
                     jcr:created="{Date}2019-01-15T15:16:04.933+01:00"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/embed/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/embed/.content.xml
@@ -95,7 +95,7 @@
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/text/v2/text"
-                    text="&lt;p>URLs to embeddable objects can be pasted in the edit dialog. Embed will check that the URL matches a supported provider and provide feedback to the author. Additional URL providers can be registered by a developer.&lt;/p>&#xd;&#xa;"
+                    text="&lt;p>URLs to embeddable objects can be pasted in the edit dialog. Embed will check that the URL matches a supported processor and provide feedback to the author. Additional URL processors can be registered by a developer.&lt;/p>&#xd;&#xa;"
                     textIsRich="true"/>
                 <demo_1160408555
                     jcr:created="{Date}2018-12-07T13:36:02.946+01:00"
@@ -152,7 +152,7 @@
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/text/v2/text"
-                    text="&lt;p>URL to embeddable objects using oEmbed to retrieve the embedding information. This uses the sample bundled Twitter configuration. Other configurations can be easily added.&lt;/p>&#xd;&#xa;"
+                    text="&lt;p>URLs to embeddable objects that use oEmbed to retrieve the embedding information. This example uses the bundled Twitter configuration. Other configurations can be easily added by a developer.&lt;/p>&#xd;&#xa;"
                     textIsRich="true"/>
                 <demo
                     jcr:created="{Date}2019-08-21T17:15:15.538+03:00"


### PR DESCRIPTION
- adds 2.7.0 to component library.
- adds 2.7.0 to README and VERSIONS.
- clarifies carousel automatic transitioning note.
- adds Order By and Sort Order Content Fragment List library example.
- adds Content Fragment List order feature to its README.
- adds missing .content.xml in Content Fragment List content.
- adds missing OOTB oEmbed providers to embed README.
- text improvements in Embed library page.
- removes unnecessary empty lines introduced.
- minor text improvements.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->
