### PR TITLE
[Image] The image of the image component placed in the accordion of the template editor is not displayed.

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -736,7 +736,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
     private long getRequestLastModifiedSuffix(@Nullable String suffix) {
         long requestLastModified = 0;
         if (StringUtils.isNotEmpty(suffix) && suffix.contains(".")) {
-            // check if the 13 digits UTC milliseconds timestamp, proceeded by a forward slash is present in the suffix
+            // check if the 13 digits UTC milliseconds timestamp, preceded by a forward slash is present in the suffix
             Pattern p = Pattern.compile("\\(|\\)|\\/\\d{13}");
             Matcher m = p.matcher(suffix);
             if (!m.find()) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -736,8 +736,8 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
     private long getRequestLastModifiedSuffix(@Nullable String suffix) {
         long requestLastModified = 0;
         if (StringUtils.isNotEmpty(suffix) && suffix.contains(".")) {
-            // check if the 13 digits UTC milliseconds timestamp is present in the suffix
-            Pattern p = Pattern.compile("\\(|\\)|\\d{13}");
+            // check if the 13 digits UTC milliseconds timestamp, proceeded by a forward slash is present in the suffix
+            Pattern p = Pattern.compile("\\(|\\)|\\/\\d{13}");
             Matcher m = p.matcher(suffix);
             if (!m.find()) {
                 return requestLastModified;


### PR DESCRIPTION
- when timestamp matching image suffixes, also check for a preceding forward slash to help prevent false matches.

The problem reported in #907 is related to all container components (accordion, tabs, carousel) where paths for items that are added via the dialog also contain a postfixed 13 digit timestamp in their path. In the adaptive image servlet the timestamp was matched based only on a 13 digit number, which resulted in an out of bounds exception in this case when determining a substring. This pull request makes the matching a little more robust by also expecting a preceding forward slash.

#### Example, with wrongly matched timestamp emboldened:

/conf/core-components-examples/settings/wcm/templates/content-page/structure.coreimg.jpeg/structure/_jcr_content/root/responsivegrid/accordion/item__**1581514061965**/1581514094392/mountain-range.jpeg

__




<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #907` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      |
| Documentation Provided   |
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
