### PR TITLE
[AMP] AMP config is overwritten by the core config

### DIFF
--- a/config/src/content/META-INF/vault/filter.xml
+++ b/config/src/content/META-INF/vault/filter.xml
@@ -15,6 +15,6 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <workspaceFilter version="1.0">
-    <filter root="/apps/core/wcm/config"/>
+    <filter root="/apps/core/wcm/config" mode="merge"/>
     <filter root="/apps/core/wcm/config.author"/>
 </workspaceFilter>


### PR DESCRIPTION
- prevent the core config to overwrite the AMP config
