### PR TITLE
[Content Fragment] Fallback to retrieve correct content type within ElementDataSourceServlet #849

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ElementsDataSourceServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ElementsDataSourceServlet.java
@@ -92,6 +92,10 @@ public class ElementsDataSourceServlet extends AbstractContentFragmentDataSource
             while (elementIterator.hasNext()) {
                 ContentElement element = elementIterator.next();
                 String contentType = element.getValue().getContentType();
+                if (contentType == null) {
+                    contentType = element.getContentType();
+                }
+
                 if (contentType != null && contentType.startsWith("text/") &&
                         !element.getValue().getDataType().isMultiValue()) {
                     elementList.add(element);


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?       | Fixes #849 
| Patch: Bug Fix?          | 👍


<!-- Describe your changes below in as much detail as possible -->
If the contentType cannot be retrieved from the ContentElement's value, it will try to get it from the ContentElement directly. 
