### PR TITLE
[Container] Author can choose whichever color even if swatches only option is enabled

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/_cq_dialog/.content.xml
@@ -20,10 +20,12 @@
     jcr:title="Container"
     sling:resourceType="cq/gui/components/authoring/dialog"
     helpPath="https://www.adobe.com/go/aem_cmp_container_v1"
-    trackingFeature="core-components:container:v1">
+    trackingFeature="core-components:container:v1"
+    extraClientlibs="[core.wcm.components.container.v1.editor]">
     <content
         jcr:primaryType="nt:unstructured"
-        sling:resourceType="granite/ui/components/coral/foundation/container">
+        sling:resourceType="granite/ui/components/coral/foundation/container"
+        granite:class="cmp-container__editor">
         <items jcr:primaryType="nt:unstructured">
             <tabs
                 jcr:primaryType="nt:unstructured"
@@ -88,10 +90,14 @@
                                                 name="./backgroundColor"
                                                 showDefaultColors="{Boolean}false"
                                                 showProperties="{Boolean}false"
-                                                showSwatches="{Boolean}true">
+                                                showSwatches="{Boolean}true"
+                                                variant="swatch">
                                                 <datasource
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="core/wcm/components/commons/datasources/allowedcolorswatches/v1"/>
+                                                <granite:data
+                                                    jcr:primaryType="nt:unstructured"
+                                                    cmp-container-v1-dialog-edit-hook="backgroundColorSwatchesOnly"/>
                                             </backgroundColorSwatchesOnly>
                                             <backgroundImageAsset
                                                 granite:hide="${!cqDesign.backgroundImageEnabled}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/clientlibs/editor/js/container.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/clientlibs/editor/js/container.js
@@ -19,6 +19,9 @@
 
     var selectors = {
         dialogContent: ".cmp-container__editor",
+        edit: {
+            backgroundColorSwatchesOnly: "[data-cmp-container-v1-dialog-edit-hook='backgroundColorSwatchesOnly']"
+        },
         policy: {
             backgroundColorEnabled: "[data-cmp-container-v1-dialog-policy-hook='backgroundColorEnabled']",
             backgroundColorSwatchesOnly: "[data-cmp-container-v1-dialog-policy-hook='backgroundColorSwatchesOnly']",
@@ -32,11 +35,32 @@
         var dialogContent = $dialogContent.length > 0 ? $dialogContent[0] : undefined;
 
         if (dialogContent) {
-            if (dialogContent.querySelector("[data-cmp-container-v1-dialog-policy-hook]")) {
+            if (dialogContent.querySelector("[data-cmp-container-v1-dialog-edit-hook]")) {
+                handleEditDialog(dialogContent);
+            } else if (dialogContent.querySelector("[data-cmp-container-v1-dialog-policy-hook]")) {
                 handlePolicyDialog(dialogContent);
             }
         }
     });
+
+    /**
+     * Binds edit dialog handling
+     *
+     * @param {HTMLElement} containerEditor The dialog wrapper
+     */
+    function handleEditDialog(containerEditor) {
+        var backgroundColorSwatchesOnly = containerEditor.querySelector(selectors.edit.backgroundColorSwatchesOnly);
+        if (backgroundColorSwatchesOnly) {
+            backgroundColorSwatchesOnly.on("coral-overlay:beforeopen.cmp-container-v1-dialog-edit", function(event) {
+                backgroundColorSwatchesOnly.off("coral-overlay:beforeopen.cmp-container-v1-dialog-edit");
+
+                // ensures the swatches overlay is displayed in dialog inline mode, by aligning it bottom left of the toggle button
+                var target = event.target || event.srcElement;
+                target.alignAt = Coral.Overlay.align.LEFT_BOTTOM;
+                target.alignMy = Coral.Overlay.align.LEFT_TOP;
+            });
+        }
+    }
 
     /**
      * Binds policy dialog handling

--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/clientlibs/editor/js/container.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/clientlibs/editor/js/container.js
@@ -54,7 +54,7 @@
             backgroundColorSwatchesOnly.on("coral-overlay:beforeopen.cmp-container-v1-dialog-edit", function(event) {
                 backgroundColorSwatchesOnly.off("coral-overlay:beforeopen.cmp-container-v1-dialog-edit");
 
-                // ensures the swatches overlay is displayed in dialog inline mode, by aligning it bottom left of the toggle button
+                // ensures the swatches overlay is displayed correctly in dialog inline mode, by aligning it bottom left of the toggle button
                 var target = event.target || event.srcElement;
                 target.alignAt = Coral.Overlay.align.LEFT_BOTTOM;
                 target.alignMy = Coral.Overlay.align.LEFT_TOP;


### PR DESCRIPTION
- switches background color swatches only field to `variant=swatch`
- adds workaround to ensure the color input overlay fits in the inline dialog context by aligning it bottom left

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #740 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      |
| Documentation Provided   |  N/A
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
