### PR TITLE
Issue 764: [Container] Render newPar placeholder in preview mode

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/simple.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/simple.html
@@ -26,7 +26,7 @@
             placeholderCss=allowed.placeholderCssClass,
             placeholderType=allowed.placeholderResourceType}"></sly>
         <sly data-sly-repeat="${container.items}" data-sly-resource="${item.path @ decoration=true}"></sly>
-        <sly data-sly-test="${!isAllowedApplicable && wcmmode.edit}"
+        <sly data-sly-test="${!isAllowedApplicable && (wcmmode.edit || wcmmode.preview)}"
              data-sly-resource="${resource.path @ resourceType='core/wcm/components/container/v1/container/new', appendPath='/*', decorationTagName='div', cssClassName='new section'}" />
     </div>
 </template>


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #764 
| Patch: Bug Fix?          | YES
| Minor: New Feature?      | NO
| Major: Breaking Change?  | NO
| Tests Added + Pass?      | N/A 
| Documentation Provided   | N/A
| Any Dependency Changes?  | NO
| License                  | Apache License, Version 2.0

Corrects issue where the new paragraph placeholder is not rendered
on the container component in "simple" layout mode unless the page
was initially loaded in edit mode.