### PR TITLE
Feature/experience fragment v2

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImpl.java
@@ -1,0 +1,221 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v2;
+
+import com.adobe.cq.export.json.ComponentExporter;
+import com.adobe.cq.export.json.ContainerExporter;
+import com.adobe.cq.export.json.ExporterConstants;
+import com.adobe.cq.wcm.core.components.models.ExperienceFragment;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.TemplatedResource;
+import com.day.cq.wcm.api.designer.ComponentStyle;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Exporter;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import org.apache.sling.models.factory.ModelFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.adobe.cq.wcm.core.components.internal.models.v2.ExperienceFragmentImpl.RESOURCE_TYPE_V2;
+import static com.adobe.cq.xf.ExperienceFragmentsConstants.PN_FRAGMENT_PATH;
+
+@Model(adaptables = SlingHttpServletRequest.class,
+        defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL,
+        adapters = {ExperienceFragment.class, ContainerExporter.class},
+        resourceType = {RESOURCE_TYPE_V2})
+@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME,
+        extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+public class ExperienceFragmentImpl extends com.adobe.cq.wcm.core.components.internal.models.v1.ExperienceFragmentImpl implements ContainerExporter {
+    
+    public static final String RESOURCE_TYPE_V2 = "core/wcm/components/experiencefragment/v2/experiencefragment";
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExperienceFragmentImpl.class);
+    
+    @Self
+    private SlingHttpServletRequest slingRequest;
+    
+    @SlingObject
+    private volatile Resource resource;
+    
+    private ValueMap properties;
+    
+    @Inject
+    private ModelFactory modelFactory;
+    
+    /**
+     * Class names of the responsive grid
+     */
+    private String classNames;
+    
+    /**
+     * Child columns of the responsive grid
+     */
+    private Map<String, ComponentExporter> children = new LinkedHashMap<>();
+    
+    /**
+     * Effective resource
+     */
+    private @Nullable
+    Resource efvResource;
+    
+    /**
+     * Number of columns set on the design or the default number of columns
+     */
+    
+    
+    @PostConstruct
+    protected void initModel() {
+        
+        super.initModel();
+        
+        properties = resource.getValueMap();
+        
+        // grid columns css
+        classNames = "aem-xf";
+        
+        retrieveExperienceFragmentContentResource();
+        
+        if (efvResource != null) {
+            // Columns provided by the design
+            
+            efvResource.getChildren().forEach((childResource) -> {
+                children.put(childResource.getName(), modelFactory.getModelFromWrappedRequest(slingRequest, childResource, ComponentExporter.class));
+            });
+            
+        } else {
+            classNames += " empty";
+        }
+        
+        
+        // add custom styles of the resource
+        classNames += " " + resource.getValueMap().get(ComponentStyle.PN_CSS_CLASS, "");
+        
+        classNames = classNames.trim();
+    }
+    
+    
+    /**
+     * @return The CSS class names to be applied to the current grid.
+     * @deprecated Use {@link #getCssClassNames()}
+     */
+    @Override
+    @JsonProperty("classNames")
+    public String getCssClassNames() {
+        return classNames;
+    }
+    
+    @Override
+    @JsonInclude
+    public boolean isPathConfigured() {
+        return StringUtils.isNotBlank(properties.get(PN_FRAGMENT_PATH, StringUtils.EMPTY));
+    }
+    
+    /**
+     * @param <T> The type of the resource
+     * @return Returns the resource optionally wrapped into a {@link TemplatedResource}
+     * <p>
+     * AdobePatentID="P6273-US"
+     */
+    @Nonnull
+    public <T extends Resource> T getEffectiveResource() {
+        if (resource instanceof TemplatedResource) {
+            return (T) resource;
+        }
+        
+        Resource templatedResource = slingRequest.adaptTo(TemplatedResource.class);
+        
+        if (templatedResource == null) {
+            return (T) resource;
+        } else {
+            return (T) templatedResource;
+        }
+    }
+    
+    /**
+     * @deprecated
+     */
+    public String getResourceSuperType() {
+        return resource.getResourceSuperType();
+    }
+    
+    
+    @Nonnull
+    @Override
+    public Map<String, ? extends ComponentExporter> getExportedItems() {
+        return children;
+    }
+    
+    @Nonnull
+    @Override
+    public String[] getExportedItemsOrder() {
+        return children.isEmpty() ?
+                new String[0] : children.keySet().toArray(new String[children.size()]);
+    }
+    
+    @Nonnull
+    @Override
+    public String getExportedType() {
+        return resource.getResourceType();
+    }
+    
+    
+    private void retrieveExperienceFragmentContentResource() {
+        Resource effectiveResource = getEffectiveResource();
+        
+        
+        String pathToExperienceFragmentVariation = effectiveResource.getValueMap().get(PN_FRAGMENT_PATH, String.class);
+        
+        if (StringUtils.isNotBlank(pathToExperienceFragmentVariation)) {
+            final ResourceResolver resourceResolver = effectiveResource.getResourceResolver();
+            
+            
+            PageManager pageManager = resourceResolver.adaptTo(PageManager.class);
+            
+            if (pageManager != null) {
+                Page page = pageManager.getPage(pathToExperienceFragmentVariation);
+                
+                efvResource = page.getContentResource();
+            } else {
+                LOGGER.error("PageManager  is null! This should never happen");
+            }
+            
+            
+        } else {
+            LOGGER.debug("Fragment path is null");
+        }
+        
+        
+    }
+    
+    
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImpl.java
@@ -104,14 +104,22 @@ public class ExperienceFragmentImpl extends com.adobe.cq.wcm.core.components.int
         
         retrieveExperienceFragmentContentResource();
         
