### PR TITLE
[Image v2] String function use should be optimized for single characters

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
@@ -507,6 +507,6 @@
     if (document.readyState !== "loading") {
         onDocumentReady();
     } else {
-        document.addEventListener("DOMContentLoaded", onDocumentReady());
+        document.addEventListener("DOMContentLoaded", onDocumentReady);
     }
 }());


### PR DESCRIPTION

| ------------------------ | ---
| Fixed Issues?            | String function use should be optimized for single characters
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes 
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

An indexOf or lastIndexOf call with a single letter String can be made more performant by switching to a call with a char argument.
