### PR TITLE
[Text] RTE Features in Edit Dialog are not controlled by Component Po…

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/_cq_dialog/.content.xml
@@ -161,16 +161,6 @@
                                                                     ref="paraformat"/>
                                                             </popovers>
                                                         </inline>
-                                                        <dialogFullScreen
-                                                            jcr:primaryType="nt:unstructured"
-                                                            toolbar="[format#bold,format#italic,format#underline,justify#justifyleft,justify#justifycenter,justify#justifyright,lists#unordered,lists#ordered,lists#outdent,lists#indent,links#modifylink,links#unlink,table#createoredit,#paraformat,image#imageProps]">
-                                                            <popovers jcr:primaryType="nt:unstructured">
-                                                                <paraformat
-                                                                    jcr:primaryType="nt:unstructured"
-                                                                    items="paraformat:getFormats:paraformat-pulldown"
-                                                                    ref="paraformat"/>
-                                                            </popovers>
-                                                        </dialogFullScreen>
                                                         <tableEditOptions
                                                             jcr:primaryType="nt:unstructured"
                                                             toolbar="[table#insertcolumn-before,table#insertcolumn-after,table#removecolumn,-,table#insertrow-before,table#insertrow-after,table#removerow,-,table#mergecells-right,table#mergecells-down,table#mergecells,table#splitcell-horizontal,table#splitcell-vertical,-,table#selectrow,table#selectcolumn,-,table#ensureparagraph,-,table#modifytableandcell,table#removetable,-,undo#undo,undo#redo,-,table#exitTableEditing,-]">


### PR DESCRIPTION
…licies

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #158
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | -
| Documentation Provided   | current README is missing description of edit and design props, will create a seaprate documentation issue for that one
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

Removing the default `<dialogFullScreen>` configuration from core text component makes all its features controllable via content policies.
