### PR TITLE
bugfix-901 panelselect.js

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelselect/js/panelselect.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelselect/js/panelselect.js
@@ -418,7 +418,7 @@
     });
 
     channel.on("cq-layer-activated", function(event) {
-        if (event.layer === "Edit") {
+        if (event.layer === "Edit" || event.layer === "structure" || event.layer === "initial") {
             ns.EditorFrame.editableToolbar.registerAction("PANEL_SELECT", panelSelect);
         }
     });


### PR DESCRIPTION
bugfix-901 show toggle select panel in editable template
https://github.com/adobe/aem-core-wcm-components/issues/901

The container components (Accordion/Tab/Carousel) does not provide option to toggle/select panel item(s) when component is authored directly in editable template (structure or initial). However, this works fine when we author the component on the page.

This PR fix addresses above issue by registering panel select option for layer structure and initial as well.

@richardhand and @rajeevyadav2  pls take a look at the PR.

