### PR TITLE
Unable to Run Individual jUnit Tests in Eclipse 

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -476,6 +476,12 @@
             <groupId>uk.org.lidalia</groupId>
             <artifactId>slf4j-test</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-commons</artifactId>
+            <version>1.5.2</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Only required for junit 4 -->
         <dependency>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes: #804
| Patch: Bug Fix?          | X
| Minor: New Feature?      | 
| Major: Breaking Change?  |
| Tests Added + Pass?      | N/A
| Documentation Provided   | N/A
| Any Dependency Changes?  | Yes, see below
| License                  | Apache License, Version 2.0

Minor fix to add junit-platform-commons version 1.5.2 to provide the missing dependency when running jUnit tests in Eclipse.