### PR TITLE
Feature/skip to main content accessibility link

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
@@ -21,8 +21,6 @@ import org.jetbrains.annotations.NotNull;
 
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
-import com.day.cq.wcm.api.policies.ContentPolicy;
-import com.day.cq.wcm.api.policies.ContentPolicyManager;
 
 public class Utils {
 
@@ -91,26 +89,4 @@ public class Utils {
             return element;
         }
     }
-
-    /**
-     * Given a {@link Page}, this method returns the correct URL, taking into account that the provided {@code page} might provide a
-     * vanity URL.
-     *
-     * @param request the current request, used to determine the server's context path
-     * @param page    the page
-     * @return the URL of the page identified by the provided {@code path}, or the original {@code path} if this doesn't identify a
-     * {@link Page}
-     */
-    public static <T> T getPolicyProperty(String property, T defaultValue, @NotNull SlingHttpServletRequest slingRequest) {
-        ContentPolicyManager policyManager = slingRequest.getResourceResolver().adaptTo(ContentPolicyManager.class);
-        if (policyManager == null) {
-            return defaultValue;
-        }
-        ContentPolicy contentPolicy = policyManager.getPolicy(slingRequest.getResource());
-        if (contentPolicy == null) {
-            return defaultValue;
-        }
-        return contentPolicy.getProperties().get(property, defaultValue);
-    }
-
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
@@ -21,6 +21,8 @@ import org.jetbrains.annotations.NotNull;
 
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.policies.ContentPolicy;
+import com.day.cq.wcm.api.policies.ContentPolicyManager;
 
 public class Utils {
 
@@ -90,5 +92,25 @@ public class Utils {
         }
     }
 
+    /**
+     * Given a {@link Page}, this method returns the correct URL, taking into account that the provided {@code page} might provide a
+     * vanity URL.
+     *
+     * @param request the current request, used to determine the server's context path
+     * @param page    the page
+     * @return the URL of the page identified by the provided {@code path}, or the original {@code path} if this doesn't identify a
+     * {@link Page}
+     */
+    public static <T> T getPolicyProperty(String property, T defaultValue, @NotNull SlingHttpServletRequest slingRequest) {
+        ContentPolicyManager policyManager = slingRequest.getResourceResolver().adaptTo(ContentPolicyManager.class);
+        if (policyManager == null) {
+            return defaultValue;
+        }
+        ContentPolicy contentPolicy = policyManager.getPolicy(slingRequest.getResource());
+        if (contentPolicy == null) {
+            return defaultValue;
+        }
+        return contentPolicy.getProperties().get(property, defaultValue);
+    }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
@@ -201,6 +201,9 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
 
     @Override
     public String getMainContentSelector() {
-        return currentStyle.get(PN_MAIN_CONTENT_SELECTOR_PROP, String.class);
+        if (currentStyle != null) {
+            return currentStyle.get(PN_MAIN_CONTENT_SELECTOR_PROP, String.class);
+        }
+        return null;
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
@@ -48,6 +48,9 @@ import com.adobe.granite.ui.clientlibs.ClientLibrary;
 import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
 import com.adobe.granite.ui.clientlibs.LibraryType;
 import com.day.cq.wcm.api.components.ComponentContext;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.policies.ContentPolicy;
+import com.day.cq.wcm.api.policies.ContentPolicyManager;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.Lists;
 
@@ -58,6 +61,7 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     protected static final String RESOURCE_TYPE = "core/wcm/components/page/v2/page";
     protected static final String PN_CLIENTLIBS_JS_HEAD = "clientlibsJsHead";
     public static final String PN_REDIRECT_TARGET = "cq:redirectTarget";
+    public static final String MAIN_CONTENT_SELECTOR_PROP = "mainContentSelector";
 
     private Boolean hasCloudconfigSupport;
 
@@ -196,5 +200,33 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
             }
         }
         return hasCloudconfigSupport;
