### PR TITLE
[ExperienceFragment] "Edit in New Tab" action does not work

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_editConfig.xml
@@ -33,7 +33,7 @@
         <editInNewTab
             jcr:primaryType="nt:unstructured"
             text="Edit"
-            handler="Granite.author.experienceFragments &amp;&amp; Granite.author.experienceFragments.actions.editInNewTab"
+            handler="CQ.CoreComponents.experienceFragment.v1.actions.editInNewTab"
             icon="edit"/>
     </cq:actionConfigs>
 </jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_editConfig.xml
@@ -33,7 +33,7 @@
         <editInNewTab
             jcr:primaryType="nt:unstructured"
             text="Edit"
-            handler="CQ.CoreComponents.experienceFragment.v1.actions.editInNewTab"
+            handler="CQ.CoreComponents.experiencefragment.v1.actions.edit"
             icon="edit"/>
     </cq:actionConfigs>
 </jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/editor/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/editor/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[cq.authoring.editor.hook]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/editor/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/editor/js.txt
@@ -1,0 +1,20 @@
+###############################################################################
+# Copyright 2019 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=js
+
+namespace.js
+experiencefragment.js

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/editor/js/experiencefragment.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/editor/js/experiencefragment.js
@@ -1,0 +1,35 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+/* global CQ */
+(function($, ns) {
+    "use strict";
+
+    var MSG_NO_FRAGMENT_PATH = Granite.I18n.get("The experience fragment doesn't have an associated variation");
+
+    ns.experienceFragment.v1.actions.editInNewTab = function() {
+        var ui = $(window).adaptTo("foundation-ui");
+        $.get(this.path + ".model.json")
+            .then(function(response) {
+                var path = response["localizedFragmentVariationPath"];
+                if (typeof path !== "undefined") {
+                    window.open(Granite.HTTP.externalize("/editor.html" +
+                        path.substring(0, path.lastIndexOf("/")) + ".html"));
+                } else {
+                    ui.notify("", MSG_NO_FRAGMENT_PATH, "notice");
+                }
+            });
+    };
+})(jQuery, CQ.CoreComponents);

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/editor/js/experiencefragment.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/editor/js/experiencefragment.js
@@ -17,14 +17,14 @@
 (function($, ns) {
     "use strict";
 
-    var MSG_NO_FRAGMENT_PATH = Granite.I18n.get("The experience fragment doesn't have an associated variation");
+    var MSG_NO_FRAGMENT_PATH = Granite.I18n.get("This experience fragment component doesn't have an associated variation");
 
-    ns.experienceFragment.v1.actions.editInNewTab = function() {
+    ns.experiencefragment.v1.actions.edit = function() {
         var ui = $(window).adaptTo("foundation-ui");
         $.get(this.path + ".model.json")
             .then(function(response) {
                 var path = response["localizedFragmentVariationPath"];
-                if (typeof path !== "undefined") {
+                if (typeof path === "string" && path.length > 0) {
                     window.open(Granite.HTTP.externalize("/editor.html" +
                         path.substring(0, path.lastIndexOf("/")) + ".html"));
                 } else {

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/editor/js/namespace.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/editor/js/namespace.js
@@ -18,7 +18,7 @@
 
     window.CQ = window.CQ || {};
     window.CQ.CoreComponents = window.CQ.CoreComponents || {};
-    window.CQ.CoreComponents.experienceFragment = window.CQ.CoreComponents.experienceFragment || {};
-    window.CQ.CoreComponents.experienceFragment.v1 = window.CQ.CoreComponents.experienceFragment.v1 || {};
-    window.CQ.CoreComponents.experienceFragment.v1.actions = {};
+    window.CQ.CoreComponents.experiencefragment = window.CQ.CoreComponents.experiencefragment || {};
+    window.CQ.CoreComponents.experiencefragment.v1 = window.CQ.CoreComponents.experiencefragment.v1 || {};
+    window.CQ.CoreComponents.experiencefragment.v1.actions = {};
 })();

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/editor/js/namespace.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/clientlibs/editor/js/namespace.js
@@ -1,0 +1,24 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2018 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+(function() {
+    "use strict";
+
+    window.CQ = window.CQ || {};
+    window.CQ.CoreComponents = window.CQ.CoreComponents || {};
+    window.CQ.CoreComponents.experienceFragment = window.CQ.CoreComponents.experienceFragment || {};
+    window.CQ.CoreComponents.experienceFragment.v1 = window.CQ.CoreComponents.experienceFragment.v1 || {};
+    window.CQ.CoreComponents.experienceFragment.v1.actions = {};
+})();


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #815 
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | No
| Documentation Provided   | no
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

- created our own edit action, instead of using the one from Experience Fragment 
- instead of using variationPath returned by .json, using localizedVariationPath from .model.json

