### PR TITLE
[Teaser] unable to drag-n-drop an SVG image into the fileupload widget

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -40,7 +40,7 @@
                                                 fieldLabel="Image Asset"
                                                 fileNameParameter="./fileName"
                                                 fileReferenceParameter="./fileReference"
-                                                mimeTypes="[image/gif,image/jpeg,image/png,image/tiff]"
+                                                mimeTypes="[image/gif,image/jpeg,image/png,image/tiff,image/svg+xml]"
                                                 multiple="{Boolean}false"
                                                 name="./file"
                                                 title="Upload Image Asset"


### PR DESCRIPTION
- enable SVG images

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #892 ` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
