### PR TITLE
[Download] title is taken from properties title when asset title is e…

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImpl.java
@@ -198,10 +198,7 @@ public class DownloadImpl implements Download {
                     url = getDownloadUrl(downloadResource);
 
                     if (titleFromAsset) {
-                        String assetTitle = downloadAsset.getMetadataValue(DamConstants.DC_TITLE);
-                        if (StringUtils.isNotBlank(assetTitle)) {
-                            title = assetTitle;
-                        }
+                        title = downloadAsset.getMetadataValue(DamConstants.DC_TITLE);
                     }
                     if (descriptionFromAsset) {
                         String assetDescription = downloadAsset.getMetadataValue(DamConstants.DC_DESCRIPTION);


### PR DESCRIPTION
…mpty

remove check for empty asset title so title in download component is empty in case the asset title is not set.

fixes #919 