### PR TITLE
[XF/CF] Add template/model class name to component

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
@@ -35,7 +34,6 @@ import org.slf4j.LoggerFactory;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.models.ExperienceFragment;
-import com.adobe.cq.xf.ExperienceFragmentVariation;
 import com.adobe.cq.xf.ExperienceFragmentsConstants;
 import com.day.cq.wcm.api.LanguageManager;
 import com.day.cq.wcm.api.Page;
@@ -104,13 +102,11 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
 
         PageManager pageManager = resolver.adaptTo(PageManager.class);
         if (pageManager != null) {
-            Page page = pageManager.getPage(fragmentVariationPath);
-            if (page != null) {
-                ExperienceFragmentVariation variation = page.adaptTo(ExperienceFragmentVariation.class);
-                if (variation != null) {
-                    com.adobe.cq.xf.ExperienceFragment parent = variation.getParent();
-                    String parentPath = parent.getPath();
-                    name = ResourceUtil.getName(parentPath);
+            Page xfVariationPage = pageManager.getPage(fragmentVariationPath);
+            if (xfVariationPage != null) {
+                Page xfPage = xfVariationPage.getParent();
+                if (xfPage != null) {
+                    name = xfPage.getName();
                 }
             }
         }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -39,6 +39,7 @@ import com.adobe.cq.xf.ExperienceFragmentVariation;
 import com.adobe.cq.xf.ExperienceFragmentsConstants;
 import com.day.cq.wcm.api.LanguageManager;
 import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.Template;
 import com.day.cq.wcm.api.WCMException;
 import com.day.cq.wcm.msm.api.LiveCopy;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
@@ -128,6 +128,12 @@ public class ContentFragmentImpl implements ContentFragment {
         return damContentFragment.getType();
     }
 
+    @Nullable
+    @Override
+    public String getName() {
+        return damContentFragment.getName();
+    }
+
     @NotNull
     @Override
     public String getGridResourceType() {
@@ -226,6 +232,11 @@ public class ContentFragmentImpl implements ContentFragment {
 
         @Override
         public @Nullable String getType() {
+            return null;
+        }
+
+        @Override
+        public @Nullable String getName() {
             return null;
         }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/DAMContentFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/DAMContentFragmentImpl.java
@@ -132,6 +132,12 @@ public class DAMContentFragmentImpl implements DAMContentFragment {
         return type;
     }
 
+    @NotNull
+    @Override
+    public String getName() {
+        return contentFragment.getName();
+    }
+
     @Nullable
     @Override
     public List<DAMContentElement> getElements() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ExperienceFragment.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ExperienceFragment.java
@@ -54,6 +54,16 @@ public interface ExperienceFragment extends ComponentExporter {
     }
 
     /**
+     * Returns the technical name of the experience fragment.
+     *
+     * @return the technical name of the experience fragment
+     * @since com.adobe.cq.wcm.core.components.models 12.11.0
+     */
+    default String getName() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * @see ComponentExporter#getExportedType()
      * @since com.adobe.cq.wcm.core.components.models 12.9.0
      */

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/DAMContentFragment.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/DAMContentFragment.java
@@ -185,6 +185,19 @@ public interface DAMContentFragment extends ComponentExporter {
     }
 
     /**
+     * Returns the technical name of the content fragment.
+     *
+     * @return the technical name of the content fragment
+     * @see com.adobe.cq.dam.cfm.ContentFragment#getName()
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.3.0
+     */
+    @NotNull
+    @JsonIgnore
+    default String getName() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Returns the description of the content fragment.
      *
      * @return the description of the content fragment

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/package-info.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("1.2.0")
+@Version("1.3.0")
 package com.adobe.cq.wcm.core.components.models.contentfragment;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImplTest.java
@@ -40,6 +40,7 @@ import com.day.cq.wcm.msm.api.LiveRelationshipManager;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -60,6 +61,7 @@ class ExperienceFragmentImplTest {
     private static final String BLUEPRINT_PAGE = BLUEPRINT_ROOT + "/page";
     private static final String LIVECOPY_ROOT = "/content/mysite/livecopy";
     private static final String LIVECOPY_PAGE = LIVECOPY_ROOT + "/page";
+    private static final String XF_NAME = "footer";
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
 
@@ -159,6 +161,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInPageWithoutLocalization() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(NO_LOC_PAGE
                 + "/jcr:content/root/xf-component-1");
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf1"));
     }
 
@@ -171,6 +174,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInTemplateWithoutLocalization() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
                 PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-1a", NO_LOC_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf1"));
     }
 
@@ -235,6 +239,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInPageWithLocalizationWithSameLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(EN_PAGE
                 + "/jcr:content/root/xf-component-10");
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf10"));
     }
 
