### PR TITLE
Use page dialog fields over path fields where relevant.

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/form/container/v1/container/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/container/v1/container/_cq_dialog/.content.xml
@@ -77,7 +77,7 @@
                             </workflowcontainer>
                             <redirect
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                 fieldDescription="Leave empty to redisplay the form after submission"
                                 fieldLabel="Thank You Page"
                                 name="./redirect"

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/_cq_dialog/.content.xml
@@ -104,7 +104,7 @@
                                             </workflowcontainer>
                                             <redirect
                                                 jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                 fieldDescription="Leave empty to redisplay the form after submission"
                                                 fieldLabel="Thank You Page"
                                                 name="./redirect"

--- a/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v1/languagenavigation/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v1/languagenavigation/_cq_design_dialog/.content.xml
@@ -38,10 +38,9 @@
                         <items jcr:primaryType="nt:unstructured">
                             <siteRoot
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                 fieldDescription="The root page of the global language structure."
                                 fieldLabel="Navigation Root"
-                                forceSelection="{Boolean}true"
                                 name="./navigationRoot"
                                 rootPath="/content"
                                 required="{Boolean}true"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v1/languagenavigation/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v1/languagenavigation/_cq_dialog/.content.xml
@@ -48,11 +48,10 @@
                                         <items jcr:primaryType="nt:unstructured">
                                             <siteRoot
                                                 jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                 fieldDescription="The root page of the global language structure."
                                                 fieldLabel="Navigation Root"
                                                 rootPath="/content"
-                                                forceSelection="{Boolean}true"
                                                 name="./navigationRoot"
                                                 value="${not empty cqDesign.navigationRoot ? cqDesign.navigationRoot : ''}"
                                                 required="{Boolean}true"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/list/v1/list/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/list/v1/list/_cq_dialog/.content.xml
@@ -80,7 +80,7 @@
                                                 <items jcr:primaryType="nt:unstructured">
                                                     <parentPage
                                                         jcr:primaryType="nt:unstructured"
-                                                        sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                        sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                         fieldDescription="Leave empty to use current page"
                                                         fieldLabel="Parent page"
                                                         name="./parentPage"
@@ -128,7 +128,7 @@
                                                                 sling:resourceType="granite/ui/components/coral/foundation/form/multifield">
                                                                 <field
                                                                     jcr:primaryType="nt:unstructured"
-                                                                    sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                                    sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                                     name="./pages"
                                                                     rootPath="/content"/>
                                                             </multi>
@@ -163,7 +163,7 @@
                                                         name="./query"/>
                                                     <queryContentPath
                                                         jcr:primaryType="nt:unstructured"
-                                                        sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                        sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                         fieldDescription="Leave empty to use current site (eg. /content/mysite)"
                                                         fieldLabel="Search in"
                                                         name="./searchIn"
@@ -192,7 +192,7 @@
                                                 <items jcr:primaryType="nt:unstructured">
                                                     <parentPage
                                                         jcr:primaryType="nt:unstructured"
-                                                        sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                        sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                         fieldDescription="Leave empty to use current page"
                                                         fieldLabel="Parent page"
                                                         name="./tagsSearchRoot"

--- a/content/src/content/jcr_root/apps/core/wcm/components/list/v2/list/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/list/v2/list/_cq_dialog/.content.xml
@@ -100,7 +100,7 @@
                                                         <items jcr:primaryType="nt:unstructured">
                                                             <parentPage
                                                                 jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                                 fieldDescription="Leave empty to use current page"
                                                                 fieldLabel="Parent Page"
                                                                 name="./parentPage"
@@ -148,7 +148,7 @@
                                                                         sling:resourceType="granite/ui/components/coral/foundation/form/multifield">
                                                                         <field
                                                                             jcr:primaryType="nt:unstructured"
-                                                                            sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                                            sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                                             name="./pages"
                                                                             rootPath="/content"/>
                                                                     </multi>
@@ -183,7 +183,7 @@
                                                                 name="./query"/>
                                                             <queryContentPath
                                                                 jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                                 fieldDescription="Leave empty to use current site (eg. /content/mysite)"
                                                                 fieldLabel="Search In"
                                                                 name="./searchIn"
@@ -212,7 +212,7 @@
                                                         <items jcr:primaryType="nt:unstructured">
                                                             <parentPage
                                                                 jcr:primaryType="nt:unstructured"
-                                                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                                 fieldDescription="Leave empty to use current page"
                                                                 fieldLabel="Parent Page"
                                                                 name="./tagsSearchRoot"

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_design_dialog/.content.xml
@@ -40,11 +40,10 @@
                         <items jcr:primaryType="nt:unstructured">
                             <navigationRoot
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                 fieldDescription="The root page from which to build the navigation. Can be a blueprint master, language master or regular page."
                                 fieldLabel="Navigation Root"
                                 rootPath="/content"
-                                forceSelection="{Boolean}true"
                                 name="./navigationRoot"
                                 required="{Boolean}true"/>
                             <structureStart

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
@@ -50,11 +50,10 @@
                                         <items jcr:primaryType="nt:unstructured">
                                             <navigationRoot
                                                 jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                 fieldDescription="The root page from which to build the navigation. Can be a blueprint master, language master or regular page."
                                                 fieldLabel="Navigation Root"
                                                 rootPath="/content"
-                                                forceSelection="{Boolean}true"
                                                 name="./navigationRoot"
                                                 value="${not empty cqDesign.navigationRoot ? cqDesign.navigationRoot : ''}"
                                                 required="{Boolean}true"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/_cq_design_dialog/.content.xml
@@ -38,11 +38,10 @@
                         <items jcr:primaryType="nt:unstructured">
                             <searchRoot
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                 fieldDescription="The root page from which to search in. Can be a blueprint master, language master or regular page."
                                 fieldLabel="Search Root"
                                 rootPath="/content"
-                                forceSelection="{Boolean}true"
                                 name="./searchRoot"
                                 required="{Boolean}true"/>
                             <resultsSize

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/_cq_dialog/.content.xml
@@ -48,11 +48,10 @@
                                         <items jcr:primaryType="nt:unstructured">
                                             <searchRoot
                                                 jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                 fieldDescription="The root page from which to search in. Can be a blueprint master, language master or regular page."
                                                 fieldLabel="Search Root"
                                                 rootPath="/content"
-                                                forceSelection="{Boolean}true"
                                                 name="./searchRoot"
                                                 value="${not empty cqDesign.searchRoot ? cqDesign.searchRoot : ''}"
                                                 required="{Boolean}true"/>


### PR DESCRIPTION
See #904

- replaces usages of path field with page field where picking a page is the intended use case.
- covers usages in form container, list, navigation, search and language navigation.
- removes properties not relevant to the page field.