### PR TITLE
Check for null in PanelContainerItemImpl

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
@@ -29,9 +29,6 @@ public class PanelContainerItemImpl extends ResourceListItemImpl implements List
 
     public PanelContainerItemImpl(@NotNull SlingHttpServletRequest request, @NotNull Resource resource) {
         super(request, resource);
-        ValueMap valueMap = resource.adaptTo(ValueMap.class);
-        if (valueMap != null) {
-            title = valueMap.get(PN_PANEL_TITLE, valueMap.get(JcrConstants.JCR_TITLE, ""));
-        }
+        title = resource.getValueMap().get(PN_PANEL_TITLE, resource.getValueMap().get(JcrConstants.JCR_TITLE, ""));
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
@@ -32,7 +32,11 @@ public class PanelContainerItemImpl extends ResourceListItemImpl implements List
         ValueMap valueMap = resource.adaptTo(ValueMap.class);
         if (valueMap != null) {
             String jcrTitle = valueMap.get(JcrConstants.JCR_TITLE, String.class);
-            title = valueMap.get(PN_PANEL_TITLE, jcrTitle);
+            if (jcrTitle == null) {
+                title = valueMap.get(PN_PANEL_TITLE, String.class);
+            } else {
+                title = valueMap.get(PN_PANEL_TITLE, jcrTitle);
+            }
         }
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
@@ -31,12 +31,7 @@ public class PanelContainerItemImpl extends ResourceListItemImpl implements List
         super(request, resource);
         ValueMap valueMap = resource.adaptTo(ValueMap.class);
         if (valueMap != null) {
-            String jcrTitle = valueMap.get(JcrConstants.JCR_TITLE, String.class);
-            if (jcrTitle == null) {
-                title = valueMap.get(PN_PANEL_TITLE, String.class);
-            } else {
-                title = valueMap.get(PN_PANEL_TITLE, jcrTitle);
-            }
+            title = valueMap.get(PN_PANEL_TITLE, valueMap.get(JcrConstants.JCR_TITLE, ""));
         }
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImplTest.java
@@ -95,7 +95,7 @@ class TabsImplTest {
     void testTabsEmptyTitleItem() {
         Tabs tabs = getTabsUnderTest(TABS_4);
         Object[][] expectedItems = {
-            {"item_1", null},
+            {"item_1", ""},
             {"item_2", "Tab Panel 2"},
         };
         verifyTabItems(expectedItems, tabs.getItems());

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImplTest.java
@@ -43,6 +43,7 @@ class TabsImplTest {
     private static final String TABS_1 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/tabs-1";
     private static final String TABS_2 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/tabs-2";
     private static final String TABS_3 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/tabs-3";
+    private static final String TABS_4 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/tabs-4";
     private static final String TEST_APPS_ROOT = "/apps/core/wcm/components";
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
@@ -88,6 +89,16 @@ class TabsImplTest {
         verifyTabItems(expectedItems, tabs.getItems());
         assertEquals("item_1", tabs.getActiveItem());
         Utils.testJSONExport(tabs, Utils.getTestExporterJSONPath(TEST_BASE, "tabs3"));
+    }
+
+    @Test
+    void testTabsEmptyTitleItem() {
+        Tabs tabs = getTabsUnderTest(TABS_4);
+        Object[][] expectedItems = {
+            {"item_1", null},
+            {"item_2", "Tab Panel 2"},
+        };
+        verifyTabItems(expectedItems, tabs.getItems());
     }
 
     private Tabs getTabsUnderTest(String resourcePath) {

--- a/bundles/core/src/test/resources/tabs/test-content.json
+++ b/bundles/core/src/test/resources/tabs/test-content.json
@@ -187,6 +187,21 @@
                             }
                         },
                         "item_3": {}
+                    },
+                    "tabs-4"          : {
+                        "jcr:primaryType"   : "nt:unstructured",
+                        "sling:resourceType": "core/wcm/components/tabs/v1/tabs",
+                        "item_1"          : {
+                            "jcr:primaryType"   : "nt:unstructured",
+                            "jcr:description"   : "Tab 1 description",
+                            "sling:resourceType": "core/wcm/components/responsivegrid"
+                        },
+                        "item_2"          : {
+                            "cq:panelTitle"     : "Tab Panel 2",
+                            "jcr:primaryType"   : "nt:unstructured",
+                            "jcr:description"   : "Tab 2 description",
+                            "sling:resourceType": "core/wcm/components/responsivegrid"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

<!-- Describe your changes below in as much detail as possible -->
In `PanelContainerItemImpl` the panel title ist read from the resource value map property `cq:panelTitle` with `jcr:title` as fallback, but `jcr:title` may not exist as well and newer versions of the Sling API don't allow a null value for the default value in `ValueMap.get(@NotNull String name, @NotNull T defaultValue)`, so `jcrTitle` needs to be checked for `null` and we have to fallback to `ValueMap.get(@NotNull String name, @NotNull Class<T> type)` to get the current behavior, i.e. return a `null` title.

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | No
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0
