### PR TITLE
added 'cmp-image' css class

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/element.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/element.html
@@ -16,7 +16,7 @@
 <template data-sly-template.element="${@ element='The content fragment element'}">
     <div class="cmp-contentfragment__element cmp-contentfragment__element--${element.name}" data-cmp-contentfragment-element-type="${element.dataType}">
         <dt class="cmp-contentfragment__element-title">${element.title}</dt>
-        <dd class="cmp-contentfragment__element-value">
+        <dd class="cmp-contentfragment__element-value cmp-image">
             <sly data-sly-test="${element.dataType == 'calendar'}" data-sly-use.tpl="core/wcm/components/contentfragment/v1/contentfragment/calendar.html"
                  data-sly-call="${tpl.element @ date = element.value}"></sly>
             <sly data-sly-test="${element.dataType == 'boolean'}">${element.value ? "true" : "false"}</sly>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Fixes #728 
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | 
| Documentation Provided   | 
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

The 'cmp-image' css class will make the images in the content fragment responsive. 