### PR TITLE
Fix possible DataLayer NPEs

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
@@ -168,6 +168,7 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
 
     @Override
     @JsonIgnore
+    @NotNull
     public List<ListItem> getItems() {
         if (items == null) {
             items = readItems();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
@@ -132,12 +132,10 @@ public class AccordionImpl extends PanelContainerImpl implements Accordion {
             List<String> expandedItemsName = Arrays.asList(expandedItems);
             List<ListItem> items = this.getItems();
 
-            List<String> expandedItemIdsList = items.stream()
+            expandedItemIds = items.stream()
                 .filter(item -> expandedItemsName.contains(item.getName()))
                 .map(item -> item.getData().getId())
-                .collect(Collectors.toList());
-
-            expandedItemIds = expandedItemIdsList.toArray(new String[expandedItemIdsList.size()]);
+                .toArray(String[]::new);
 
         }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
@@ -17,8 +17,8 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -34,7 +34,8 @@ import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.internal.Utils;
 import com.adobe.cq.wcm.core.components.models.Accordion;
-import com.adobe.cq.wcm.core.components.models.ListItem;
+import com.adobe.cq.wcm.core.components.models.Component;
+import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import com.day.cq.wcm.api.designer.Style;
 
 @Model(
@@ -130,13 +131,13 @@ public class AccordionImpl extends PanelContainerImpl implements Accordion {
 
         if (expandedItemIds == null) {
             List<String> expandedItemsName = Arrays.asList(expandedItems);
-            List<ListItem> items = this.getItems();
 
-            expandedItemIds = items.stream()
+            expandedItemIds = this.getItems().stream()
                 .filter(item -> expandedItemsName.contains(item.getName()))
-                .map(item -> item.getData().getId())
+                .map(Component::getData)
+                .filter(Objects::nonNull)
+                .map(ComponentData::getId)
                 .toArray(String[]::new);
-
         }
 
         return Arrays.copyOf(expandedItemIds, expandedItemIds.length);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
@@ -132,16 +132,12 @@ public class AccordionImpl extends PanelContainerImpl implements Accordion {
             List<String> expandedItemsName = Arrays.asList(expandedItems);
             List<ListItem> items = this.getItems();
 
-            if (items != null) {
-                List<String> expandedItemIdsList = items.stream()
-                    .filter(item -> expandedItemsName.contains(item.getName()))
-                    .map(item -> item.getData().getId())
-                    .collect(Collectors.toList());
+            List<String> expandedItemIdsList = items.stream()
+                .filter(item -> expandedItemsName.contains(item.getName()))
+                .map(item -> item.getData().getId())
+                .collect(Collectors.toList());
 
-                expandedItemIds = expandedItemIdsList.toArray(new String[expandedItemIdsList.size()]);
-            } else {
-                expandedItemIds = new String[0];
-            }
+            expandedItemIds = expandedItemIdsList.toArray(new String[expandedItemIdsList.size()]);
 
         }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
@@ -17,6 +17,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -44,14 +45,13 @@ public class PanelContainerImpl extends AbstractContainerImpl implements Contain
     protected Map<String, ComponentExporter> getItemModels(@NotNull SlingHttpServletRequest request,
                                                            @NotNull Class<ComponentExporter> modelClass) {
         Map<String, ComponentExporter> models = super.getItemModels(request, modelClass);
-        models.entrySet().forEach(entry -> {
-            ListItem match = getItems().stream()
-                .filter(item -> item != null && StringUtils.isNotEmpty(item.getName()) && StringUtils.equals(item.getName(), entry.getKey()))
-                .findFirst().get();
-            if (match != null) {
-                entry.setValue(new JsonWrapper(entry.getValue(), match));
-            }
-        });
+        models.entrySet().forEach(entry ->
+            getItems().stream()
+                .filter(Objects::nonNull)
+                .filter(item -> StringUtils.isNotEmpty(item.getName()) && StringUtils.equals(item.getName(), entry.getKey()))
+                .findFirst()
+                .ifPresent(match -> entry.setValue(new JsonWrapper(entry.getValue(), match)))
+        );
         return models;
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
@@ -15,9 +15,9 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -33,12 +33,11 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 public class PanelContainerImpl extends AbstractContainerImpl implements Container {
 
     @Override
+    @NotNull
     protected List<ListItem> readItems() {
-        List<ListItem> items = new LinkedList<>();
-        getChildren().forEach(res -> {
-            items.add(new PanelContainerItemImpl(request, res, getId()));
-        });
-        return items;
+        return getChildren().stream()
+            .map(res -> new PanelContainerItemImpl(request, res, getId()))
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
@@ -15,9 +15,10 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
+import java.util.Optional;
+
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ValueMap;
 import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.wcm.core.components.models.ListItem;
@@ -29,10 +30,7 @@ public class PanelContainerItemImpl extends ResourceListItemImpl implements List
 
     public PanelContainerItemImpl(@NotNull SlingHttpServletRequest request, @NotNull Resource resource, String parentId) {
         super(request, resource, parentId);
-        ValueMap valueMap = resource.adaptTo(ValueMap.class);
-        if (valueMap != null) {
-            String jcrTitle = valueMap.get(JcrConstants.JCR_TITLE, String.class);
-            title = valueMap.get(PN_PANEL_TITLE, jcrTitle);
-        }
+        title = Optional.ofNullable(resource.getValueMap().get(PN_PANEL_TITLE, String.class))
+            .orElseGet(() -> resource.getValueMap().get(JcrConstants.JCR_TITLE, String.class));
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
@@ -16,6 +16,7 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -94,19 +95,16 @@ public class TabsImpl extends PanelContainerImpl implements Tabs {
 
     @Override
     public String[] getDataLayerShownItems() {
-        String[] shownItems = new String[0];
-        ListItem activeItem = null;
         String activeItemName = getActiveItem();
         List<ListItem> items = getItems();
-        if (!items.isEmpty()) {
-            activeItem = items.stream()
-                    .filter(e -> StringUtils.equals(e.getName(), activeItemName))
-                    .findFirst().orElse(items.get(0));
-            ComponentData componentData = activeItem.getData();
-            if (componentData != null) {
-                shownItems = new String[]{componentData.getId()};
-            }
-        }
-        return shownItems;
+        return Optional.ofNullable(
+            items.stream()
+                .filter(e -> StringUtils.equals(e.getName(), activeItemName))
+                .findFirst()
+                .orElse(items.get(0))
+                .getData())
+            .map(ComponentData::getId)
+            .map(item -> new String[]{item})
+            .orElseGet(() -> new String[0]);
     }
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | None filed
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | None added
| Documentation Provided   | N/A
| Any Dependency Changes?  | N/A
| License                  | Apache License, Version 2.0

Fixes possible NPEs introduced in the DataLayer.

Specifically:
1) in AccordionImpl `item.getData().getId()` introduces a possible NPE because getData() may return null.
2) in PanelContainerImpl `.findFirst().get();` introduces a possible NPE because findFirst() returns an Optional, Optional.get() causes a NPE if the Optional is empty. It does not return null if the Optional is empty. The null check following the `findFirst().get()` is impossible to be false, because a NPE would occur prior to the null check.
3) in PanelContainerItemImpl the use of a possibly null default value in a call to ValueMap.get() can result in an NPE because not every ValueMap implementation handles a default value of null. For this reason the documentation for ValueMap indicates this value must not be null. 

Additionally, `TabImpl#getDataLayerShownItems()` is cleaned up. There are several unnecessary temporary variables. Streams & Optionals area already in use, might as well follow them through to the end result which introduces less opportunity for error. 