+    }
+
+    @Override
+    public String getMainContentSelector() {
+        PageManager pageManager = request.getResourceResolver().adaptTo(PageManager.class);
+        if (pageManager == null) {
+            return getPolicyProperty(MAIN_CONTENT_SELECTOR_PROP, "", request);
+        }
+        com.day.cq.wcm.api.Page page = pageManager.getContainingPage(request.getResource());
+        if (page != null) {
+            String mainContentSelector = page.getProperties().get(MAIN_CONTENT_SELECTOR_PROP, "");
+            if (!mainContentSelector.isEmpty()) {
+                return mainContentSelector;
+            }
+        }
+        return getPolicyProperty(MAIN_CONTENT_SELECTOR_PROP, "", request);
+    }
+
+    private <T> T getPolicyProperty(String property, T defaultValue, @NotNull SlingHttpServletRequest slingRequest) {
+        ContentPolicyManager policyManager = slingRequest.getResourceResolver().adaptTo(ContentPolicyManager.class);
+        if (policyManager == null) {
+            return defaultValue;
+        }
+        ContentPolicy contentPolicy = policyManager.getPolicy(slingRequest.getResource());
+        if (contentPolicy == null) {
+            return defaultValue;
+        }
+        return contentPolicy.getProperties().get(property, defaultValue);
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
@@ -41,6 +41,7 @@ import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.internal.models.v1.RedirectItemImpl;
+import com.adobe.cq.wcm.core.components.internal.Utils;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.adobe.cq.wcm.core.components.models.Page;
 import com.adobe.granite.license.ProductInfoProvider;
@@ -49,8 +50,6 @@ import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
 import com.adobe.granite.ui.clientlibs.LibraryType;
 import com.day.cq.wcm.api.components.ComponentContext;
 import com.day.cq.wcm.api.PageManager;
-import com.day.cq.wcm.api.policies.ContentPolicy;
-import com.day.cq.wcm.api.policies.ContentPolicyManager;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.Lists;
 
@@ -206,7 +205,7 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     public String getMainContentSelector() {
         PageManager pageManager = request.getResourceResolver().adaptTo(PageManager.class);
         if (pageManager == null) {
-            return getPolicyProperty(MAIN_CONTENT_SELECTOR_PROP, "", request);
+            return Utils.getPolicyProperty(MAIN_CONTENT_SELECTOR_PROP, "", request);
         }
         com.day.cq.wcm.api.Page page = pageManager.getContainingPage(request.getResource());
         if (page != null) {
@@ -215,18 +214,6 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
                 return mainContentSelector;
             }
         }
-        return getPolicyProperty(MAIN_CONTENT_SELECTOR_PROP, "", request);
-    }
-
-    private <T> T getPolicyProperty(String property, T defaultValue, @NotNull SlingHttpServletRequest slingRequest) {
-        ContentPolicyManager policyManager = slingRequest.getResourceResolver().adaptTo(ContentPolicyManager.class);
-        if (policyManager == null) {
-            return defaultValue;
-        }
-        ContentPolicy contentPolicy = policyManager.getPolicy(slingRequest.getResource());
-        if (contentPolicy == null) {
-            return defaultValue;
-        }
-        return contentPolicy.getProperties().get(property, defaultValue);
+        return Utils.getPolicyProperty(MAIN_CONTENT_SELECTOR_PROP, "", request);
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
@@ -41,7 +41,6 @@ import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.internal.models.v1.RedirectItemImpl;
-import com.adobe.cq.wcm.core.components.internal.Utils;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.adobe.cq.wcm.core.components.models.Page;
 import com.adobe.granite.license.ProductInfoProvider;
@@ -49,7 +48,6 @@ import com.adobe.granite.ui.clientlibs.ClientLibrary;
 import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
 import com.adobe.granite.ui.clientlibs.LibraryType;
 import com.day.cq.wcm.api.components.ComponentContext;
-import com.day.cq.wcm.api.PageManager;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.Lists;
 
@@ -60,7 +58,7 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     protected static final String RESOURCE_TYPE = "core/wcm/components/page/v2/page";
     protected static final String PN_CLIENTLIBS_JS_HEAD = "clientlibsJsHead";
     public static final String PN_REDIRECT_TARGET = "cq:redirectTarget";
-    public static final String MAIN_CONTENT_SELECTOR_PROP = "mainContentSelector";
+    public static final String PN_MAIN_CONTENT_SELECTOR_PROP = "mainContentSelector";
 
     private Boolean hasCloudconfigSupport;
 
@@ -203,17 +201,6 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
 
     @Override
     public String getMainContentSelector() {
-        PageManager pageManager = request.getResourceResolver().adaptTo(PageManager.class);
-        if (pageManager == null) {
-            return Utils.getPolicyProperty(MAIN_CONTENT_SELECTOR_PROP, "", request);
-        }
-        com.day.cq.wcm.api.Page page = pageManager.getContainingPage(request.getResource());
-        if (page != null) {
-            String mainContentSelector = page.getProperties().get(MAIN_CONTENT_SELECTOR_PROP, "");
-            if (!mainContentSelector.isEmpty()) {
-                return mainContentSelector;
-            }
-        }
-        return Utils.getPolicyProperty(MAIN_CONTENT_SELECTOR_PROP, "", request);
+        return currentStyle.get(PN_MAIN_CONTENT_SELECTOR_PROP, String.class);
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
@@ -348,8 +348,7 @@ public interface Page extends ContainerExporter {
     }
 
     /**
-     * @see ContainerExporter#getMainContentSelector()
-     * @since com.adobe.cq.wcm.core.components.models 12.2.0
+     * @since com.adobe.cq.wcm.core.components.models 12.4.0
      */
     @NotNull
     default String getMainContentSelector() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
@@ -348,7 +348,7 @@ public interface Page extends ContainerExporter {
     }
 
     /**
-     * @see ContainerExporter#getExportedType()
+     * @see ContainerExporter#getMainContentSelector()
      * @since com.adobe.cq.wcm.core.components.models 12.2.0
      */
     @NotNull

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
@@ -348,6 +348,9 @@ public interface Page extends ContainerExporter {
     }
 
     /**
+     * Returns the selector for the main content element of the page (used by the "skip to main content" accessibility feature)
+     *
+     * @return selector for the main content element
      * @since com.adobe.cq.wcm.core.components.models 12.4.0
      */
     @NotNull

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
@@ -347,4 +347,12 @@ public interface Page extends ContainerExporter {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * @see ContainerExporter#getExportedType()
+     * @since com.adobe.cq.wcm.core.components.models 12.2.0
+     */
+    @NotNull
+    default String getMainContentSelector() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
@@ -1,13 +1,13 @@
 {
-    "designPath"      : "/etc/designs/mysite",
-    "title"           : "Templated Page",
-    "lastModifiedDate": 1453282416000,
-    "templateName"    : "product-page",
-    "appResourcesPath": "/core/etc.clientlibs/wcm/core/page/clientlibs/favicon/resources",
-    "cssClassNames"   : "class1 class2",
-    "language"        : "en-GB",
+    "designPath"         : "/etc/designs/mysite",
+    "title"              : "Templated Page",
+    "lastModifiedDate"   : 1453282416000,
+    "templateName"       : "product-page",
+    "appResourcesPath"   : "/core/etc.clientlibs/wcm/core/page/clientlibs/favicon/resources",
+    "cssClassNames"      : "class1 class2",
+    "language"           : "en-GB",
     "mainContentSelector":"",
-    ":itemsOrder"     : [
+    ":itemsOrder"        : [
         "root"
     ],
     ":items"          : {

--- a/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
@@ -6,6 +6,7 @@
     "appResourcesPath": "/core/etc.clientlibs/wcm/core/page/clientlibs/favicon/resources",
     "cssClassNames"   : "class1 class2",
     "language"        : "en-GB",
+    "mainContentSelector":"",
     ":itemsOrder"     : [
         "root"
     ],

--- a/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
@@ -1,13 +1,12 @@
 {
-    "designPath"         : "/etc/designs/mysite",
-    "title"              : "Templated Page",
-    "lastModifiedDate"   : 1453282416000,
-    "templateName"       : "product-page",
-    "appResourcesPath"   : "/core/etc.clientlibs/wcm/core/page/clientlibs/favicon/resources",
-    "cssClassNames"      : "class1 class2",
-    "language"           : "en-GB",
-    "mainContentSelector":"",
-    ":itemsOrder"        : [
+    "designPath"       : "/etc/designs/mysite",
+    "title"            : "Templated Page",
+    "lastModifiedDate" : 1453282416000,
+    "templateName"     : "product-page",
+    "appResourcesPath" : "/core/etc.clientlibs/wcm/core/page/clientlibs/favicon/resources",
+    "cssClassNames"    : "class1 class2",
+    "language"         : "en-GB",
+    ":itemsOrder"      : [
         "root"
     ],
     ":items"          : {

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/README.md
@@ -79,7 +79,7 @@ The following properties are written to JCR for this Page component and are expe
 media
 20. `./cq:contextHubPath` - defines the Context Path configuration used by this page.
 21. `./cq:contextHubSegmentsPath` - defines the Context Path Segments Path.
-22. `./mainContentSelector` - defines selector for main content element of the page to be used by accessibility feature "skip to main content".
+22. `./mainContentSelector` - defines the selector for the main content element of the page (used by the "skip to main content" accessibility feature).
 
 ## Web Resources Client Library
 A web resources client library can be defined at the template level (see `./appResourcesClientlib` component policy configuration).

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/README.md
@@ -79,6 +79,7 @@ The following properties are written to JCR for this Page component and are expe
 media
 20. `./cq:contextHubPath` - defines the Context Path configuration used by this page.
 21. `./cq:contextHubSegmentsPath` - defines the Context Path Segments Path.
+22. `./mainContentSelector` - defines selector for main content element of the page to be used by accessibility feature "skip to main content".
 
 ## Web Resources Client Library
 A web resources client library can be defined at the template level (see `./appResourcesClientlib` component policy configuration).

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -115,7 +115,7 @@
                             <mainContentSelector
                                 jcr:primaryType="nt:unstructured"
                                 fieldLabel="Skip to main content element selector"
-                                fieldDescription="This property defines selector wchich links to main part of the page. It is used by accessibility feature which allows user to skip directly to the main content of the page."
+                                fieldDescription="Selector for the main section of the page. Used as accessibility feature to skip directly to the main content of the page."
                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                 name="./mainContentSelector"/>
                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -112,6 +112,12 @@
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="granite/ui/components/foundation/form/autocomplete/list"/>
                             </appResourcesClientlib>
+                            <mainContentSelector
+                                jcr:primaryType="nt:unstructured"
+                                valueType="string"
+                                fieldLabel="Skip to main content ID selector"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                name="./mainContentSelector"/>
                         </items>
                     </properties>
                     <styletab

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -115,7 +115,7 @@
                             <mainContentSelector
                                 jcr:primaryType="nt:unstructured"
                                 valueType="string"
-                                fieldLabel="Skip to main content ID selector"
+                                fieldLabel="Skip to main content element selector"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                 name="./mainContentSelector"/>
                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -114,8 +114,8 @@
                             </appResourcesClientlib>
                             <mainContentSelector
                                 jcr:primaryType="nt:unstructured"
-                                valueType="string"
                                 fieldLabel="Skip to main content element selector"
+                                fieldDescription="This property defines selector wchich links to main part of the page. It is used by accessibility feature which allows user to skip directly to the main content of the page."
                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                 name="./mainContentSelector"/>
                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/body.skiptomaincontent.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/body.skiptomaincontent.html
@@ -19,7 +19,7 @@
      data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
      data-sly-test="${page.mainContentSelector}">
     <a class="core-skip-to-main-content__link"
-       href="#${page.mainContentSelector}">${'skipToMainContentLink' @ i18n}</a>
+       href="#${page.mainContentSelector}">${'Skip to main content' @ i18n}</a>
 </div>
 <sly data-sly-call="${clientlib.css @ categories='core.wcm.components.page.v2.skiptomaincontent'}"
      data-sly-test="${page.mainContentSelector}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/body.skiptomaincontent.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/body.skiptomaincontent.html
@@ -1,0 +1,25 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2020 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+
+<div class="core-skip-to-main-content"
+     data-sly-use.page="com.adobe.cq.wcm.core.components.models.Page"
+     data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
+     data-sly-test="${page.mainContentSelector}">
+    <a class="core-skip-to-main-content__link"
+       href="#${page.mainContentSelector}">${'skipToMainContentLink' @ i18n}</a>
+</div>
+<sly data-sly-call="${clientlib.css @ categories='core.wcm.components.page.v2.skiptomaincontent'}"
+     data-sly-test="${page.mainContentSelector}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/body.skiptomaincontent.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/body.skiptomaincontent.html
@@ -14,12 +14,12 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 
-<div class="core-skip-to-main-content"
+<div class="cmp-page__skiptomaincontent"
      data-sly-use.page="com.adobe.cq.wcm.core.components.models.Page"
      data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
      data-sly-test="${page.mainContentSelector}">
-    <a class="core-skip-to-main-content__link"
-       alt="Skip to main content link"
+    <a class="cmp-page__skiptomaincontent-link"
+       alt="${'Skip to main content link' @ i18n}"
        href="#${page.mainContentSelector}">${'Skip to main content' @ i18n}</a>
 </div>
 <sly data-sly-call="${clientlib.css @ categories='core.wcm.components.page.v2.skiptomaincontent'}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/body.skiptomaincontent.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/body.skiptomaincontent.html
@@ -19,6 +19,7 @@
      data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
      data-sly-test="${page.mainContentSelector}">
     <a class="core-skip-to-main-content__link"
+       alt="Skip to main content link"
        href="#${page.mainContentSelector}">${'Skip to main content' @ i18n}</a>
 </div>
 <sly data-sly-call="${clientlib.css @ categories='core.wcm.components.page.v2.skiptomaincontent'}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[core.wcm.components.page.v2.skiptomaincontent]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/css.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/css.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2016 Adobe
+# Copyright 2020 Adobe
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/css.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/css.txt
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright 2016 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=css
+
+skip.less

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/css/skip.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/css/skip.less
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2019 Adobe
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+.core-skip-to-main-content {
+    .core-skip-to-main-content__link {
+        position: absolute;
+        left: -999px;
+        top: 0;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        z-index: -999;
+    }
+
+    .core-skip-to-main-content__link:focus, .core-skip-to-main-content__link:active {
+        left: 20px;
+        top: 20px;
+        width: auto;
+        height: auto;
+        color: blue;
+        background: white;
+        border: 1px solid blue;
+        overflow: auto;
+        padding: 10px;
+        margin: 5px;
+        z-index: 999;
+    }
+}

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/css/skip.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/css/skip.less
@@ -14,8 +14,8 @@
  *  limitations under the License.
  */
 
-.core-skip-to-main-content {
-    .core-skip-to-main-content__link {
+.cmp-page__skiptomaincontent {
+    .cmp-page__skiptomaincontent__link {
         position: absolute;
         left: -999px;
         top: 0;
@@ -23,19 +23,19 @@
         height: 1px;
         overflow: hidden;
         z-index: -999;
-    }
 
-    .core-skip-to-main-content__link:focus, .core-skip-to-main-content__link:active {
-        left: 20px;
-        top: 20px;
-        width: auto;
-        height: auto;
-        color: blue;
-        background: white;
-        border: 1px solid blue;
-        overflow: auto;
-        padding: 10px;
-        margin: 5px;
-        z-index: 999;
+        &:focus, &:active {
+            left: 20px;
+            top: 20px;
+            width: auto;
+            height: auto;
+            color: blue;
+            background: white;
+            border: 1px solid blue;
+            overflow: auto;
+            padding: 10px;
+            margin: 5px;
+            z-index: 999;
+        }
     }
 }

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/css/skip.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/css/skip.less
@@ -15,7 +15,7 @@
  */
 
 .cmp-page__skiptomaincontent {
-    .cmp-page__skiptomaincontent__link {
+    .cmp-page__skiptomaincontent-link {
         position: absolute;
         left: -999px;
         top: 0;

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/css/skip.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/clientlibs/site/skiptomaincontent/css/skip.less
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019 Adobe
+ *  Copyright 2020 Adobe
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/page.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/page.html
@@ -23,6 +23,7 @@
         <sly data-sly-test.isRedirectPage="${page.redirectTarget && (wcmmode.edit || wcmmode.preview)}"
              data-sly-call="${redirect.redirect @ redirectTarget = page.redirectTarget}"></sly>
         <sly data-sly-test="${!isRedirectPage}">
+            <sly data-sly-include="body.skiptomaincontent.html"></sly>
             <sly data-sly-include="body.socialmedia_begin.html"></sly>
             <sly data-sly-include="body.html"></sly>
             <sly data-sly-call="${footer.footer @ page = page}"></sly>

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/_cq_design_dialog/.content.xml
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/_cq_design_dialog/.content.xml
@@ -137,7 +137,7 @@
                             <mainContentSelector
                                 jcr:primaryType="nt:unstructured"
                                 valueType="string"
-                                fieldLabel="Skip to main content ID selector"
+                                fieldLabel="Skip to main content element selector"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                 name="./mainContentSelector"/>
                         </items>

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/_cq_design_dialog/.content.xml
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/_cq_design_dialog/.content.xml
@@ -138,6 +138,7 @@
                                 jcr:primaryType="nt:unstructured"
                                 valueType="string"
                                 fieldLabel="Skip to main content element selector"
+                                fieldDescription="This property defines selector wchich links to main part of the page. It is used by accessibility feature which allows user to skip directly to the main content of the page."
                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                 name="./mainContentSelector"/>
                         </items>

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/_cq_design_dialog/.content.xml
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/_cq_design_dialog/.content.xml
@@ -134,6 +134,12 @@
                                         value="ampOnly"/>
                                 </items>
                             </ampmode>
+                            <mainContentSelector
+                                jcr:primaryType="nt:unstructured"
+                                valueType="string"
+                                fieldLabel="Skip to main content ID selector"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                name="./mainContentSelector"/>
                         </items>
                     </properties>
                 </items>

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/_cq_design_dialog/.content.xml
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/_cq_design_dialog/.content.xml
@@ -138,7 +138,7 @@
                                 jcr:primaryType="nt:unstructured"
                                 valueType="string"
                                 fieldLabel="Skip to main content element selector"
-                                fieldDescription="This property defines selector wchich links to main part of the page. It is used by accessibility feature which allows user to skip directly to the main content of the page."
+                                fieldDescription="Selector for the main section of the page. Used as accessibility feature to skip directly to the main content of the page."
                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                 name="./mainContentSelector"/>
                         </items>

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/_cq_dialog/.content.xml
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/_cq_dialog/.content.xml
@@ -82,19 +82,6 @@
                                             </ampmode>
                                         </items>
                                     </amp>
-                                    <accessibility
-                                        jcr:primaryType="nt:unstructured"
-                                        jcr:title="Accessibility"
-                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
-                                        <items jcr:primaryType="nt:unstructured">
-                                            <mainContentSelector
-                                                jcr:primaryType="nt:unstructured"
-                                                valueType="string"
-                                                fieldLabel="Skip to main content ID selector"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                name="./mainContentSelector"/>
-                                        </items>
-                                    </accessibility>
                                 </items>
                             </column>
                         </items>

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/_cq_dialog/.content.xml
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/_cq_dialog/.content.xml
@@ -82,6 +82,19 @@
                                             </ampmode>
                                         </items>
                                     </amp>
+                                    <accessibility
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Accessibility"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <mainContentSelector
+                                                jcr:primaryType="nt:unstructured"
+                                                valueType="string"
+                                                fieldLabel="Skip to main content ID selector"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                name="./mainContentSelector"/>
+                                        </items>
+                                    </accessibility>
                                 </items>
                             </column>
                         </items>


### PR DESCRIPTION
Accessibility improvement.

Feature implements an option to specify "main content selector" which will be visible as a first link in the body of the page. This link allows us to skip directly to the main content of the page. Main content selector can be set in the content policy of the template / page. You can specify only one link for the "skip to" selector.