@@ -247,6 +252,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInTemplateWithLocalizationWithSameLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
                 PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-10a", EN_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf10"));
     }
 
@@ -259,6 +265,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInPageWithLocalizationWithDifferentLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(EN_PAGE
                 + "/jcr:content/root/xf-component-11");
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf11"));
     }
 
@@ -271,6 +278,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInTemplateWithLocalizationWithDifferentLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
                 PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-11a", EN_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf11a"));
     }
 
@@ -335,6 +343,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInPageWithLocalizationWithSameCountryLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(US_EN_PAGE
                 + "/jcr:content/root/xf-component-20");
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf20"));
     }
 
@@ -347,6 +356,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInTemplateWithLocalizationWithSameCountryLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
                 PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-20a", US_EN_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf20"));
     }
 
@@ -359,6 +369,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInPageWithLocalizationWithDifferentCountryLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(US_EN_PAGE
                 + "/jcr:content/root/xf-component-21");
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf21"));
     }
 
@@ -371,6 +382,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInTemplateWithLocalizationWithDifferentCountryLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
                 PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-21a", US_EN_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf21a"));
     }
 
@@ -411,6 +423,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInPageWithLocalizationWithSameCountrySiteLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(CH_MYSITE_FR_PAGE
                 + "/jcr:content/root/xf-component-30");
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf30"));
     }
 
@@ -423,6 +436,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInTemplateWithLocalizationWithSameCountrySiteLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
                 PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-30a", CH_MYSITE_FR_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf30"));
     }
 
@@ -435,6 +449,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInPageWithLocalizationWithDifferentCountrySiteLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(CH_MYSITE_FR_PAGE
                 + "/jcr:content/root/xf-component-31");
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf31"));
     }
 
@@ -447,6 +462,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInTemplateWithLocalizationWithDifferentCountrySiteLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
                 PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-31a", CH_MYSITE_FR_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf31a"));
     }
 
@@ -487,6 +503,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInPageWithLocalizationWithSameCountry_Language() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(CH_FR_PAGE
                 + "/jcr:content/root/xf-component-40");
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf40"));
     }
 
@@ -499,6 +516,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInTemplateWithLocalizationWithSameCountry_Language() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
             PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-40a", CH_FR_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf40"));
     }
 
@@ -511,6 +529,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInPageWithLocalizationWithDifferentCountry_Language() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(CH_FR_PAGE
             + "/jcr:content/root/xf-component-41");
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf41"));
     }
 
@@ -523,6 +542,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInTemplateWithLocalizationWithDifferentCountry_Language() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
                 PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-41a", CH_FR_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf41a"));
     }
 
@@ -563,6 +583,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInPageWithLocalizationWithSameBlueprint() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(BLUEPRINT_PAGE
                 + "/jcr:content/root/xf-component-50");
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf50"));
     }
 
@@ -575,6 +596,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInTemplateWithLocalizationWithSameBlueprint() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
                 PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-50a", BLUEPRINT_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf50"));
     }
 
@@ -587,6 +609,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInPageWithLocalizationWithDifferentBlueprint() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(BLUEPRINT_PAGE
                 + "/jcr:content/root/xf-component-51");
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf51"));
     }
 
@@ -599,6 +622,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInTemplateWithLocalizationWithDifferentBlueprint() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
                 PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-51a", BLUEPRINT_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf51a"));
     }
 
@@ -611,6 +635,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInPageWithLocalizationWithSameLivecopy() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(LIVECOPY_PAGE
                 + "/jcr:content/root/xf-component-60");
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf60"));
     }
 
@@ -623,6 +648,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInTemplateLocalizationWithSameLivecopy() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
                 PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-60a", LIVECOPY_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf60"));
     }
 
@@ -635,6 +661,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInPageWithLocalizationWithDifferentLivecopy() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(LIVECOPY_PAGE
                 + "/jcr:content/root/xf-component-61");
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf61"));
     }
 