+        boolean isEmpty = true;
+        
         if (efvResource != null) {
             // Columns provided by the design
-            
-            efvResource.getChildren().forEach((childResource) -> {
-                children.put(childResource.getName(), modelFactory.getModelFromWrappedRequest(slingRequest, childResource, ComponentExporter.class));
-            });
-            
-        } else {
+    
+            for(Resource childResource : efvResource.getChildren()){
+                final ComponentExporter modelFromWrappedRequest = modelFactory.getModelFromWrappedRequest(slingRequest, childResource, ComponentExporter.class);
+                if(modelFromWrappedRequest != null){
+                    children.put(childResource.getName(), modelFromWrappedRequest);
+                    isEmpty = false;
+                }
+            }
+    
+        }
+        
+        if(isEmpty){
             classNames += " empty";
         }
         

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImpl.java
@@ -162,14 +162,6 @@ public class ExperienceFragmentImpl extends com.adobe.cq.wcm.core.components.int
         }
     }
     
-    /**
-     * @deprecated
-     */
-    public String getResourceSuperType() {
-        return resource.getResourceSuperType();
-    }
-    
-    
     @Nonnull
     @Override
     public Map<String, ? extends ComponentExporter> getExportedItems() {
@@ -182,13 +174,6 @@ public class ExperienceFragmentImpl extends com.adobe.cq.wcm.core.components.int
         return children.isEmpty() ?
                 new String[0] : children.keySet().toArray(new String[children.size()]);
     }
