### PR TITLE
[Library] Visual bug on Firefox/Safari for categories in side navigation

### DIFF
--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/accordion.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/accordion.less
@@ -39,6 +39,7 @@
         font-size: @cmp-examples-font-size-s;
         font-weight: @cmp-examples-font-weight-bold;
         color: @cmp-examples-color-gray-800;
+        background-color: transparent;
 
         &:hover {
             background-color: @cmp-examples-color-gray-200;


### PR DESCRIPTION
- sets an explicit transparency for accordion buttons in the aside so the browser default isn't taken

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #891` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | N/A
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
