### PR TITLE
[Image][Accessibility] Empty alt attribute for non-decorative images

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/image.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/image.html
@@ -24,7 +24,7 @@
        data-title="${image.title || image.alt}" data-asset="${image.fileReference}">
         <noscript data-sly-unwrap="${!image.json}" data-cmp-image="${image.json}">
             <img src="${image.src}"
-                 alt="${image.alt || true}"
+                 alt="${image.alt}"
                  title="${image.displayPopupTitle && image.title}"/>
         </noscript>
     </a>

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_dialog/.content.xml
@@ -97,6 +97,7 @@
                                                 granite:class="cmp-image__editor-alt">
                                                 <items jcr:primaryType="nt:unstructured">
                                                     <alt
+                                                        granite:class="cmp-image__editor-alt-text"
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                         fieldDescription="Textual alternative of the meaning or function of the image, for visually impaired readers."

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/editor/js/image.js
@@ -87,6 +87,12 @@
             }
             toggleAlternativeFieldsAndLink(isDecorative);
         }
+
+        $(window).adaptTo("foundation-registry").register("foundation.validation.selector", {
+            submittable: ".cmp-image__editor-alt-text",
+            candidate: ".cmp-image__editor-alt-text:not(:hidden)",
+            exclusion: ".cmp-image__editor-alt-text *"
+        });
     });
 
     $(window).on("focus", function() {

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/image.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/image.html
@@ -34,7 +34,7 @@
             <sly data-sly-test.usemap="${'{0}{1}' @ format=['#', resource.path]}"></sly>
             <img src="${image.src}" class="cmp-image__image" itemprop="contentUrl" data-cmp-hook-image="image"
                  data-sly-attribute.usemap="${image.areas ? usemap : ''}"
-                 alt="${image.alt || true}" title="${image.displayPopupTitle && image.title}"/>
+                 alt="${image.alt}" title="${image.displayPopupTitle && image.title}"/>
             <map data-sly-test="${image.areas}"
                  data-sly-list.area="${image.areas}"
                  name="${resource.path}"


### PR DESCRIPTION
- remove empty alt attribute in markup
- force validation of alt field in dialog as long the image is not decorative

fixes #922