### PR TITLE
Pass selectors to experiencefragment

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/experiencefragment.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/experiencefragment.html
@@ -17,7 +17,8 @@
      data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.template="core/wcm/components/commons/v1/templates.html"
      data-sly-test.localizedFragmentVariationPath=${fragment.localizedFragmentVariationPath}
-     data-sly-resource="${@path=localizedFragmentVariationPath, selectors='content', wcmmode='disabled'}"
+     data-sly-set.selector="content.${request.requestPathInfo.selectorString}"
+     data-sly-resource="${@path=localizedFragmentVariationPath, selectors=selector, wcmmode='disabled'}"
      id="${component.id}"
      class="cmp-experiencefragment cmp-experiencefragment--${fragment.name}">
 </div>


### PR DESCRIPTION
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | No
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Add the moment the experience fragment is only included with the `content` selector`.

**Expected behaviour**
All selectors should be added to the existing `content` selector before including the experience fragment.