-    
-    @Nonnull
-    @Override
-    public String getExportedType() {
-        return resource.getResourceType();
-    }
-    
     
     private void retrieveExperienceFragmentContentResource() {
         Resource effectiveResource = getEffectiveResource();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImpl.java
@@ -48,7 +48,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static com.adobe.cq.wcm.core.components.internal.models.v2.ExperienceFragmentImpl.RESOURCE_TYPE_V2;
-import static com.adobe.cq.xf.ExperienceFragmentsConstants.PN_FRAGMENT_PATH;
 
 @Model(adaptables = SlingHttpServletRequest.class,
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL,

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImpl.java
@@ -23,6 +23,7 @@ import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.TemplatedResource;
 import com.day.cq.wcm.api.designer.ComponentStyle;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.StringUtils;
@@ -85,8 +86,7 @@ public class ExperienceFragmentImpl extends com.adobe.cq.wcm.core.components.int
     /**
      * Effective resource
      */
-    private @Nullable
-    Resource efvResource;
+    private @Nullable Resource efvResource;
     
     /**
      * Number of columns set on the design or the default number of columns
@@ -137,7 +137,7 @@ public class ExperienceFragmentImpl extends com.adobe.cq.wcm.core.components.int
     @Override
     @JsonInclude
     public boolean isPathConfigured() {
-        return StringUtils.isNotBlank(properties.get(PN_FRAGMENT_PATH, StringUtils.EMPTY));
+        return StringUtils.isNotBlank(properties.get(PN_FRAGMENT_VARIATION_PATH, StringUtils.EMPTY));
     }
     
     /**
@@ -147,6 +147,7 @@ public class ExperienceFragmentImpl extends com.adobe.cq.wcm.core.components.int
      * AdobePatentID="P6273-US"
      */
     @Nonnull
+    @JsonIgnore
     public <T extends Resource> T getEffectiveResource() {
         if (resource instanceof TemplatedResource) {
             return (T) resource;
@@ -193,7 +194,7 @@ public class ExperienceFragmentImpl extends com.adobe.cq.wcm.core.components.int
         Resource effectiveResource = getEffectiveResource();
         
         
-        String pathToExperienceFragmentVariation = effectiveResource.getValueMap().get(PN_FRAGMENT_PATH, String.class);
+        String pathToExperienceFragmentVariation = effectiveResource.getValueMap().get(PN_FRAGMENT_VARIATION_PATH, String.class);
         
         if (StringUtils.isNotBlank(pathToExperienceFragmentVariation)) {
             final ResourceResolver resourceResolver = effectiveResource.getResourceResolver();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ExperienceFragment.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ExperienceFragment.java
@@ -15,10 +15,13 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.models;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.annotation.versioning.ConsumerType;
 
 import com.adobe.cq.export.json.ComponentExporter;
+
+import javax.annotation.Nullable;
 
 /**
  * Defines the {@code ExperienceFragment} Sling Model used for the
@@ -72,5 +75,22 @@ public interface ExperienceFragment extends ComponentExporter {
     default String getExportedType() {
         throw new UnsupportedOperationException();
     }
+    
+    /**
+     * Generates some container class names (needed for SPA framework)
+     * @return Css Class names
+     * @since com.adobe.cq.wcm.core.components.models 12.13.0
+     */
+    @Nullable
+    default String getCssClassNames()  {
+        throw new UnsupportedOperationException();
+    }
+    
+    /**
+     * Simple boolean flag to check if the path is configured
+     * @return
+     * @since com.adobe.cq.wcm.core.components.models 12.13.0
+     */
+    default boolean isPathConfigured()  {throw new UnsupportedOperationException(); }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.12.0")
+@Version("12.13.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.13.0")
+@Version("12.12.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/dummy/DummyTestImageModel.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/dummy/DummyTestImageModel.java
@@ -1,3 +1,18 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2017 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.dummy;
 
 import com.adobe.cq.export.json.ComponentExporter;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/dummy/DummyTestImageModel.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/dummy/DummyTestImageModel.java
@@ -1,0 +1,37 @@
+package com.adobe.cq.wcm.core.components.internal.models.dummy;
+
+import com.adobe.cq.export.json.ComponentExporter;
+import com.adobe.cq.export.json.ExporterConstants;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Exporter;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+
+import javax.annotation.Nonnull;
+
+@Model(
+        adaptables = SlingHttpServletRequest.class,
+        adapters = {DummyTestImageModel.class, ComponentExporter.class},
+        defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL,
+        resourceType = DummyTestImageModel.RESOURCE_TYPE)
+@Exporter(
+        name = ExporterConstants.SLING_MODEL_EXPORTER_NAME,
+        extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+public class DummyTestImageModel implements ComponentExporter {
+    
+    static final String RESOURCE_TYPE = "my/test/image";
+    
+    @ValueMapValue
+    private String url;
+    
+    public String getUrl() {
+        return url;
+    }
+    
+    @Nonnull
+    @Override
+    public String getExportedType() {
+        return RESOURCE_TYPE;
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/dummy/DummyTestTextModel.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/dummy/DummyTestTextModel.java
@@ -1,3 +1,18 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2017 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.dummy;
 
 import com.adobe.cq.export.json.ComponentExporter;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/dummy/DummyTestTextModel.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/dummy/DummyTestTextModel.java
@@ -1,0 +1,37 @@
+package com.adobe.cq.wcm.core.components.internal.models.dummy;
+
+import com.adobe.cq.export.json.ComponentExporter;
+import com.adobe.cq.export.json.ExporterConstants;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Exporter;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+
+import javax.annotation.Nonnull;
+
+@Model(
+        adaptables = SlingHttpServletRequest.class,
+        adapters = {DummyTestTextModel.class, ComponentExporter.class},
+        defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL,
+        resourceType = DummyTestTextModel.RESOURCE_TYPE)
+@Exporter(
+        name = ExporterConstants.SLING_MODEL_EXPORTER_NAME,
+        extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+public class DummyTestTextModel implements ComponentExporter {
+    
+    static final String RESOURCE_TYPE = "my/test/text";
+    
+    @ValueMapValue
+    private String text;
+    
+    public String getText() {
+        return text;
+    }
+    
+    @Nonnull
+    @Override
+    public String getExportedType() {
+        return RESOURCE_TYPE;
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImplTest.java
@@ -40,25 +40,51 @@ public class ExperienceFragmentImplTest {
     private static final String TEST_BASE = "/experiencefragment/v2";
     private static final String PAGE_PATH = "/content/experience-fragment-page";
     private static final String FRAGMENT_PAGE_LOCATION = "/content/experience-fragments/fragment";
+    private static final String EMPTY_FRAGMENT_PAGE_LOCATION = "/content/experience-fragments/empty-fragment";
     
-    private static final AemContext CONTEXT = CoreComponentTestContext.newAemContext();
+    private final AemContext context = CoreComponentTestContext.newAemContext();
     
     @BeforeEach
     void setUp(){
-        CONTEXT.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, PAGE_PATH);
-        CONTEXT.load().json(TEST_BASE + "/experiencefragment-test-fragment.json", FRAGMENT_PAGE_LOCATION);
-        CONTEXT.addModelsForPackage("com.adobe.cq.wcm.core.components.internal.models.dummy");
-        CONTEXT.addModelsForClasses("com.adobe.cq.wcm.core.components.internal.models.v2");
-        CONTEXT.currentPage(PAGE_PATH);
-        CONTEXT.currentResource( PAGE_PATH + "/" + JcrConstants.JCR_CONTENT + "/root/responsivegrid/experiencefragment");
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, PAGE_PATH);
+        context.load().json(TEST_BASE + "/experiencefragment-test-fragment.json", FRAGMENT_PAGE_LOCATION);
+        context.addModelsForPackage("com.adobe.cq.wcm.core.components.internal.models.dummy");
+        context.addModelsForClasses("com.adobe.cq.wcm.core.components.internal.models.v2");
     }
     
+    @Test
+    public void test_no_path(){
+    
+        context.currentResource( PAGE_PATH + "/" + JcrConstants.JCR_CONTENT + "/root/responsivegrid/experiencefragment-no-path");
+        ExperienceFragment exporter = context.request().adaptTo(ExperienceFragment.class);
+    
+        assertNotNull(exporter);
+    
+        assertTrue("Should contain empty class", exporter.getCssClassNames().contains("empty"));
+    
+    }
+    
+    @Test
+    public void test_empty(){
+        
+        context.load().json(TEST_BASE + "/experiencefragment-test-empty-fragment.json", EMPTY_FRAGMENT_PAGE_LOCATION);
+        context.currentResource( PAGE_PATH + "/" + JcrConstants.JCR_CONTENT + "/root/responsivegrid/experiencefragment-empty");
+        ExperienceFragment exporter = context.request().adaptTo(ExperienceFragment.class);
+        
+        assertNotNull(exporter);
+        
+        assertTrue("Should contain empty class", exporter.getCssClassNames().contains("empty"));
+        
+    }
     
     @Test
     public void test_export(){
     
+        context.currentPage(PAGE_PATH);
+        context.currentResource( PAGE_PATH + "/" + JcrConstants.JCR_CONTENT + "/root/responsivegrid/experiencefragment");
         
-        ContainerExporter exporter = CONTEXT.request().adaptTo(ContainerExporter.class);
+        
+        ContainerExporter exporter = context.request().adaptTo(ContainerExporter.class);
         
         assertNotNull(exporter);
         
@@ -78,7 +104,7 @@ public class ExperienceFragmentImplTest {
         assertEquals("Hi there", textExporter.getText());
         assertEquals("/content/dam/we-retail-journal/hq/thunder.png", imageExporter.getUrl());
         
-        ExperienceFragment experienceFragment = CONTEXT.request().adaptTo(ExperienceFragment.class);
+        ExperienceFragment experienceFragment = context.request().adaptTo(ExperienceFragment.class);
 
         String exportedCssClass =  experienceFragment.getCssClassNames();
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImplTest.java
@@ -1,3 +1,18 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2017 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v2;
 
 
@@ -5,6 +20,7 @@ import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.internal.models.dummy.DummyTestImageModel;
 import com.adobe.cq.wcm.core.components.internal.models.dummy.DummyTestTextModel;
+import com.adobe.cq.wcm.core.components.models.ExperienceFragment;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 import org.apache.jackrabbit.JcrConstants;
@@ -12,8 +28,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 
 @ExtendWith(AemContextExtension.class)
@@ -23,22 +41,23 @@ public class ExperienceFragmentImplTest {
     private static final String PAGE_PATH = "/content/experience-fragment-page";
     private static final String FRAGMENT_PAGE_LOCATION = "/content/experience-fragments/fragment";
     
-    public static final AemContext CONTEXT =  CoreComponentTestContext.newAemContext();
+    private static final AemContext CONTEXT = CoreComponentTestContext.newAemContext();
     
     @BeforeEach
     void setUp(){
         CONTEXT.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, PAGE_PATH);
         CONTEXT.load().json(TEST_BASE + "/experiencefragment-test-fragment.json", FRAGMENT_PAGE_LOCATION);
-        CONTEXT.currentPage(PAGE_PATH);
-        CONTEXT.currentResource( PAGE_PATH + "/" + JcrConstants.JCR_CONTENT + "/root/responsivegrid/experiencefragment");
         CONTEXT.addModelsForPackage("com.adobe.cq.wcm.core.components.internal.models.dummy");
         CONTEXT.addModelsForClasses("com.adobe.cq.wcm.core.components.internal.models.v2");
+        CONTEXT.currentPage(PAGE_PATH);
+        CONTEXT.currentResource( PAGE_PATH + "/" + JcrConstants.JCR_CONTENT + "/root/responsivegrid/experiencefragment");
     }
     
     
     @Test
     public void test_export(){
     
+        
         ContainerExporter exporter = CONTEXT.request().adaptTo(ContainerExporter.class);
         
         assertNotNull(exporter);
@@ -48,11 +67,25 @@ public class ExperienceFragmentImplTest {
         DummyTestTextModel textExporter = (DummyTestTextModel) exporter.getExportedItems().get("text");
         DummyTestImageModel imageExporter = (DummyTestImageModel) exporter.getExportedItems().get("image");
         
+        String[] order = exporter.getExportedItemsOrder();
+        
+        String[] expectedOrder = new String[]{"text","image"};
+        assertArrayEquals(expectedOrder, order);
+        
         assertNotNull(textExporter);
         assertNotNull(imageExporter);
         
         assertEquals("Hi there", textExporter.getText());
         assertEquals("/content/dam/we-retail-journal/hq/thunder.png", imageExporter.getUrl());
+        
+        ExperienceFragment experienceFragment = CONTEXT.request().adaptTo(ExperienceFragment.class);
+
+        String exportedCssClass =  experienceFragment.getCssClassNames();
+
+        assertTrue("css class should always contain 'aem-xf'", exportedCssClass.contains("aem-xf"));
+        assertTrue("should contain the css class in the properties", exportedCssClass.contains("testCssClass"));
+
+        assertTrue("path should be configured", experienceFragment.isPathConfigured());
     }
     
     

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ExperienceFragmentImplTest.java
@@ -1,0 +1,60 @@
+package com.adobe.cq.wcm.core.components.internal.models.v2;
+
+
+import com.adobe.cq.export.json.ContainerExporter;
+import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
+import com.adobe.cq.wcm.core.components.internal.models.dummy.DummyTestImageModel;
+import com.adobe.cq.wcm.core.components.internal.models.dummy.DummyTestTextModel;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.apache.jackrabbit.JcrConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+
+@ExtendWith(AemContextExtension.class)
+public class ExperienceFragmentImplTest {
+    
+    private static final String TEST_BASE = "/experiencefragment/v2";
+    private static final String PAGE_PATH = "/content/experience-fragment-page";
+    private static final String FRAGMENT_PAGE_LOCATION = "/content/experience-fragments/fragment";
+    
+    public static final AemContext CONTEXT =  CoreComponentTestContext.newAemContext();
+    
+    @BeforeEach
+    void setUp(){
+        CONTEXT.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, PAGE_PATH);
+        CONTEXT.load().json(TEST_BASE + "/experiencefragment-test-fragment.json", FRAGMENT_PAGE_LOCATION);
+        CONTEXT.currentPage(PAGE_PATH);
+        CONTEXT.currentResource( PAGE_PATH + "/" + JcrConstants.JCR_CONTENT + "/root/responsivegrid/experiencefragment");
+        CONTEXT.addModelsForPackage("com.adobe.cq.wcm.core.components.internal.models.dummy");
+        CONTEXT.addModelsForClasses("com.adobe.cq.wcm.core.components.internal.models.v2");
+    }
+    
+    
+    @Test
+    public void test_export(){
+    
+        ContainerExporter exporter = CONTEXT.request().adaptTo(ContainerExporter.class);
+        
+        assertNotNull(exporter);
+        
+        assertEquals(2, exporter.getExportedItems().size());
+        
+        DummyTestTextModel textExporter = (DummyTestTextModel) exporter.getExportedItems().get("text");
+        DummyTestImageModel imageExporter = (DummyTestImageModel) exporter.getExportedItems().get("image");
+        
+        assertNotNull(textExporter);
+        assertNotNull(imageExporter);
+        
+        assertEquals("Hi there", textExporter.getText());
+        assertEquals("/content/dam/we-retail-journal/hq/thunder.png", imageExporter.getUrl());
+    }
+    
+    
+    
+}

--- a/bundles/core/src/test/resources/experiencefragment/v2/experiencefragment-test-empty-fragment.json
+++ b/bundles/core/src/test/resources/experiencefragment/v2/experiencefragment-test-empty-fragment.json
@@ -1,0 +1,37 @@
+{
+    "jcr:primaryType": "cq:Page",
+    "jcr:createdBy": "admin",
+    "jcr:created": "Tue Oct 08 2019 21:16:23 GMT+0200",
+    "jcr:content": {
+        "jcr:primaryType": "cq:PageContent",
+        "jcr:createdBy": "admin",
+        "jcr:title": "Experience Fragment spa test",
+        "cq:template": "/libs/cq/experience-fragments/components/experiencefragment/template",
+        "jcr:created": "Tue Oct 08 2019 21:16:23 GMT+0200",
+        "cq:lastModified": "Mon Sep 30 2019 12:24:46 GMT+0200",
+        "cq:tags": [],
+        "sling:resourceType": "cq/experience-fragments/components/experiencefragment",
+        "cq:lastModifiedBy": "admin"
+    },
+    "master": {
+        "jcr:primaryType": "cq:Page",
+        "jcr:createdBy": "admin",
+        "jcr:created": "Tue Oct 08 2019 21:16:23 GMT+0200",
+        "jcr:content": {
+            "jcr:primaryType": "cq:PageContent",
+            "jcr:createdBy": "admin",
+            "jcr:title": "Experience Fragment spa test",
+            "cq:xfShowInEditor": "true",
+            "cq:template": "/conf/we-retail-journal/settings/wcm/templates/xf-page",
+            "cq:xfMasterVariation": true,
+            "cq:xfSocialActionStatus": "Not Posted",
+            "jcr:created": "Tue Oct 08 2019 21:16:23 GMT+0200",
+            "cq:lastModified": "Fri Oct 04 2019 16:15:45 GMT+0200",
+            "cq:xfVariantType": "web",
+            "cq:tags": [],
+            "sling:resourceType": "we-retail-journal/components/page/xfpage",
+            "cq:lastModifiedBy": "admin",
+            "isExperienceFragmentPage": true
+        }
+    }
+}

--- a/bundles/core/src/test/resources/experiencefragment/v2/experiencefragment-test-fragment.json
+++ b/bundles/core/src/test/resources/experiencefragment/v2/experiencefragment-test-fragment.json
@@ -1,0 +1,55 @@
+{
+    "jcr:primaryType": "cq:Page",
+    "jcr:createdBy": "admin",
+    "jcr:created": "Tue Oct 08 2019 21:16:23 GMT+0200",
+    "jcr:content": {
+        "jcr:primaryType": "cq:PageContent",
+        "jcr:createdBy": "admin",
+        "jcr:title": "Experience Fragment spa test",
+        "cq:template": "/libs/cq/experience-fragments/components/experiencefragment/template",
+        "jcr:created": "Tue Oct 08 2019 21:16:23 GMT+0200",
+        "cq:lastModified": "Mon Sep 30 2019 12:24:46 GMT+0200",
+        "cq:tags": [],
+        "sling:resourceType": "cq/experience-fragments/components/experiencefragment",
+        "cq:lastModifiedBy": "admin"
+    },
+    "master": {
+        "jcr:primaryType": "cq:Page",
+        "jcr:createdBy": "admin",
+        "jcr:created": "Tue Oct 08 2019 21:16:23 GMT+0200",
+        "jcr:content": {
+            "jcr:primaryType": "cq:PageContent",
+            "jcr:createdBy": "admin",
+            "jcr:title": "Experience Fragment spa test",
+            "cq:xfShowInEditor": "true",
+            "cq:template": "/conf/we-retail-journal/settings/wcm/templates/xf-page",
+            "cq:xfMasterVariation": true,
+            "cq:xfSocialActionStatus": "Not Posted",
+            "jcr:created": "Tue Oct 08 2019 21:16:23 GMT+0200",
+            "cq:lastModified": "Fri Oct 04 2019 16:15:45 GMT+0200",
+            "cq:xfVariantType": "web",
+            "cq:tags": [],
+            "sling:resourceType": "we-retail-journal/components/page/xfpage",
+            "cq:lastModifiedBy": "admin",
+            "isExperienceFragmentPage": true,
+            "text": {
+                "jcr:primaryType": "nt:unstructured",
+                "jcr:createdBy": "admin",
+                "text": "Hi there",
+                "jcr:lastModifiedBy": "admin",
+                "jcr:created": "Fri Oct 04 2019 16:15:35 GMT+0200",
+                "jcr:lastModified": "Fri Oct 04 2019 16:15:42 GMT+0200",
+                "sling:resourceType": "my/test/text"
+            },
+            "image": {
+                "jcr:primaryType": "nt:unstructured",
+                "jcr:createdBy": "admin",
+                "url": "/content/dam/we-retail-journal/hq/thunder.png",
+                "jcr:lastModifiedBy": "admin",
+                "jcr:created": "Fri Oct 04 2019 16:15:38 GMT+0200",
+                "jcr:lastModified": "Fri Oct 04 2019 16:15:44 GMT+0200",
+                "sling:resourceType": "my/test/image"
+            }
+        }
+    }
+}

--- a/bundles/core/src/test/resources/experiencefragment/v2/test-content.json
+++ b/bundles/core/src/test/resources/experiencefragment/v2/test-content.json
@@ -34,6 +34,27 @@
                     "textIsRich": "true",
                     "cq:cssClass": "testCssClass",
                     "fragmentVariationPath": "/content/experience-fragments/fragment/master"
+                },
+                "experiencefragment-no-path": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "jcr:createdBy": "admin",
+                    "jcr:lastModifiedBy": "admin",
+                    "jcr:created": "Mon Oct 21 2019 07:53:59 GMT+0200",
+                    "jcr:lastModified": "Mon Oct 21 2019 07:54:15 GMT+0200",
+                    "sling:resourceType": "core/wcm/components/experiencefragment/v2/experiencefragment",
+                    "textIsRich": "true",
+                    "cq:cssClass": "testCssClass"
+                },
+                "experiencefragment-empty": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "jcr:createdBy": "admin",
+                    "jcr:lastModifiedBy": "admin",
+                    "jcr:created": "Mon Oct 21 2019 07:53:59 GMT+0200",
+                    "jcr:lastModified": "Mon Oct 21 2019 07:54:15 GMT+0200",
+                    "sling:resourceType": "core/wcm/components/experiencefragment/v2/experiencefragment",
+                    "textIsRich": "true",
+                    "cq:cssClass": "testCssClass",
+                    "fragmentVariationPath": "/content/experience-fragments/empty-fragment/master"
                 }
             }
         }

--- a/bundles/core/src/test/resources/experiencefragment/v2/test-content.json
+++ b/bundles/core/src/test/resources/experiencefragment/v2/test-content.json
@@ -1,0 +1,40 @@
+{
+    "jcr:primaryType": "cq:Page",
+    "jcr:createdBy": "admin",
+    "jcr:created": "Tue Oct 08 2019 21:16:23 GMT+0200",
+    "jcr:content": {
+        "jcr:primaryType": "cq:PageContent",
+        "jcr:createdBy": "admin",
+        "jcr:title": "Homepage",
+        "cq:template": "/conf/we-retail-journal/settings/wcm/templates/content-page-template",
+        "externalNavUrl": "http://google.com",
+        "jcr:created": "Tue Oct 08 2019 21:16:23 GMT+0200",
+        "cq:lastModified": "Mon Oct 21 2019 07:54:15 GMT+0200",
+        "hideInNav": "true",
+        "sling:resourceType": "we-retail-journal/components/page",
+        "cq:lastModifiedBy": "admin",
+        "root": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "wcm/foundation/components/responsivegrid",
+            "responsivegrid": {
+                "jcr:primaryType": "nt:unstructured",
+                "jcr:createdBy": "admin",
+                "jcr:lastModifiedBy": "admin",
+                "jcr:created": "Fri Sep 27 2019 10:50:23 GMT+0200",
+                "jcr:lastModified": "Fri Sep 27 2019 11:01:08 GMT+0200",
+                "sling:resourceType": "wcm/foundation/components/responsivegrid",
+    
+                "experiencefragment": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "jcr:createdBy": "admin",
+                    "jcr:lastModifiedBy": "admin",
+                    "jcr:created": "Mon Oct 21 2019 07:53:59 GMT+0200",
+                    "jcr:lastModified": "Mon Oct 21 2019 07:54:15 GMT+0200",
+                    "sling:resourceType": "core/wcm/components/experiencefragment/v2/experiencefragment",
+                    "textIsRich": "true",
+                    "fragmentPath": "/content/experience-fragments/fragment/master"
+                }
+            }
+        }
+    }
+}

--- a/bundles/core/src/test/resources/experiencefragment/v2/test-content.json
+++ b/bundles/core/src/test/resources/experiencefragment/v2/test-content.json
@@ -32,6 +32,7 @@
                     "jcr:lastModified": "Mon Oct 21 2019 07:54:15 GMT+0200",
                     "sling:resourceType": "core/wcm/components/experiencefragment/v2/experiencefragment",
                     "textIsRich": "true",
+                    "cq:cssClass": "testCssClass",
                     "fragmentVariationPath": "/content/experience-fragments/fragment/master"
                 }
             }

--- a/bundles/core/src/test/resources/experiencefragment/v2/test-content.json
+++ b/bundles/core/src/test/resources/experiencefragment/v2/test-content.json
@@ -32,7 +32,7 @@
                     "jcr:lastModified": "Mon Oct 21 2019 07:54:15 GMT+0200",
                     "sling:resourceType": "core/wcm/components/experiencefragment/v2/experiencefragment",
                     "textIsRich": "true",
-                    "fragmentPath": "/content/experience-fragments/fragment/master"
+                    "fragmentVariationPath": "/content/experience-fragments/fragment/master"
                 }
             }
         }


### PR DESCRIPTION
Experience Fragment Variation V2: Basically the same as the original XFV.
In addition:

Exports underlying contents of the experience fragment immediately in the JSON output, using the modelfactory.

This can be used by the javascript components to render the fragment without performing an AJAX request.
A internal PR is created for the react spa editor to support the experience fragment using on this resource type.

Extensive tests added, along with basic javadoc.

No breaking changes or existing code modified.