### PR TITLE
#897 - Issue with Navigation.getItems() for non-language live copy

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
@@ -136,7 +136,8 @@ public class NavigationImpl implements Navigation {
                 } else if (liveCopiesIterator != null) {
                     while (liveCopiesIterator.hasNext()) {
                         LiveRelationship relationship = (LiveRelationship) liveCopiesIterator.next();
-                        if ((currentPage.getPath() + "/").startsWith(relationship.getTargetPath() + "/")) {
+                        String currentPagePath = currentPage.getPath() + "/";
+                        if (currentPagePath.startsWith(relationship.getTargetPath() + "/")) {
                             Page liveCopyNavigationRoot = pageManager.getPage(relationship.getTargetPath());
                             if (liveCopyNavigationRoot != null) {
                                 navigationRoot = new NavigationRoot(liveCopyNavigationRoot, structureDepth);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
@@ -136,7 +136,7 @@ public class NavigationImpl implements Navigation {
                 } else if (liveCopiesIterator != null) {
                     while (liveCopiesIterator.hasNext()) {
                         LiveRelationship relationship = (LiveRelationship) liveCopiesIterator.next();
-                        if (currentPage.getPath().startsWith(relationship.getTargetPath() + "/")) {
+                        if ((currentPage.getPath() + "/").startsWith(relationship.getTargetPath() + "/")) {
                             Page liveCopyNavigationRoot = pageManager.getPage(relationship.getTargetPath());
                             if (liveCopyNavigationRoot != null) {
                                 navigationRoot = new NavigationRoot(liveCopyNavigationRoot, structureDepth);

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImplTest.java
@@ -78,6 +78,7 @@ class NavigationImplTest {
     private static final String NAV_COMPONENT_12 = TEST_ROOT + "/jcr:content/root/navigation-component-12";
     private static final String NAV_COMPONENT_13 = TEST_ROOT + "/jcr:content/root/navigation-component-13";
     private static final String NAV_COMPONENT_14 = TEST_ROOT + "/jcr:content/root/navigation-component-14";
+    private static final String NAV_COMPONENT_15 = "/content/navigation-livecopy/jcr:content/root/navigation-component-15";
 
     @BeforeEach
     void setUp() throws WCMException {
@@ -272,6 +273,21 @@ class NavigationImplTest {
                 {"/content/navigation-livecopy/1/1-3", 2, false, "/content/navigation-livecopy/1/1-3.html"},
                 {"/content/navigation-livecopy/2", 1, true, "/content/navigation-livecopy/2.html"},
                 {"/content/navigation-livecopy/3", 1, false, "/content/navigation-livecopy/3.html"},
+
+        };
+        verifyNavigationItems(expectedPages, getNavigationItems(navigation));
+    }
+
+    @Test
+    void testNavigationWithLiveCopyTreeCurrentPageAtRoot() {
+        Navigation navigation = getNavigationUnderTest(NAV_COMPONENT_15);
+        Object[][] expectedPages = {
+            {"/content/navigation-livecopy", 0, true, "/content/navigation-livecopy.html"},
+            {"/content/navigation-livecopy/1", 1, false, "/content/navigation-livecopy/1.html"},
+            {"/content/navigation-livecopy/1/1-1", 2, false, "/content/navigation-livecopy/1/1-1.html"},
+            {"/content/navigation-livecopy/1/1-3", 2, false, "/content/navigation-livecopy/1/1-3.html"},
+            {"/content/navigation-livecopy/2", 1, false, "/content/navigation-livecopy/2.html"},
+            {"/content/navigation-livecopy/3", 1, false, "/content/navigation-livecopy/3.html"},
 
         };
         verifyNavigationItems(expectedPages, getNavigationItems(navigation));

--- a/bundles/core/src/test/resources/navigation/test-content.json
+++ b/bundles/core/src/test/resources/navigation/test-content.json
@@ -313,7 +313,16 @@
     "navigation-livecopy"         : {
         "jcr:primaryType": "cq:Page",
         "jcr:content"    : {
-            "jcr:primaryType": "cq:PageContent"
+            "jcr:primaryType": "cq:PageContent",
+            "root"           : {
+                "jcr:primaryType"        : "nt:unstructured",
+                "navigation-component-15": {
+                    "jcr:primaryType"   : "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/navigation/v1/navigation",
+                    "navigationRoot"    : "/content/navigation-blueprint",
+                    "skipNavigationRoot": false
+                }
+            }
         },
         "1"              : {
             "jcr:primaryType": "cq:Page",


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #897
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | No
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

Ensure that by accessing the root page of a non-language live copy, the navigation items provided by the navigation component placed on the page should be the children of the actual live copy and not the children of the source of the live copy.

The solution is to make the condition comparing current page path to live copy path to be true when the two paths are equal, in NavigationImp.getItems().