### PR TITLE
[Image] Javascript exception when linkURL is removed from the dialog

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/editor/js/image.js
@@ -118,7 +118,9 @@
                 $altGroup.show();
                 $linkURLGroup.show();
             }
-            $linkURLField.adaptTo("foundation-field").setDisabled(checkbox.checked);
+            if ($linkURLField.length) {
+                $linkURLField.adaptTo("foundation-field").setDisabled(checkbox.checked);
+            }
             altTuple.hideTextfield(checkbox.checked);
             if (fileReference) {
                 altTuple.hideCheckbox(checkbox.checked);


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1009
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Adds a check that the $linkURLField jquery element is present in the dialog before trying to use the element properties (in this case the .setDisabled function). This way you can remove the linkURL from the dialog without breaking the functionality.
