### PR TITLE
[Teaser] Drag & drop SVG on teaser component doesn't work #857

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_editConfig.xml
@@ -4,7 +4,7 @@
     <cq:dropTargets jcr:primaryType="nt:unstructured">
         <image
             jcr:primaryType="cq:DropTargetConfig"
-            accept="[image/gif,image/jpeg,image/png,image/tiff]"
+            accept="[image/gif,image/jpeg,image/png,image/tiff,image/svg\\+xml]"
             groups="[media]"
             propertyName="./fileReference">
             <parameters


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |Fixes #857  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes - Teaser Component
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | No
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
I added `image/svg\\+xml` to `accept` property in cq:editConfig for teaser component in order to fix drag & drop SVG images from content finder.

