### PR TITLE
[Teaser] Allow teaser CTA to be marked as highlighted #838

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -18,6 +18,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
@@ -284,14 +285,14 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
         private final String title;
 
         /**
-         * Teaser action URL.
+         * Teaser action path.
          */
-        private final String url;
+        private final String path;
 
         /**
-         * Teaser action page.
+         * Teaser action url.
          */
-        private final Page page;
+        private final String url;
 
         /**
          * Flag indicating if the teaser action is highlighted.
@@ -305,26 +306,27 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
          */
         TeaserActionImpl(@NotNull final Resource actionRes) {
             ValueMap properties = actionRes.getValueMap();
-            title = properties.get(PN_ACTION_TEXT, String.class);
-            url = properties.get(PN_ACTION_LINK, String.class);
-            if (url != null && url.startsWith("/")) {
-                page = pageManager.getPage(url);
-            } else {
-                page = null;
-            }
+            this.title = properties.get(PN_ACTION_TEXT, String.class);
+            this.path = properties.get(PN_ACTION_LINK, String.class);
+            this.url = Optional.ofNullable(this.path)
+                .filter(p -> p.startsWith("/"))
+                .map(pageManager::getPage)
+                .map(p -> Utils.getURL(request, p))
+                .orElse(this.path);
+
             this.highlighted = properties.get(PN_ACTION_HIGHLIGHTED, Boolean.FALSE);
         }
 
         @Nullable
         @Override
         public String getTitle() {
-            return title;
+            return this.title;
         }
 
         @Nullable
         @Override
         public String getPath() {
-            return url;
+            return this.path;
         }
 
         @Override
@@ -335,11 +337,7 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
         @Nullable
         @Override
         public String getURL() {
-            if (page != null) {
-                return Utils.getURL(request, page);
-            } else {
-                return url;
-            }
+            return this.url;
         }
 
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Teaser.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Teaser.java
@@ -58,6 +58,11 @@ public interface Teaser extends ComponentExporter {
     String PN_ACTION_TEXT = "text";
 
     /**
+     * Name of the resource property that stores the Call-to-Action flag indicating if the CTA is highlighted.
+     */
+    String PN_ACTION_HIGHLIGHTED = "highlighted";
+
+    /**
      * Name of the policy property that defines whether or not Call-to-Actions are disabled
      *
      * @since com.adobe.cq.wcm.core.components.models 12.4.0
@@ -130,7 +135,7 @@ public interface Teaser extends ComponentExporter {
      * @return the list of CTAs
      * @since com.adobe.cq.wcm.core.components.models 12.4.0
      */
-    default List<ListItem> getActions() {
+    default List<TeaserAction> getActions() {
         throw new UnsupportedOperationException();
     }
 
@@ -211,6 +216,21 @@ public interface Teaser extends ComponentExporter {
     @Override
     default String getExportedType() {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Teaser action interface.
+     */
+    interface TeaserAction extends ListItem {
+
+        /**
+         * Checks if the teaser instance is marked as highlighted.
+         *
+         * @return True if the teaser instance is highlighted, false if not.
+         */
+        default boolean getHighlighted() {
+            throw new UnsupportedOperationException();
+        }
     }
 
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
@@ -175,9 +175,11 @@ class TeaserImplTest {
         Teaser teaser = getTeaserUnderTest(TEASER_7);
         assertTrue("Expected teaser with actions", teaser.isActionsEnabled());
         assertEquals("Expected to find two actions", 2, teaser.getActions().size());
-        ListItem action = teaser.getActions().get(0);
+        Teaser.TeaserAction action = teaser.getActions().get(0);
         assertEquals("Action link does not match", "http://www.adobe.com", action.getPath());
         assertEquals("Action text does not match", "Adobe", action.getTitle());
+        assertTrue("Action is not highlighted",  action.getHighlighted());
+        assertFalse("Action is highlighted", Objects.requireNonNull(teaser.getActions().get(1)).getHighlighted());
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(TEST_BASE, "teaser9"));
     }
 

--- a/bundles/core/src/test/resources/teaser/exporter-teaser11.json
+++ b/bundles/core/src/test/resources/teaser/exporter-teaser11.json
@@ -8,11 +8,13 @@
   "actions": [
     {
       "title": "Teasers",
-      "url": "/core/content/teasers.html"
+      "url": "/core/content/teasers.html",
+      "highlighted": false
     },
     {
       "title": "Adobe",
-      "url": "http://www.adobe.com"
+      "url": "http://www.adobe.com",
+      "highlighted": false
     }
   ],
   "imagePath": "/core/content/teasers/_jcr_content/root/responsivegrid/teaser-8.coreimg.png/1490005239000/adobe-systems-logo-and-wordmark.png",

--- a/bundles/core/src/test/resources/teaser/exporter-teaser9.json
+++ b/bundles/core/src/test/resources/teaser/exporter-teaser9.json
@@ -7,11 +7,13 @@
   "actions": [
     {
       "title": "Adobe",
-      "url": "http://www.adobe.com"
+      "url": "http://www.adobe.com",
+      "highlighted": true
     },
     {
       "title": "Teasers",
-      "url": "/core/content/teasers.html"
+      "url": "/core/content/teasers.html",
+      "highlighted": false
     }
   ],
   "imagePath": "/core/content/teasers/_jcr_content/root/responsivegrid/teaser-7.coreimg.png/1490005239000/adobe-systems-logo-and-wordmark.png",

--- a/bundles/core/src/test/resources/teaser/test-content.json
+++ b/bundles/core/src/test/resources/teaser/test-content.json
@@ -71,7 +71,8 @@
                             "item0" : {
                                 "jcr:primaryType" : "nt:unstructured",
                                 "link": "http://www.adobe.com",
-                                "text": "Adobe"
+                                "text": "Adobe",
+                                "highlighted": true
                             },
                             "item1" : {
                                 "jcr:primaryType" : "nt:unstructured",

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -330,6 +330,20 @@
                                                                 jcr:primaryType="nt:unstructured"
                                                                 cmp-teaser-v1-dialog-edit-hook="actionTitle"/>
                                                         </text>
+                                                        <highlighted
+                                                            granite:class="cmp-teaser__editor-actionField"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                            name="highlighted"
+                                                            text="Hightlight"
+                                                            checked="{Boolean}false"
+                                                            deleteHint="{Boolean}true"
+                                                            value="{Boolean}true"/>
+                                                        <highlightedTypeHint
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/foundation/form/hidden"
+                                                            name="highlighted@TypeHint"
+                                                            value="Boolean"/>
                                                     </items>
                                                 </field>
                                             </actions>

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/action.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/action.html
@@ -14,5 +14,5 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <sly data-sly-template.action="${@ action}">
-    <a class="cmp-teaser__action-link" href="${action.URL}">${action.title}</a>
+    <a class="cmp-teaser__action-link${action.highlighted ? ' cmp-teaser__action-link-highlighted' : ''}" href="${action.URL}">${action.title}</a>
 </sly>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #838 
| Patch: Bug Fix?          | No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No (probably)
| Tests Added + Pass?      | Yes
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Adds a checkbox to the CTA section of the Teaser component, allowing a CTA to be marked as "highlighted". An additional class is added to the CTA link if the checkbox is checked.

The models are updated to expose the value of this checkbox.