### PR TITLE
[Navigation][Accessibility] Inconsistent isActive behavior #688

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/NavigationItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/NavigationItem.java
@@ -45,7 +45,7 @@ public interface NavigationItem extends ListItem {
     /**
      * Returns {@code true} if the page contained by this navigation item is active.
      *
-     * @return {@code true} if it is the current page, otherwise {@code false}
+     * @return {@code true} if it is the current page or one of its ancestors, otherwise {@code false}
      * @since com.adobe.cq.wcm.core.components.models 11.0.0; marked <code>default</code> in 12.1.0
      */
     default boolean isActive() {


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #688 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

The javadoc of `NavigationItem#isActive`stated that it returns `true` if it is the current page, but in reality it returns `true` if it is the current page or one of its ancestors. So, fixed the javadoc.