@@ -647,6 +674,7 @@ class ExperienceFragmentImplTest {
     void testValidXFInTemplateWithLocalizationWithDifferentLivecopy() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
             PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-61a", LIVECOPY_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf61a"));
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/AbstractContentFragmentTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/AbstractContentFragmentTest.java
@@ -77,8 +77,11 @@ public abstract class AbstractContentFragmentTest<T> {
     static final String TITLE = "Test Content Fragment";
     static final String DESCRIPTION = "This is a test content fragment.";
     static final String TEXT_ONLY_TYPE = "/content/dam/contentfragments/text-only/jcr:content/model";
+    static final String TEXT_ONLY_NAME = "text-only";
     static final String STRUCTURED_TYPE = "global/models/test";
+    static final String STRUCTURED_NAME = "structured";
     static final String STRUCTURED_TYPE_NESTED = "global/nested/models/test";
+    static final String STRUCTURED_NESTED_NAME = "structured-nested-model";
     static final String[] ASSOCIATED_CONTENT = new String[]{"/content/dam/collections/X/X7v6pJAcy5qtkUdXdIxR/test"};
 
     static final MockElement MAIN = new MockElement("main", "Main", "text/html",

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
@@ -66,14 +66,14 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     @Test
     void textOnly() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY);
-        assertContentFragment(fragment, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, ASSOCIATED_CONTENT, MAIN, SECOND_TEXT_ONLY);
+        assertContentFragment(fragment, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, TEXT_ONLY_NAME, ASSOCIATED_CONTENT, MAIN, SECOND_TEXT_ONLY);
         Utils.testJSONExport(fragment, Utils.getTestExporterJSONPath(TEST_BASE, CF_TEXT_ONLY));
     }
 
     @Test
     void textOnlyVariation() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_VARIATION);
-        assertContentFragment(fragment, VARIATION_NAME, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, ASSOCIATED_CONTENT, MAIN,
+        assertContentFragment(fragment, VARIATION_NAME, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, TEXT_ONLY_NAME, ASSOCIATED_CONTENT, MAIN,
             SECOND_TEXT_ONLY);
         Utils.testJSONExport(fragment, Utils.getTestExporterJSONPath(TEST_BASE, CF_TEXT_ONLY_VARIATION));
     }
@@ -81,21 +81,21 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     @Test
     void textOnlyNonExistingVariation() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_NON_EXISTING_VARIATION);
-        assertContentFragment(fragment, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, ASSOCIATED_CONTENT, MAIN, SECOND_TEXT_ONLY);
+        assertContentFragment(fragment, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, TEXT_ONLY_NAME, ASSOCIATED_CONTENT, MAIN, SECOND_TEXT_ONLY);
         Utils.testJSONExport(fragment, Utils.getTestExporterJSONPath(TEST_BASE, CF_TEXT_ONLY_NON_EXISTING_VARIATION));
     }
 
     @Test
     void textOnlySingleElement() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_SINGLE_ELEMENT);
-        assertContentFragment(fragment, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, ASSOCIATED_CONTENT, SECOND_TEXT_ONLY);
+        assertContentFragment(fragment, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, TEXT_ONLY_NAME, ASSOCIATED_CONTENT, SECOND_TEXT_ONLY);
         Utils.testJSONExport(fragment, Utils.getTestExporterJSONPath(TEST_BASE, CF_TEXT_ONLY_SINGLE_ELEMENT));
     }
 
     @Test
     void textOnlyMultipleElements() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_MULTIPLE_ELEMENTS);
-        assertContentFragment(fragment, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, ASSOCIATED_CONTENT, SECOND_TEXT_ONLY, MAIN);
+        assertContentFragment(fragment, TITLE, DESCRIPTION, TEXT_ONLY_TYPE, TEXT_ONLY_NAME, ASSOCIATED_CONTENT, SECOND_TEXT_ONLY, MAIN);
         Utils.testJSONExport(fragment, Utils.getTestExporterJSONPath(TEST_BASE, CF_TEXT_ONLY_MULTIPLE_ELEMENTS));
     }
 
@@ -127,7 +127,7 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     @Test
     void structured() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED);
-        assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, ASSOCIATED_CONTENT, MAIN,
+        assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, STRUCTURED_NAME, ASSOCIATED_CONTENT, MAIN,
             SECOND_STRUCTURED);
         Utils.testJSONExport(fragment, Utils.getTestExporterJSONPath(TEST_BASE, CF_STRUCTURED));
     }
