### PR TITLE
[Tabs][Library] JS errors thrown in console for aemcomponents.dev

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/site/clientlibs/container/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/site/clientlibs/container/.content.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
-    categories="[core.wcm.components.commons.site.container]"/>
+    categories="[core.wcm.components.commons.site.container]"
+    allowProxy="{Boolean}true"/>


### PR DESCRIPTION
- make the utils clientlib available on publish instance
