### PR TITLE
[Container] Documentation: Add cq:isContainer="{Boolean}true" for proxy component in README

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/README.md
@@ -57,6 +57,11 @@ The following properties are written to JCR for this Container component and are
 BLOCK cmp-container
 ```
 
+### Enabling Container Editing Functionality
+The following property is required in the proxy component to enable full editing functionality for the Container:
+
+1. `./cq:isContainer` - set to `{Boolean}true`, marks the Container as a container component
+
 ## Information
 * **Vendor**: Adobe
 * **Version**: v1


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #771`
| Patch: Bug Fix?          | Documentation update
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | No
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Updated documentation in the Container component README when setting up the proxy component user must add cq:isContainer="{Boolean}true" to enable full functionality.