@@ -135,7 +135,7 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     @Test
     void structuredVariation() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_VARIATION);
-        assertContentFragment(fragment, VARIATION_NAME, TITLE, DESCRIPTION, STRUCTURED_TYPE, ASSOCIATED_CONTENT, MAIN,
+        assertContentFragment(fragment, VARIATION_NAME, TITLE, DESCRIPTION, STRUCTURED_TYPE, STRUCTURED_NAME, ASSOCIATED_CONTENT, MAIN,
             SECOND_STRUCTURED);
         Utils.testJSONExport(fragment, Utils.getTestExporterJSONPath(TEST_BASE, CF_STRUCTURED_VARIATION));
     }
@@ -144,7 +144,7 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     void structuredNonExistingVariation() {
         when(fragmentRenderService.render(any(Resource.class))).thenReturn(MAIN_CONTENT);
         ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_NON_EXISTING_VARIATION);
-        assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, ASSOCIATED_CONTENT, MAIN,
+        assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, STRUCTURED_NAME, ASSOCIATED_CONTENT, MAIN,
             SECOND_STRUCTURED);
         Utils.testJSONExport(fragment, Utils.getTestExporterJSONPath(TEST_BASE, CF_STRUCTURED_NON_EXISTING_VARIATION));
     }
@@ -152,7 +152,7 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     @Test
     void structuredNestedModel() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_NESTED_MODEL);
-        assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE_NESTED, ASSOCIATED_CONTENT, MAIN,
+        assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE_NESTED, STRUCTURED_NESTED_NAME, ASSOCIATED_CONTENT, MAIN,
             SECOND_STRUCTURED);
         Utils.testJSONExport(fragment, Utils.getTestExporterJSONPath(TEST_BASE, CF_STRUCTURED_NESTED_MODEL));
     }
@@ -160,14 +160,14 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     @Test
     void structuredSingleElement() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_SINGLE_ELEMENT);
-        assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, ASSOCIATED_CONTENT, SECOND_STRUCTURED);
+        assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, STRUCTURED_NAME, ASSOCIATED_CONTENT, SECOND_STRUCTURED);
         Utils.testJSONExport(fragment, Utils.getTestExporterJSONPath(TEST_BASE, CF_STRUCTURED_SINGLE_ELEMENT));
     }
 
     @Test
     void structuredMultipleElements() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_MULTIPLE_ELEMENTS);
-        assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, ASSOCIATED_CONTENT, SECOND_STRUCTURED,
+        assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, STRUCTURED_NAME, ASSOCIATED_CONTENT, SECOND_STRUCTURED,
             MAIN);
         Utils.testJSONExport(fragment, Utils.getTestExporterJSONPath(TEST_BASE, CF_STRUCTURED_MULTIPLE_ELEMENTS));
     }
@@ -176,7 +176,7 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     void structuredSingleElementMain() {
         when(fragmentRenderService.render(any(Resource.class))).thenReturn(MAIN_CONTENT);
         ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_SINGLE_ELEMENT_MAIN);
-        assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, ASSOCIATED_CONTENT, MAIN);
+        assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, STRUCTURED_NAME, ASSOCIATED_CONTENT, MAIN);
         Utils.testJSONExport(fragment, Utils.getTestExporterJSONPath(TEST_BASE, CF_STRUCTURED_SINGLE_ELEMENT_MAIN));
     }
 
