### PR TITLE
fix #878: data-sly-test should not be used for concatenating Strings

### DIFF
--- a/content/pom.xml
+++ b/content/pom.xml
@@ -74,6 +74,12 @@
                         <configuration>
                             <generateJavaClasses>true</generateJavaClasses>
                             <generatedJavaClassesPrefix>org.apache.sling.scripting.sightly</generatedJavaClassesPrefix>
+                            <allowedExpressionOptions>
+                                <allowedExpressionOption>cssClassName</allowedExpressionOption>
+                                <allowedExpressionOption>decoration</allowedExpressionOption>
+                                <allowedExpressionOption>decorationTagName</allowedExpressionOption>
+                                <allowedExpressionOption>wcmmode</allowedExpressionOption>
+                            </allowedExpressionOptions>
                         </configuration>
                     </execution>
                 </executions>
@@ -206,13 +212,13 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.sightly.compiler</artifactId>
-            <version>1.0.22-1.4.0</version>
+            <version>1.2.4-1.4.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.scripting.sightly.compiler.java</artifactId>
-            <version>1.0.24-1.4.0</version>
+            <artifactId>org.apache.sling.scripting.sightly.runtime</artifactId>
+            <version>1.2.0-1.4.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v1/hidden/hidden.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v1/hidden/hidden.html
@@ -15,6 +15,6 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <input data-sly-use.field="com.adobe.cq.wcm.core.components.models.form.Field"
        data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-       data-sly-test.appendText="${field.name && 'name='}${field.name}${field.value && ' | value='}${field.value}"
+       data-sly-set.appendText="${field.name && 'name='}${field.name}${field.value && ' | value='}${field.value}"
        data-sly-call="${templates.placeholder @ isEmpty = true, classAppend, emptyTextAppend = appendText}"
        type="hidden" id="${field.id}" name="${field.name}" value="${field.value}" />

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v2/hidden/hidden.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v2/hidden/hidden.html
@@ -15,6 +15,6 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <input data-sly-use.field="com.adobe.cq.wcm.core.components.models.form.Field"
        data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-       data-sly-test.appendText="${field.name && 'name='}${field.name}${field.value && ' | value='}${field.value}"
+       data-sly-set.appendText="${field.name && 'name='}${field.name}${field.value && ' | value='}${field.value}"
        data-sly-call="${templates.placeholder @ isEmpty = true, classAppend, emptyTextAppend = appendText}"
        type="hidden" id="${field.id}" name="${field.name}" value="${field.value}" />

--- a/examples/ui.apps/pom.xml
+++ b/examples/ui.apps/pom.xml
@@ -79,6 +79,12 @@
                         <configuration>
                             <generateJavaClasses>true</generateJavaClasses>
                             <generatedJavaClassesPrefix>org.apache.sling.scripting.sightly</generatedJavaClassesPrefix>
+                            <allowedExpressionOptions>
+                                <allowedExpressionOption>cssClassName</allowedExpressionOption>
+                                <allowedExpressionOption>decoration</allowedExpressionOption>
+                                <allowedExpressionOption>decorationTagName</allowedExpressionOption>
+                                <allowedExpressionOption>wcmmode</allowedExpressionOption>
+                            </allowedExpressionOptions>
                         </configuration>
                     </execution>
                 </executions>
@@ -217,13 +223,13 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.sightly.compiler</artifactId>
-            <version>1.0.14</version>
+            <version>1.2.4-1.4.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.scripting.sightly.compiler.java</artifactId>
-            <version>1.0.16</version>
+            <artifactId>org.apache.sling.scripting.sightly.runtime</artifactId>
+            <version>1.2.0-1.4.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -368,7 +368,7 @@
                 <plugin>
                     <groupId>org.apache.sling</groupId>
                     <artifactId>htl-maven-plugin</artifactId>
-                    <version>1.2.0-1.4.0</version>
+                    <version>1.3.4-1.4.0</version>
                     <configuration>
                         <failOnWarnings>true</failOnWarnings>
                     </configuration>


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #878
| Patch: Bug Fix?          | ✓
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | No new tests; it's just a syntax improvement
| Documentation Provided   | No
| Any Dependency Changes?  | Updated `htl-maven-plugin` to `1.3.4-1.4.0`
| License                  | Apache License, Version 2.0