### PR TITLE
#883 Image attribute not decoded with .atoffer.html extension

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -84,6 +84,9 @@
          * @type {String}
          */
         "src": {
+            "transform": function(value) {
+                return decodeURIComponent(value);
+            }
         }
     };
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #883 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | No (no idea where / how to add this test)
| Documentation Provided   | No (change is trivial and clear)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

In order to solve the issue, the attribute value need to be decoded at initialization time, which is the purpose of the "transform" function.