### PR TITLE
[Download] Size of asset is not visible #819

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImpl.java
@@ -210,12 +210,16 @@ public class DownloadImpl implements Download {
                         }
                     }
 
-                    size = null;
+                    long rawFileSize;
                     Object rawFileSizeObject = downloadAsset.getMetadata(DamConstants.DAM_SIZE);
+
                     if (rawFileSizeObject != null) {
-                        long rawFileSize = (Long) rawFileSizeObject;
-                        size = FileUtils.byteCountToDisplaySize(rawFileSize);
+                        rawFileSize = (Long) rawFileSizeObject;
+                    } else {
+                        rawFileSize = downloadAsset.getOriginal().getSize();
                     }
+
+                    size = FileUtils.byteCountToDisplaySize(rawFileSize);
             }
         }
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImplTest.java
@@ -40,10 +40,12 @@ class DownloadImplTest {
     private static final String CONTENT_ROOT = "/content";
     private static final String PDF_BINARY_NAME = "Download_Test_PDF.pdf";
     private static final String PDF_ASSET_PATH = "/content/dam/core/documents/" + PDF_BINARY_NAME;
+    private static final String PDF_ASSET_WITHOUT_SIZE_PROP_PATH = "/content/dam/core/documents_without_size/" + PDF_BINARY_NAME;
     private static final String PDF_FILE_PATH = "/content/downloads/jcr:content/root/responsivegrid/download-3/file";
     private static final String PDF_ASSET_DOWNLOAD_PATH = PDF_ASSET_PATH + "." + DownloadServlet.SELECTOR + ".pdf";
     private static final String PDF_FILE_DOWNLOAD_PATH = PDF_FILE_PATH + "." + DownloadServlet.SELECTOR + ".inline.pdf/" + PDF_BINARY_NAME;
     private static final String TEST_CONTENT_DAM_JSON = "/test-content-dam.json";
+    private static final String TEST_CONTENT_DAM_WITHOUT_SIZE_PROP_JSON = "/test-content-dam-without-size-prop.json";
     private static final String CONTEXT_PATH = "/core";
     private static final String TEST_ROOT_PAGE = "/content/downloads";
     private static final String TEST_ROOT_PAGE_GRID = "/jcr:content/root/responsivegrid";
@@ -60,6 +62,7 @@ class DownloadImplTest {
     private static final String DOWNLOAD_1 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/download-1";
     private static final String DOWNLOAD_2 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/download-2";
     private static final String DOWNLOAD_3 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/download-3";
+    private static final String DOWNLOAD_4 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/download-4";
     private static final String DOWNLOAD_FULLY_CONFIGURED = "download-fully-configured";
     private static final String DOWNLOAD_WITH_DAM_PROPERTIES = "download-with-dam-properties";
     private static final String DOWNLOAD_FULLY_CONFIGURED_FILE = "download-fully-configured-file";
@@ -86,6 +89,22 @@ class DownloadImplTest {
         assertEquals(PDF_FORMAT_STRING, download.getFormat());
         assertEquals(COMPONENT_ACTION_TEXT, download.getActionText());
         Utils.testJSONExport(download, Utils.getTestExporterJSONPath(TEST_BASE, DOWNLOAD_FULLY_CONFIGURED));
+    }
+
+    @Test
+    void testFullyConfiguredDownload_assetWithoutSizeProperty() {
+        context.load().json(TEST_BASE + TEST_CONTENT_DAM_WITHOUT_SIZE_PROP_JSON, "/content/dam/core/documents_without_size");
+        context.load().binaryFile("/download/" + PDF_BINARY_NAME, PDF_ASSET_WITHOUT_SIZE_PROP_PATH + "/jcr:content/renditions/original");
+
+        Download download = getDownloadUnderTest(DOWNLOAD_4);
+        assertEquals(TITLE, download.getTitle());
+        assertEquals(DESCRIPTION, download.getDescription());
+        assertEquals(PDF_ASSET_WITHOUT_SIZE_PROP_PATH + "." + DownloadServlet.SELECTOR + ".pdf", download.getUrl());
+        assertEquals(PDF_FILENAME, download.getFilename());
+        assertEquals(PDF_EXTENSION, download.getExtension());
+        assertEquals(PDF_FILESIZE_STRING, download.getSize());
+        assertEquals(PDF_FORMAT_STRING, download.getFormat());
+        assertEquals(COMPONENT_ACTION_TEXT, download.getActionText());
     }
 
     @Test

--- a/bundles/core/src/test/resources/download/test-content-dam-without-size-prop.json
+++ b/bundles/core/src/test/resources/download/test-content-dam-without-size-prop.json
@@ -1,0 +1,109 @@
+{
+    "Download_Test_PDF.pdf": {
+        "jcr:primaryType": "dam:Asset",
+        "jcr:mixinTypes": [
+            "mix:referenceable",
+            "mix:versionable"
+        ],
+        "jcr:createdBy": "admin",
+        "jcr:versionHistory": "50e61be8-1ba3-461d-81cc-2cb00d3b212d",
+        "jcr:predecessors": [
+            "e0de5899-ff22-4521-8aea-37566ce4735f"
+        ],
+        "jcr:created": "Thu Oct 18 2018 12:00:37 GMT-0700",
+        "jcr:baseVersion": "e0de5899-ff22-4521-8aea-37566ce4735f",
+        "jcr:isCheckedOut": true,
+        "jcr:uuid": "8d7e96d4-501a-4ade-93d5-a5956b13a5df",
+        "jcr:content": {
+            "jcr:primaryType": "dam:AssetContent",
+            "jcr:lastModifiedBy": "admin",
+            "dam:assetState": "processed",
+            "cq:name": "Download_Test_PDF.pdf",
+            "jcr:lastModified": "Thu Oct 18 2018 16:50:44 GMT-0700",
+            "cq:parentPath": "/content/dam/core/documents",
+            "dam:relativePath": "core/documents/Download_Test_PDF.pdf",
+            "renditions": {
+                "jcr:primaryType": "nt:folder",
+                "jcr:createdBy": "admin",
+                "jcr:created": "Thu Oct 18 2018 12:00:37 GMT-0700",
+                "cq5dam.thumbnail.48.48.png": {
+                    "jcr:primaryType": "nt:file",
+                    "jcr:createdBy": "workflow-process-service",
+                    "jcr:created": "Thu Oct 18 2018 12:00:38 GMT-0700",
+                    "jcr:content": {
+                        "jcr:primaryType": "oak:Resource",
+                        "jcr:lastModifiedBy": "workflow-process-service",
+                        "jcr:mimeType": "image/png",
+                        "jcr:lastModified": "Thu Oct 18 2018 12:00:38 GMT-0700",
+                        ":jcr:data": 1434
+                    }
+                },
+                "cq5dam.thumbnail.140.100.png": {
+                    "jcr:primaryType": "nt:file",
+                    "jcr:createdBy": "workflow-process-service",
+                    "jcr:created": "Thu Oct 18 2018 12:00:38 GMT-0700",
+                    "jcr:content": {
+                        "jcr:primaryType": "oak:Resource",
+                        "jcr:lastModifiedBy": "workflow-process-service",
+                        "jcr:mimeType": "image/png",
+                        "jcr:lastModified": "Thu Oct 18 2018 12:00:38 GMT-0700",
+                        ":jcr:data": 4436
+                    }
+                },
+                "cq5dam.web.1280.1280.jpeg": {
+                    "jcr:primaryType": "nt:file",
+                    "jcr:createdBy": "workflow-process-service",
+                    "jcr:created": "Thu Oct 18 2018 12:00:38 GMT-0700",
+                    "jcr:content": {
+                        "jcr:primaryType": "oak:Resource",
+                        "jcr:lastModifiedBy": "workflow-process-service",
+                        "jcr:mimeType": "image/jpeg",
+                        "jcr:lastModified": "Thu Oct 18 2018 12:00:38 GMT-0700",
+                        ":jcr:data": 82835
+                    }
+                },
+                "cq5dam.thumbnail.319.319.png": {
+                    "jcr:primaryType": "nt:file",
+                    "jcr:createdBy": "workflow-process-service",
+                    "jcr:created": "Thu Oct 18 2018 12:00:38 GMT-0700",
+                    "jcr:content": {
+                        "jcr:primaryType": "oak:Resource",
+                        "jcr:lastModifiedBy": "workflow-process-service",
+                        "jcr:mimeType": "image/png",
+                        "jcr:lastModified": "Thu Oct 18 2018 12:00:38 GMT-0700",
+                        ":jcr:data": 31265
+                    }
+                }
+            },
+            "related": {
+                "jcr:primaryType": "nt:unstructured"
+            },
+            "metadata": {
+                "jcr:primaryType": "nt:unstructured",
+                "jcr:mixinTypes": [
+                    "cq:Taggable"
+                ],
+                "dam:Physicalheightininches": "11.0",
+                "dam:Physicalwidthininches": "8.5",
+                "dam:numPages": 3,
+                "jcr:lastModifiedBy": "admin",
+                "xmp:CreatorTool": "Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+                "dam:extracted": "Thu Oct 18 2018 12:00:37 GMT-0700",
+                "dc:format": "application/pdf",
+                "dc:description": "This is the description from the PDF.",
+                "dam:Producer": "Skia/PDF m69",
+                "dc:modified": "Thu Oct 18 2018 16:50:40 GMT-0700",
+                "xmp:MetadataDate": "Thu Oct 18 2018 18:56:02 GMT+0000",
+                "jcr:lastModified": "Thu Oct 18 2018 16:50:40 GMT-0700",
+                "pdf:Producer": "Skia/PDF m69",
+                "xmp:ModifyDate": "Thu Oct 18 2018 11:56:02 GMT-0700",
+                "xmp:CreateDate": "Thu Oct 18 2018 11:56:02 GMT-0700",
+                "dam:sha1": "af873625d4359ce515e02a2bed8eedad48b070a8",
+                "dc:title": "This is the title from the PDF.",
+                "Iptc4xmpCore:CreatorContactInfo": {
+                    "jcr:primaryType": "nt:unstructured"
+                }
+            }
+        }
+    }
+}

--- a/bundles/core/src/test/resources/download/test-content.json
+++ b/bundles/core/src/test/resources/download/test-content.json
@@ -57,6 +57,14 @@
                                 "jcr:uuid": "1927d32d-fc6c-4046-85d1-d0c3c87d4449"
                             }
                         }
+                    },
+                    "download-4"          : {
+                        "jcr:primaryType"   : "nt:unstructured",
+                        "fileReference"     : "/content/dam/core/documents_without_size/Download_Test_PDF.pdf",
+                        "jcr:title"         : "Download",
+                        "jcr:description"   : "Description",
+                        "actionText"        : "Click",
+                        "sling:resourceType": "core/wcm/components/download/v1/download"
                     }
                 }
             }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes adobe#819 <!-- remove the (`) quotes to link the issues -->
| Patch:          | Yes - Download Component
| Minor:      | No
| Major:   | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0


<!-- Describe your changes below in as much detail as possible -->

I added fallback for initialize size field if an asset does't contain `dam:size` property.