### PR TITLE
Issue 788 - trim the richtext html value before saving in data attribute

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/v1/clientlibs/editor/checkboxTextfieldTuple/checkboxTextfieldTuple.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/v1/clientlibs/editor/checkboxTextfieldTuple/checkboxTextfieldTuple.js
@@ -210,11 +210,16 @@
      * @private
      */
     CheckboxTextfieldTuple.prototype._getTextfieldValue = function() {
+        var result;
         if (this._isRichText) {
-            return $(this._textfield).html();
+            result = $(this._textfield).html();
+            if (result) {
+                result = result.trim();
+            }
         } else {
-            return this._textfield.value;
+            result = this._textfield.value;
         }
+        return result;
     };
 
     /**


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #788 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes - bugfix
| Minor: New Feature?      | No
| Major: Breaking Change?  | Should not break anything
| Tests Added + Pass?      | No new tests, changed internal implementation
| Documentation Provided   | No, changed internal implementation only
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Added the trimming of richtext html before saving the value in data attribute to prevent unwanted white spaces in teaser description field