### PR TITLE
Add isDecorative method to Image interface (Adobe#686)

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
@@ -327,6 +327,12 @@ public class ImageImpl implements Image {
         return resource.getResourceType();
     }
 
+    @Override
+    @JsonIgnore
+    public boolean isDecorative() {
+        return this.isDecorative;
+    }
+
     protected void buildJson() {
         JsonArrayBuilder smartSizesJsonBuilder = Json.createArrayBuilder();
         for (int size : smartSizes) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
@@ -290,4 +290,11 @@ public interface Image extends ComponentExporter {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Whether the image is decorative.
+     * @since com.adobe.cq.wcm.core.components.models 12.11.0
+     */
+    default boolean isDecorative() {
+        throw new UnsupportedOperationException();
+    };
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
@@ -291,7 +291,9 @@ public interface Image extends ComponentExporter {
     }
 
     /**
-     * Whether the image is decorative.
+     * Indicates whether the image is decorative.
+     *
+     * @return true if the image is decorative; false otherwise
      * @since com.adobe.cq.wcm.core.components.models 12.11.0
      */
     default boolean isDecorative() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.10.0")
+@Version("12.11.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #686 
| Patch: Bug Fix?          | No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

As discussed in the issue, this PR adds the isDecorative method to the Image interface.
