### PR TITLE
[Teaser] Blank lines in teaser description when Link or CTA is filled

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/v1/clientlibs/editor/checkboxTextfieldTuple/checkboxTextfieldTuple.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/v1/clientlibs/editor/checkboxTextfieldTuple/checkboxTextfieldTuple.js
@@ -21,6 +21,9 @@
     window.CQ.CoreComponents = window.CQ.CoreComponents || {};
     window.CQ.CoreComponents.CheckboxTextfieldTuple = window.CQ.CoreComponents.CheckboxTextfieldTuple || {};
 
+    var CQ_RICHTEXT = ".cq-RichText";
+    var CQ_RICHTEXT_INPUT = "input[type=hidden][data-cq-richtext-input='true']";
+
     /**
      * Creates a tuple consisting of a checkbox and a text field located in the same dialog.
      *
@@ -211,7 +214,13 @@
      */
     CheckboxTextfieldTuple.prototype._getTextfieldValue = function() {
         if (this._isRichText) {
-            return $(this._textfield).html();
+            var $richText = $(this._textfield).closest(CQ_RICHTEXT);
+            if ($richText.length) {
+                var $richTextInput = $richText.find(CQ_RICHTEXT_INPUT);
+                if ($richTextInput.length) {
+                    return $richTextInput.val();
+                }
+            }
         } else {
             return this._textfield.value;
         }


### PR DESCRIPTION
Checkbox Textfield Tuple - read the richtext value from the hidden input field rather than the html of the editable.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #788` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      |
| Documentation Provided   | (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