@@ -262,9 +262,9 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
      * default variation.
      */
     private void assertContentFragment(ContentFragment fragment, String expectedTitle, String expectedDescription,
-                                       String expectedType, String[] expectedAssociatedContent,
+                                       String expectedType, String expectedName, String[] expectedAssociatedContent,
                                        MockElement... expectedElements) {
-        assertContentFragment(fragment, null, expectedTitle, expectedDescription, expectedType,
+        assertContentFragment(fragment, null, expectedTitle, expectedDescription, expectedType, expectedName,
             expectedAssociatedContent, expectedElements);
     }
 
@@ -273,11 +273,12 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
      * specified variation.
      */
     private void assertContentFragment(ContentFragment fragment, String variationName, String expectedTitle,
-                                       String expectedDescription, String expectedType,
+                                       String expectedDescription, String expectedType, String expectedName,
                                        String[] expectedAssociatedContent, MockElement... expectedElements) {
         assertEquals("Content fragment has wrong title", expectedTitle, fragment.getTitle());
         assertEquals("Content fragment has wrong description", expectedDescription, fragment.getDescription());
         assertEquals("Content fragment has wrong type", expectedType, fragment.getType());
+        assertEquals("Content fragment has wrong name", expectedName, fragment.getName());
         List<Resource> associatedContent = fragment.getAssociatedContent();
         assertEquals("Content fragment has wrong number of associated content", expectedAssociatedContent.length, associatedContent.size());
         for (int i = 0; i < expectedAssociatedContent.length; i++) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentMockAdapter.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentMockAdapter.java
@@ -95,6 +95,7 @@ public class ContentFragmentMockAdapter implements Function<Resource, ContentFra
 
         String title = contentProperties.get(JCR_TITLE, String.class);
         String description = contentProperties.get(JCR_DESCRIPTION, String.class);
+        String cfName = resource.getName();
         Resource model;
         Resource modelAdaptee;
         List<ContentElement> elements = new LinkedList<>();
@@ -133,6 +134,7 @@ public class ContentFragmentMockAdapter implements Function<Resource, ContentFra
         ContentFragment fragment = mock(ContentFragment.class, withSettings().lenient());
         when(fragment.getTitle()).thenReturn(title);
         when(fragment.getDescription()).thenReturn(description);
+        when(fragment.getName()).thenReturn(cfName);
         when(fragment.adaptTo(Resource.class)).thenReturn(resource);
         when(fragment.getElement(isNull())).thenAnswer(invocation -> {
             String name = invocation.getArgument(0);

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/README.md
@@ -40,6 +40,7 @@ The following JCR properties are used:
 ## BEM description
 ```
 BLOCK cmp-contentfragment
+  MOD cmp-contentfragment--<name>
     ELEMENT cmp-contentfragment__title
     ELEMENT cmp-contentfragment__description
     ELEMENT cmp-contentfragment__elements

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/templates.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/templates.html
@@ -15,7 +15,7 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 
 <template data-sly-template.contentFragment="${@ fragment='The content fragment', fragmentPath='', wcmmode='WCM mode'}">
-    <article class="cmp-contentfragment"
+    <article class="cmp-contentfragment cmp-contentfragment--${fragment.name}"
              data-cmp-contentfragment-model="${fragment.type}"
              data-sly-attribute.data-cmp-contentfragment-path="${fragmentPath}"
              data-json="${!wcmmode.disabled && fragment.editorJSON}">

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/README.md
@@ -34,6 +34,7 @@ The following property is written to JCR for the experience fragment component a
 ## BEM Description
 ```
 BLOCK cmp-experiencefragment
+  MOD cmp-experiencefragment--<name>
 ```
 
 Note: the rendered HTML markup of the experience fragment component may contain CSS classes that start with `xf-` (e.g. `xf-content-height` or `xf-master-building-block`) -

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/experiencefragment.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/experiencefragment.html
@@ -13,10 +13,10 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<div class="cmp-experiencefragment"
-     data-sly-use.fragment="com.adobe.cq.wcm.core.components.models.ExperienceFragment"
+<div data-sly-use.fragment="com.adobe.cq.wcm.core.components.models.ExperienceFragment"
      data-sly-use.template="core/wcm/components/commons/v1/templates.html"
      data-sly-test.localizedFragmentVariationPath=${fragment.localizedFragmentVariationPath}
-     data-sly-resource="${@path=localizedFragmentVariationPath, selectors='content', wcmmode='disabled'}">
+     data-sly-resource="${@path=localizedFragmentVariationPath, selectors='content', wcmmode='disabled'}"
+     class="cmp-experiencefragment cmp-experiencefragment--${fragment.name}">
 </div>
 <sly data-sly-call="${template.placeholder @ isEmpty=!localizedFragmentVariationPath, classAppend='cmp-dd-experiencefragment'}"></sly>


### PR DESCRIPTION
* Adds `ContentFragment#getName` and applies the result in the markup as BEM modifier on the block.
* Adds `ExperienceFragment#getName` and applies the result in the markup as BEM modifier on the block.
* Updates READMEs.
* Updates test cases.
 
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #860` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      | Yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
