### PR TITLE
[Maintenance] Fixes failing List UI tests

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImpl.java
@@ -308,6 +308,9 @@ public class ListImpl implements List {
 
     private Page getRootPage(String fieldName) {
         String parentPath = properties.get(fieldName, currentPage.getPath());
+        if (StringUtils.isBlank(parentPath)) {
+            parentPath = currentPage.getPath();
+        }
         return pageManager.getContainingPage(resourceResolver.getResource(parentPath));
     }
 


### PR DESCRIPTION
- checks for the `./currentPage` property also being blank, as well as missing
- in both cases use the current page path