### PR TITLE
Decreasing commons-codec version to support AEM 6.3

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -682,7 +682,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.14</version>
+                <version>1.10</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
The core component core bundle is currently not started on AEM 6.3/6.4 and 6.5 because of the commons-codec dependency to 1.14 which can't be satisfied.