### PR TITLE
Title is not linked when external action

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -144,8 +144,6 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
                 } else if (actionsEnabled && !actions.isEmpty()) {
                     title = actions.get(0).getTitle();
                     linkURL = actions.get(0).getURL();
-                } else {
-                    title = null;
                 }
             }
         }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -144,6 +144,8 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
                 } else if (actionsEnabled && !actions.isEmpty()) {
                     title = actions.get(0).getTitle();
                     linkURL = actions.get(0).getURL();
+                } else {
+                    title = null;
                 }
             }
         }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -54,8 +54,9 @@ import com.day.cq.wcm.api.designer.Style;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-@Model(adaptables = SlingHttpServletRequest.class, adapters = {Teaser.class, ComponentExporter.class}, resourceType = TeaserImpl.RESOURCE_TYPE)
-@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME , extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+@Model(adaptables = SlingHttpServletRequest.class, adapters = {Teaser.class,
+    ComponentExporter.class}, resourceType = TeaserImpl.RESOURCE_TYPE)
+@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TeaserImpl.class);
@@ -118,7 +119,7 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
             hiddenImageResourceProperties.add(ImageResource.PN_LINK_URL);
             linkURL = null;
             populateActions();
-            if (actions.size() > 0) {
+            if (!actions.isEmpty()) {
                 ListItem firstAction = actions.get(0);
                 if (firstAction != null) {
                     targetPage = pageManager.getPage(firstAction.getPath());
@@ -140,6 +141,9 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
             if (titleFromPage) {
                 if (targetPage != null) {
                     title = StringUtils.defaultIfEmpty(targetPage.getPageTitle(), targetPage.getTitle());
+                } else if (actionsEnabled) {
+                    title = actions.get(0).getTitle();
+                    linkURL = actions.get(0).getURL();
                 } else {
                     title = null;
                 }
@@ -160,18 +164,18 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
         String fileReference = properties.get(DownloadResource.PN_REFERENCE, String.class);
         boolean hasImage = true;
         if (StringUtils.isEmpty(linkURL)) {
-            LOGGER.debug("Teaser component from " + request.getResource().getPath() + " does not define a link.");
+            LOGGER.debug("Teaser component from {} does not define a link.", request.getResource().getPath());
         }
         if (StringUtils.isEmpty(fileReference)) {
             if (request.getResource().getChild(DownloadResource.NN_FILE) == null) {
-                LOGGER.debug("Teaser component from " + request.getResource().getPath() + " does not have an asset or an image file " +
-                        "configured.");
+                LOGGER.debug("Teaser component from {} does not have an asset or an image file " +
+                    "configured.", request.getResource().getPath());
                 hasImage = false;
             }
         } else {
             if (request.getResourceResolver().getResource(fileReference) == null) {
-                LOGGER.error("Asset " + fileReference + " configured for the teaser component from " + request.getResource().getPath() +
-                        " doesn't exist.");
+                LOGGER.error("Asset {} configured for the teaser component from {} doesn 't exist.", fileReference,
+                    request.getResource().getPath());
                 hasImage = false;
             }
         }
@@ -287,6 +291,7 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
 
     @JsonIgnoreProperties({"path", "description", "lastModified", "name"})
     public class Action implements ListItem {
+
         ValueMap properties;
         String title;
         String url;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -291,7 +291,6 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
 
     @JsonIgnoreProperties({"path", "description", "lastModified", "name"})
     public class Action implements ListItem {
-
         ValueMap properties;
         String title;
         String url;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -141,7 +141,7 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
             if (titleFromPage) {
                 if (targetPage != null) {
                     title = StringUtils.defaultIfEmpty(targetPage.getPageTitle(), targetPage.getTitle());
-                } else if (actionsEnabled) {
+                } else if (actionsEnabled && !actions.isEmpty()) {
                     title = actions.get(0).getTitle();
                     linkURL = actions.get(0).getURL();
                 } else {
@@ -164,18 +164,18 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
         String fileReference = properties.get(DownloadResource.PN_REFERENCE, String.class);
         boolean hasImage = true;
         if (StringUtils.isEmpty(linkURL)) {
-            LOGGER.debug("Teaser component from {} does not define a link.", request.getResource().getPath());
+            LOGGER.debug("Teaser component from " + request.getResource().getPath() + " does not define a link.");
         }
         if (StringUtils.isEmpty(fileReference)) {
             if (request.getResource().getChild(DownloadResource.NN_FILE) == null) {
-                LOGGER.debug("Teaser component from {} does not have an asset or an image file " +
-                    "configured.", request.getResource().getPath());
+                LOGGER.debug("Teaser component from " + request.getResource().getPath() + " does not have an asset or an image file " +
+                        "configured.");
                 hasImage = false;
             }
         } else {
             if (request.getResourceResolver().getResource(fileReference) == null) {
-                LOGGER.error("Asset {} configured for the teaser component from {} doesn 't exist.", fileReference,
-                    request.getResource().getPath());
+                LOGGER.error("Asset " + fileReference + " configured for the teaser component from " + request.getResource().getPath() +
+                        " doesn't exist.");
                 hasImage = false;
             }
         }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
@@ -16,6 +16,7 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.sling.api.resource.Resource;
@@ -71,6 +72,8 @@ class TeaserImplTest {
     private static final String TEASER_7 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-7";
     private static final String TEASER_8 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-8";
     private static final String TEASER_9 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-9";
+    private static final String TEASER_10 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-10";
+    private static final String TEASER_11 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-11";
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
     private TestLogger testLogger;
@@ -207,7 +210,6 @@ class TeaserImplTest {
             Teaser.PN_TITLE_TYPE, "h5");
         assertEquals("Expected title type is not correct", "h5", teaser.getTitleType());
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(TEST_BASE, "teaser2"));
-
     }
 
     @Test
@@ -215,6 +217,24 @@ class TeaserImplTest {
         Teaser teaser = getTeaserUnderTest(TEASER_1);
         assertNull("Expected the default title type is not correct", teaser.getTitleType());
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(TEST_BASE, "teaser1"));
+    }
+
+    @Test
+    void testTeaserWithTitleNotFromPageAndNoActions() {
+        Teaser teaser = getTeaserUnderTest(TEASER_10);
+        assertEquals("Teaser", teaser.getTitle());
+        assertTrue(teaser.getActions().isEmpty());
+    }
+
+    @Test
+    void testTeaserWithTitleNotFromPageAndActions() {
+        Teaser teaser = getTeaserUnderTest(TEASER_11);
+        assertEquals("Teaser", teaser.getTitle());
+        List<ListItem> actions = teaser.getActions();
+        assertEquals("http://www.adobe.com", actions.get(0).getPath());
+        assertEquals("Adobe", actions.get(0).getTitle());
+        assertEquals("/content/teasers", actions.get(1).getPath());
+        assertEquals("Teasers", actions.get(1).getTitle());
     }
 
     private Teaser getTeaserUnderTest(String resourcePath, Object... properties) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
@@ -74,6 +74,7 @@ class TeaserImplTest {
     private static final String TEASER_9 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-9";
     private static final String TEASER_10 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-10";
     private static final String TEASER_11 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-11";
+    private static final String TEASER_12 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-12";
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
     private TestLogger testLogger;
@@ -220,14 +221,14 @@ class TeaserImplTest {
     }
 
     @Test
-    void testTeaserWithTitleNotFromPageAndNoActions() {
+    void testTeaserWithTitleNotFromLinkedPageAndNoActions() {
         Teaser teaser = getTeaserUnderTest(TEASER_10);
         assertEquals("Teaser", teaser.getTitle());
         assertTrue(teaser.getActions().isEmpty());
     }
 
     @Test
-    void testTeaserWithTitleNotFromPageAndActions() {
+    void testTeaserWithTitleNotFromLinkedPageAndActions() {
         Teaser teaser = getTeaserUnderTest(TEASER_11);
         assertEquals("Teaser", teaser.getTitle());
         List<ListItem> actions = teaser.getActions();
@@ -235,6 +236,15 @@ class TeaserImplTest {
         assertEquals("Adobe", actions.get(0).getTitle());
         assertEquals("/content/teasers", actions.get(1).getPath());
         assertEquals("Teasers", actions.get(1).getTitle());
+    }
+
+    @Test
+    void testTeaserWithTitleFromLinkedPageAndActions() {
+        Teaser teaser = getTeaserUnderTest(TEASER_12);
+        assertEquals("Adobe", teaser.getTitle());
+        List<ListItem> actions = teaser.getActions();
+        assertEquals("http://www.adobe.com", actions.get(0).getPath());
+        assertEquals("Adobe", actions.get(0).getTitle());
     }
 
     private Teaser getTeaserUnderTest(String resourcePath, Object... properties) {

--- a/bundles/core/src/test/resources/teaser/test-content.json
+++ b/bundles/core/src/test/resources/teaser/test-content.json
@@ -135,6 +135,21 @@
                                 "text": "Teasers"
                             }
                         }
+                    },
+                    "teaser-12"          : {
+                        "jcr:primaryType"     : "nt:unstructured",
+                        "jcr:title"           : "Teaser",
+                        "actionsEnabled"      : true,
+                        "titleFromPage"       : true,
+                        "sling:resourceType"  : "core/wcm/components/teaser/v1/teaser",
+                        "actions" : {
+                            "jcr:primaryType" : "nt:unstructured",
+                            "item0" : {
+                                "jcr:primaryType" : "nt:unstructured",
+                                "link": "http://www.adobe.com",
+                                "text": "Adobe"
+                            }
+                        }
                     }
                 }
             }

--- a/bundles/core/src/test/resources/teaser/test-content.json
+++ b/bundles/core/src/test/resources/teaser/test-content.json
@@ -109,6 +109,32 @@
                         "jcr:description"   : "Description",
                         "linkURL"           : "/content/teasers",
                         "sling:resourceType": "core/wcm/components/teaser/v1/teaser"
+                    },
+                    "teaser-10"          : {
+                        "jcr:primaryType"   : "nt:unstructured",
+                        "jcr:title"         : "Teaser",
+                        "jcr:description"   : "Description",
+                        "linkURL"           : "/content/teasers",
+                        "sling:resourceType": "core/wcm/components/teaser/v1/teaser"
+                    },
+                    "teaser-11"          : {
+                        "jcr:primaryType"     : "nt:unstructured",
+                        "jcr:title"           : "Teaser",
+                        "actionsEnabled"      : true,
+                        "sling:resourceType"  : "core/wcm/components/teaser/v1/teaser",
+                        "actions" : {
+                            "jcr:primaryType" : "nt:unstructured",
+                            "item0" : {
+                                "jcr:primaryType" : "nt:unstructured",
+                                "link": "http://www.adobe.com",
+                                "text": "Adobe"
+                            },
+                            "item1" : {
+                                "jcr:primaryType" : "nt:unstructured",
+                                "link": "/content/teasers",
+                                "text": "Teasers"
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | Fixes #948
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | No
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Title is now visible when the first call-to-action is an external link.
