### PR TITLE
Issue/1030: Annotate optional sling model fields as `@Nullable` and fix potential NPEs

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractComponentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractComponentImpl.java
@@ -51,9 +51,11 @@ public abstract class AbstractComponentImpl implements Component {
     protected Resource resource;
 
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     protected ComponentContext componentContext;
 
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private Page currentPage;
 
     private String id;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
@@ -20,14 +20,16 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
@@ -43,7 +45,6 @@ import com.adobe.cq.wcm.core.components.models.Container;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import com.day.cq.wcm.api.TemplatedResource;
-import com.day.cq.wcm.api.components.Component;
 import com.day.cq.wcm.api.components.ComponentManager;
 import com.day.cq.wcm.api.designer.Style;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -53,65 +54,77 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 public abstract class AbstractContainerImpl extends AbstractComponentImpl implements Container {
 
+    /**
+     * The current request.
+     */
     @Self
     protected SlingHttpServletRequest request;
 
+    /**
+     * The current style for this component.
+     */
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
     @JsonIgnore
     @Nullable
     protected Style currentStyle;
 
+    /**
+     * The sling model factory service.
+     */
     @OSGiService
     protected SlingModelFilter slingModelFilter;
 
+    /**
+     * The model factory.
+     */
     @OSGiService
     protected ModelFactory modelFactory;
 
+    /**
+     * The list of child items.
+     */
     protected List<ListItem> items;
-    protected List<Resource> childComponents;
-    protected List<Resource> filteredChildComponents;
-
-    protected Map<String, ? extends ComponentExporter> itemModels;
-    private String[] exportedItemsOrder;
-
-    private boolean backgroundColorEnabled;
-    private boolean backgroundImageEnabled;
-    private String backgroundImageReference;
-    private String backgroundColor;
-    private StringBuilder styleBuilder;
 
     /**
-     * Read the list of children resources that are components
-     *
-     * @return
+     * The list of child resources that are components.
      */
-    @NotNull
-    private List<Resource> readChildren() {
-        List<Resource> children = new LinkedList<>();
-        Resource effectiveResource = this.getEffectiveResource();
-        if (effectiveResource != null) {
-            ComponentManager componentManager = request.getResourceResolver().adaptTo(ComponentManager.class);
-            if (componentManager != null) {
-                effectiveResource.getChildren().forEach(res -> {
-                    Component component = componentManager.getComponentOfResource(res);
-                    if (component != null) {
-                        children.add(res);
-                    }
-                });
-            }
-        }
-        return children;
-    }
+    protected List<Resource> childComponents;
+
+    /**
+     * The child resources to be exported.
+     */
+    protected List<Resource> filteredChildComponents;
+
+    /**
+     * Map of the child items to be exported wherein the key is the child name, and the value is the child model.
+     */
+    protected Map<String, ? extends ComponentExporter> itemModels;
+
+    /**
+     * The name of the child resources in the order they are to be exported.
+     */
+    private String[] exportedItemsOrder;
+
+    /**
+     * The background style string for this container component.
+     */
+    private String backgroundStyle;
 
     /**
      * Return (and cache) the list of children resources that are components
      *
-     * @return
+     * @return List of all children resources that are components.
      */
     @NotNull
     protected List<Resource> getChildren() {
         if (childComponents == null) {
-            childComponents = readChildren();
+            Resource effectiveResource = this.getEffectiveResource();
+            childComponents = Optional.ofNullable(request.getResourceResolver().adaptTo(ComponentManager.class))
+                .map(componentManager ->
+                    StreamSupport.stream(effectiveResource.getChildren().spliterator(), false)
+                        .filter(res -> Objects.nonNull(componentManager.getComponentOfResource(res))))
+                .orElseGet(Stream::empty)
+                .collect(Collectors.toList());
         }
         return childComponents;
     }
@@ -120,7 +133,7 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
      * Return (and cache) the list of children resources that are components, filtered by the Sling Model Filter. This
      * should only be used for JSON export, for other usages refer to {@link AbstractContainerImpl#getChildren}.
      *
-     * @return
+     * @return The list of children resources available for JSON export.
      */
     @NotNull
     protected List<Resource> getFilteredChildren() {
@@ -140,24 +153,28 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
     @NotNull
     protected abstract List<? extends ListItem> readItems();
 
-    private void populateStyleProperties() {
-        backgroundColorEnabled = currentStyle.get(PN_BACKGROUND_COLOR_ENABLED, false);
-        backgroundImageEnabled = currentStyle.get(PN_BACKGROUND_IMAGE_ENABLED, false);
-        if (resource != null) {
-            ValueMap properties = resource.getValueMap();
-            backgroundColor = properties.get(PN_BACKGROUND_COLOR, String.class);
-            backgroundImageReference = properties.get(PN_BACKGROUND_IMAGE_REFERENCE, String.class);
-        }
+    /**
+     * Get the background colour.
+     *
+     * @return The background colour if set, empty if background colour is not enabled or not defined.
+     */
+    private Optional<String> getBackgroundColor() {
+        return Optional.ofNullable(this.currentStyle)
+            .filter(style -> style.get(PN_BACKGROUND_COLOR_ENABLED, Boolean.FALSE))
+            .flatMap(style -> Optional.ofNullable(this.resource.getValueMap().get(PN_BACKGROUND_COLOR, String.class)))
+            .filter(StringUtils::isNotEmpty);
     }
 
-    private void setBackgroundStyleString() {
-        styleBuilder = new StringBuilder();
-        if (backgroundImageEnabled && !StringUtils.isEmpty(backgroundImageReference)) {
-            styleBuilder.append("background-image:url(" + backgroundImageReference + ");background-size:cover;background-repeat:no-repeat;");
-        }
-        if (backgroundColorEnabled && !StringUtils.isEmpty(backgroundColor)) {
-            styleBuilder.append("background-color:" + backgroundColor + ";");
-        }
+    /**
+     * Get the background image.
+     *
+     * @return The background image if set, empty if background image is not enabled or not defined.
+     */
+    private Optional<String> getBackgroundImage() {
+        return Optional.ofNullable(this.currentStyle)
+            .filter(style -> style.get(PN_BACKGROUND_IMAGE_ENABLED, Boolean.FALSE))
+            .flatMap(style -> Optional.ofNullable(this.resource.getValueMap().get(PN_BACKGROUND_IMAGE_REFERENCE, String.class)))
+            .filter(StringUtils::isNotEmpty);
     }
 
     @Override
@@ -173,15 +190,21 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
     @Nullable
     @Override
     public String getBackgroundStyle() {
-        if (styleBuilder == null) {
-            populateStyleProperties();
-            setBackgroundStyleString();
+        if (this.backgroundStyle == null) {
+            StringBuilder styleBuilder = new StringBuilder();
+            getBackgroundImage().ifPresent(image -> {
+                styleBuilder.append("background-image:url(").append(image).append(");background-size:cover;background-repeat:no-repeat;");
+            });
+            getBackgroundColor().ifPresent(color -> {
+                styleBuilder.append("background-color:").append(color).append(";");
+            });
+            this.backgroundStyle = styleBuilder.toString();
         }
-        String style = styleBuilder.toString();
-        if (StringUtils.isEmpty(style)) {
+
+        if (StringUtils.isEmpty(this.backgroundStyle)) {
             return null;
         }
-        return style;
+        return this.backgroundStyle;
     }
 
     @NotNull
@@ -213,8 +236,15 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
         return Arrays.copyOf(exportedItemsOrder, exportedItemsOrder.length);
     }
 
-    protected Map<String, ComponentExporter> getItemModels(@NotNull SlingHttpServletRequest request,
-                                                           @NotNull Class<ComponentExporter> modelClass) {
+    /**
+     * Get the models for the child resources as provided by {@link AbstractContainerImpl#getFilteredChildren()}.
+     *
+     * @param request The current request.
+     * @param modelClass The child model class.
+     * @return Map of models wherein the key is the child name, and the value is it's model.
+     */
+    protected Map<String, ComponentExporter> getItemModels(@NotNull final SlingHttpServletRequest request,
+                                                           @NotNull final Class<ComponentExporter> modelClass) {
         Map<String, ComponentExporter> models = new LinkedHashMap<>();
         getFilteredChildren().forEach(child -> {
             ComponentExporter model = modelFactory.getModelFromWrappedRequest(request, child, modelClass);
@@ -225,15 +255,17 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
         return models;
     }
 
-    @Nullable
+    /**
+     * Get the effective {@link TemplatedResource} for the current resource.
+     *
+     * @return The TemplatedResource, or the current resource if it cannot be adapted to a TemplatedResource.
+     */
+    @NotNull
     protected Resource getEffectiveResource() {
-        if (this.resource != null) {
-            if (this.resource instanceof TemplatedResource) {
-                return this.resource;
-            }
-            return Optional.ofNullable((Resource)this.request.adaptTo(TemplatedResource.class)).orElse(this.resource);
+        if (this.resource instanceof TemplatedResource) {
+            return this.resource;
         }
-        return null;
+        return Optional.ofNullable((Resource)this.request.adaptTo(TemplatedResource.class)).orElse(this.resource);
     }
 
     /*

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.annotation.CheckForNull;
-
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -59,6 +57,7 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
 
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
     @JsonIgnore
+    @Nullable
     protected Style currentStyle;
 
     @OSGiService
@@ -231,7 +230,7 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
         return models;
     }
 
-    @CheckForNull
+    @Nullable
     protected Resource getEffectiveResource() {
         if (this.resource != null) {
             if (this.resource instanceof TemplatedResource) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
@@ -21,6 +21,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -132,18 +133,12 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
     }
 
     /**
-     * Read the list of items in the container
+     * Get the list of items in the container.
      *
-     * @return
+     * @return The list of items in the container.
      */
     @NotNull
-    protected List<ListItem> readItems() {
-        List<ListItem> items = new LinkedList<>();
-        getChildren().forEach(res -> {
-            items.add(new ResourceListItemImpl(request, res, getId()));
-        });
-        return items;
-    }
+    protected abstract List<? extends ListItem> readItems();
 
     private void populateStyleProperties() {
         backgroundColorEnabled = currentStyle.get(PN_BACKGROUND_COLOR_ENABLED, false);
@@ -170,7 +165,7 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
     @NotNull
     public List<ListItem> getItems() {
         if (items == null) {
-            items = readItems();
+            items = readItems().stream().map(i -> (ListItem) i).collect(Collectors.toList());
         }
         return items;
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
@@ -15,14 +15,15 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
-import org.apache.commons.lang3.ArrayUtils;
+import com.adobe.cq.wcm.core.components.models.Component;
+import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
@@ -35,10 +36,11 @@ import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.internal.Utils;
 import com.adobe.cq.wcm.core.components.models.Accordion;
-import com.adobe.cq.wcm.core.components.models.Component;
-import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import com.day.cq.wcm.api.designer.Style;
 
+/**
+ * V1 Accordion model implementation.
+ */
 @Model(
     adaptables = SlingHttpServletRequest.class,
     adapters = { Accordion.class, ComponentExporter.class, ContainerExporter.class },
@@ -50,19 +52,34 @@ import com.day.cq.wcm.api.designer.Style;
 )
 public class AccordionImpl extends PanelContainerImpl implements Accordion {
 
+    /**
+     * Resource type.
+     */
     public final static String RESOURCE_TYPE = "core/wcm/components/accordion/v1/accordion";
 
+    /**
+     * Flag indicating if single expansion is enabled.
+     */
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
     private boolean singleExpansion;
 
+    /**
+     * Array of expanded items.
+     */
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
     @Nullable
     private String[] expandedItems;
 
+    /**
+     * The heading element.
+     */
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
     @Nullable
     private String headingElement;
 
+    /**
+     * The current style for this component.
+     */
     @ScriptVariable
     private Style currentStyle;
 
@@ -90,20 +107,12 @@ public class AccordionImpl extends PanelContainerImpl implements Accordion {
     @Override
     public String[] getExpandedItems() {
         if (expandedItemNames == null) {
-            List<String> expanded = new ArrayList<>();
-            if (expandedItems != null) {
-                for (String expandedItemName : expandedItems) {
-                    Resource child = resource.getChild(expandedItemName);
-                    if (child != null) {
-                        expanded.add(expandedItemName);
-                    }
-                }
-            }
-            if (!expanded.isEmpty()) {
-                expandedItemNames = expanded.toArray(ArrayUtils.EMPTY_STRING_ARRAY);
-            } else {
-                expandedItemNames = ArrayUtils.EMPTY_STRING_ARRAY;
-            }
+            this.expandedItemNames = Optional.ofNullable(this.expandedItems)
+                .map(Arrays::stream)
+                .orElse(Stream.empty())
+                .filter(Objects::nonNull)
+                .filter(item -> Objects.nonNull(resource.getChild(item)))
+                .toArray(String[]::new);
         }
         return Arrays.copyOf(expandedItemNames, expandedItemNames.length);
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
@@ -28,6 +28,7 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
@@ -55,9 +56,11 @@ public class AccordionImpl extends PanelContainerImpl implements Accordion {
     private boolean singleExpansion;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String[] expandedItems;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String headingElement;
 
     @ScriptVariable

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ButtonImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ButtonImpl.java
@@ -25,6 +25,7 @@ import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
@@ -57,15 +58,19 @@ public class ButtonImpl extends AbstractComponentImpl implements Button {
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
     @Named(JcrConstants.JCR_TITLE)
+    @Nullable
     private String text;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String link;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String icon;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     protected String accessibilityLabel;
 
     @Override
@@ -87,11 +92,13 @@ public class ButtonImpl extends AbstractComponentImpl implements Button {
     }
 
     @Override
+    @Nullable
     public String getIcon() {
         return icon;
     }
 
     @Override
+    @Nullable
     public String getAccessibilityLabel() {
         return accessibilityLabel;
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
@@ -33,6 +33,7 @@ import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.models.Carousel;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
+import org.jetbrains.annotations.Nullable;
 
 @Model(adaptables = SlingHttpServletRequest.class, adapters = {Carousel.class, ComponentExporter.class, ContainerExporter.class}, resourceType = CarouselImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
@@ -45,6 +46,7 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
     protected ValueMap properties;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     protected String accessibilityLabel;
 
     protected boolean autoplay;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
@@ -16,9 +16,11 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.annotation.PostConstruct;
 
+import com.day.cq.wcm.api.designer.Style;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Exporter;
@@ -35,29 +37,75 @@ import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import org.jetbrains.annotations.Nullable;
 
-@Model(adaptables = SlingHttpServletRequest.class, adapters = {Carousel.class, ComponentExporter.class, ContainerExporter.class}, resourceType = CarouselImpl.RESOURCE_TYPE)
+/**
+ * V1 Carousel model implementation.
+ */
+@Model(
+    adaptables = SlingHttpServletRequest.class,
+    adapters = {Carousel.class, ComponentExporter.class, ContainerExporter.class},
+    resourceType = CarouselImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class CarouselImpl extends PanelContainerImpl implements Carousel {
 
+    /**
+     * The resource type.
+     */
     public static final String RESOURCE_TYPE = "core/wcm/components/carousel/v1/carousel";
-    protected static final Long DEFAULT_DELAY = 5000L; // milliseconds
 
+    /**
+     * The default slide transition delay in milliseconds.
+     */
+    protected static final Long DEFAULT_DELAY = 5000L;
+
+    /**
+     * The current resource properties.
+     */
     @ScriptVariable
     protected ValueMap properties;
 
+    /**
+     * The accessibility label.
+     */
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
     @Nullable
     protected String accessibilityLabel;
 
+    /**
+     * Flag indicating if autoplay is enabled.
+     */
     protected boolean autoplay;
+
+    /**
+     * Time in milliseconds between slide transitions.
+     */
     protected Long delay;
+
+    /**
+     * Flag indicating if auto-pause (on slide hover) is disabled.
+     */
     protected boolean autopauseDisabled;
 
+    /**
+     * Initialize the model.
+     */
     @PostConstruct
     protected void initModel() {
-        autoplay = properties.get(PN_AUTOPLAY, currentStyle.get(PN_AUTOPLAY, false));
-        delay = properties.get(PN_DELAY, currentStyle.get(PN_DELAY, DEFAULT_DELAY));
-        autopauseDisabled = properties.get(PN_AUTOPAUSE_DISABLED, currentStyle.get(PN_AUTOPAUSE_DISABLED, false));
+        Optional<Style> optionalStyle =  Optional.ofNullable(currentStyle);
+
+        // get the autoplay value from the resource, or the style if not set, or default false if neither set
+        autoplay = Optional.ofNullable(properties.get(PN_AUTOPLAY, Boolean.class))
+            .orElseGet(() -> optionalStyle.map(style -> style.get(PN_AUTOPLAY, Boolean.class))
+                .orElse(false));
+
+        // get the autoplay delay from the resource, or the style if not set, or default value if neither set
+        delay = Optional.ofNullable(properties.get(PN_DELAY, Long.class))
+            .orElseGet(() -> optionalStyle.map(style -> style.get(PN_DELAY, Long.class))
+                .orElse(DEFAULT_DELAY));
+
+        // get the autopause disabled flag from the resource, or the style if not set, or false if neither set.
+        autopauseDisabled = Optional.ofNullable(properties.get(PN_AUTOPAUSE_DISABLED, Boolean.class))
+            .orElseGet(() -> optionalStyle.map(style -> style.get(PN_AUTOPAUSE_DISABLED, Boolean.class))
+                .orElse(false));
     }
 
     @Override
@@ -76,6 +124,7 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
     }
 
     @Override
+    @Nullable
     public String getAccessibilityLabel() {
         return accessibilityLabel;
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImpl.java
@@ -50,6 +50,7 @@ import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.DamConstants;
 import com.day.cq.wcm.api.designer.Style;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,6 +79,7 @@ public class DownloadImpl implements Download {
 
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
     @JsonIgnore
+    @Nullable
     protected Style currentStyle;
 
     @SlingObject
@@ -97,15 +99,16 @@ public class DownloadImpl implements Download {
 
     private boolean displayFilename;
 
-    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL,
-                   name = JcrConstants.JCR_TITLE)
+    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL, name = JcrConstants.JCR_TITLE)
+    @Nullable
     private String title;
 
-    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL,
-                   name = JcrConstants.JCR_DESCRIPTION)
+    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL, name = JcrConstants.JCR_DESCRIPTION)
+    @Nullable
     private String description;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String actionText;
 
     private String titleType;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/EmbedImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/EmbedImpl.java
@@ -52,18 +52,23 @@ public class EmbedImpl implements Embed {
     protected static final String RESOURCE_TYPE = "core/wcm/components/embed/v1/embed";
 
     @ValueMapValue(name = PN_TYPE, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String type;
 
     @ValueMapValue(name = PN_URL, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String url;
 
     @ValueMapValue(name = PN_HTML, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String html;
 
     @ValueMapValue(name = PN_EMBEDDABLE_RESOURCE_TYPE, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String embeddableResourceType;
 
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private Style currentStyle;
 
     @Inject @Optional

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -26,8 +26,14 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.injectorspecific.*;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,6 +82,7 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
     private Page currentPage;
 
     @ValueMapValue(name = ExperienceFragment.PN_FRAGMENT_VARIATION_PATH, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String fragmentVariationPath;
 
     @OSGiService
@@ -190,8 +197,7 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
         try {
             if (relationshipManager.isSource(resource)) {
                 // the resource is a blueprint
-                RangeIterator liveCopiesIterator = null;
-                liveCopiesIterator = relationshipManager.getLiveRelationships(resource, null, null);
+                RangeIterator liveCopiesIterator = relationshipManager.getLiveRelationships(resource, null, null);
                 if (liveCopiesIterator != null) {
                     LiveRelationship relationship = (LiveRelationship) liveCopiesIterator.next();
                     LiveCopy liveCopy = relationship.getLiveCopy();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
@@ -18,6 +18,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Calendar;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -257,13 +258,14 @@ public class ImageImpl extends AbstractComponentImpl implements Image {
      * @return image name from DAM
      */
     protected String getImageNameFromDam() {
-        String imageName = "";
-        Resource damResource = request.getResourceResolver().getResource(fileReference);
-        if (damResource != null) {
-            Asset asset = damResource.adaptTo(Asset.class);
-            imageName = asset != null ? StringUtils.trimToNull(asset.getName()) : "";
-        }
-        return getSeoFriendlyName(FilenameUtils.getBaseName(imageName));
+        return Optional.ofNullable(this.fileReference)
+            .map(reference -> request.getResourceResolver().getResource(reference))
+            .map(damResource -> damResource.adaptTo(Asset.class))
+            .map(Asset::getName)
+            .map(StringUtils::trimToNull)
+            .map(FilenameUtils::getBaseName)
+            .map(this::getSeoFriendlyName)
+            .orElse(StringUtils.EMPTY);
     }
 
     /**
@@ -272,7 +274,7 @@ public class ImageImpl extends AbstractComponentImpl implements Image {
      * {@code application/x-www-form-urlencoded} format using {@code utf-8} encoding
      * scheme.
      *
-     * @param imageName
+     * @param imageName The image name
      * @return the SEO friendly image name
      */
     protected String getSeoFriendlyName(String imageName) {
@@ -283,7 +285,7 @@ public class ImageImpl extends AbstractComponentImpl implements Image {
         try {
             seoFriendlyName = URLEncoder.encode(seoFriendlyName, CharEncoding.UTF_8);
         } catch (UnsupportedEncodingException e) {
-            LOGGER.error(String.format("The Character Encoding is not supported."));
+            LOGGER.error("The Character Encoding is not supported.");
         }
         return seoFriendlyName;
     }
@@ -385,7 +387,9 @@ public class ImageImpl extends AbstractComponentImpl implements Image {
 
     @Override
     public Resource getDataLayerAssetResource() {
-        return resource.getResourceResolver().getResource(fileReference);
+        return Optional.ofNullable(this.fileReference)
+            .map(reference -> request.getResourceResolver().getResource(reference))
+            .orElse(null);
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
@@ -45,6 +45,7 @@ import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,15 +100,19 @@ public class ImageImpl extends AbstractComponentImpl implements Image {
     protected MimeTypeService mimeTypeService;
 
     @ValueMapValue(name = DownloadResource.PN_REFERENCE, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     protected String fileReference;
 
     @ValueMapValue(name = ImageResource.PN_ALT, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     protected String alt;
 
     @ValueMapValue(name = JcrConstants.JCR_TITLE, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     protected String title;
 
     @ValueMapValue(name = ImageResource.PN_LINK_URL, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String linkURL;
 
     protected String src;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
@@ -19,7 +19,6 @@ import javax.annotation.PostConstruct;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.jetbrains.annotations.NotNull;
@@ -27,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import com.adobe.cq.wcm.core.components.models.LayoutContainer;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Model(adaptables = SlingHttpServletRequest.class, adapters = LayoutContainer.class, resourceType = LayoutContainerImpl.RESOURCE_TYPE_V1)
@@ -41,16 +41,9 @@ public class LayoutContainerImpl extends AbstractContainerImpl implements Layout
 
     @PostConstruct
     protected void initModel() {
-        if (resource != null) {
-            ValueMap properties = resource.getValueMap();
-            if (properties != null) {
-                String layoutProperty = properties.get(LayoutContainer.PN_LAYOUT, String.class);
-                layout = LayoutType.getLayoutType(layoutProperty);
-                if (layout == null) {
-                    layout = LayoutType.SIMPLE;
-                }
-            }
-        }
+        this.layout = Optional.ofNullable(resource.getValueMap().get(LayoutContainer.PN_LAYOUT, String.class))
+            .map(LayoutType::getLayoutType)
+            .orElse(LayoutType.SIMPLE);
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
@@ -26,6 +26,9 @@ import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.wcm.core.components.models.LayoutContainer;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Model(adaptables = SlingHttpServletRequest.class, adapters = LayoutContainer.class, resourceType = LayoutContainerImpl.RESOURCE_TYPE_V1)
 public class LayoutContainerImpl extends AbstractContainerImpl implements LayoutContainer {
 
@@ -48,6 +51,14 @@ public class LayoutContainerImpl extends AbstractContainerImpl implements Layout
                 }
             }
         }
+    }
+
+    @Override
+    @NotNull
+    protected List<ResourceListItemImpl> readItems() {
+        return getChildren().stream()
+            .map(res -> new ResourceListItemImpl(request, res, getId()))
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
@@ -15,7 +15,12 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
 
 import javax.annotation.PostConstruct;
 import javax.jcr.RangeIterator;
@@ -72,6 +77,7 @@ public class NavigationImpl extends AbstractComponentImpl implements Navigation 
     private LiveRelationshipManager relationshipManager;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String accessibilityLabel;
 
     private int structureDepth;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
@@ -57,6 +57,7 @@ import com.day.cq.wcm.api.designer.Design;
 import com.day.cq.wcm.api.designer.Designer;
 import com.day.cq.wcm.api.designer.Style;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.jetbrains.annotations.Nullable;
 
 @Model(adaptables = SlingHttpServletRequest.class, adapters = { Page.class,
         ContainerExporter.class }, resourceType = PageImpl.RESOURCE_TYPE)
@@ -77,6 +78,7 @@ public class PageImpl extends AbstractComponentImpl implements Page {
 
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
     @JsonIgnore
+    @Nullable
     protected Style currentStyle;
 
     @ScriptVariable

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
@@ -35,7 +35,7 @@ public class PanelContainerImpl extends AbstractContainerImpl implements Contain
 
     @Override
     @NotNull
-    protected List<ListItem> readItems() {
+    protected List<PanelContainerItemImpl> readItems() {
         return getChildren().stream()
             .map(res -> new PanelContainerItemImpl(request, res, getId()))
             .collect(Collectors.toList());

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
@@ -16,7 +16,9 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.StreamSupport;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -35,9 +37,11 @@ import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.models.Tabs;
 import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
-import com.day.cq.wcm.api.components.Component;
 import com.day.cq.wcm.api.components.ComponentManager;
 
+/**
+ * Tabs model implementation.
+ */
 @Model(adaptables = SlingHttpServletRequest.class,
        adapters = {Tabs.class, ComponentExporter.class, ContainerExporter.class},
        resourceType = TabsImpl.RESOURCE_TYPE)
@@ -45,49 +49,62 @@ import com.day.cq.wcm.api.components.ComponentManager;
           extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class TabsImpl extends PanelContainerImpl implements Tabs {
 
+    /**
+     * The resource type.
+     */
     public final static String RESOURCE_TYPE = "core/wcm/components/tabs/v1/tabs";
 
+    /**
+     * The current active tab.
+     */
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
     @Nullable
     private String activeItem;
 
+    /**
+     * The accessibility label.
+     */
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
     @Nullable
     private String accessibilityLabel;
 
+    /**
+     * The current resource.
+     */
     @SlingObject
     private Resource resource;
 
+    /**
+     * The current request.
+     */
     @Self
     SlingHttpServletRequest request;
 
+    /**
+     * The name of the active item.
+     */
     private String activeItemName;
 
     @Override
     public String getActiveItem() {
         if (activeItemName == null) {
-            Resource active = resource.getChild(activeItem);
-            if (active != null) {
-                activeItemName = activeItem;
-            } else {
-                ComponentManager componentManager = request.getResourceResolver().adaptTo(ComponentManager.class);
-                if (componentManager != null) {
-                    for (Resource res : resource.getChildren()) {
-                        if (res != null) {
-                            Component component = componentManager.getComponentOfResource(res);
-                            if (component != null) {
-                                activeItemName = res.getName();
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
+            this.activeItemName = Optional.ofNullable(this.activeItem)
+                .map(resource::getChild)
+                .map(Resource::getName)
+                .orElseGet(() ->
+                    Optional.ofNullable(request.getResourceResolver().adaptTo(ComponentManager.class))
+                        .flatMap(componentManager -> StreamSupport.stream(resource.getChildren().spliterator(), false)
+                            .filter(Objects::nonNull)
+                            .filter(res -> Objects.nonNull(componentManager.getComponentOfResource(res)))
+                            .findFirst()
+                            .map(Resource::getName))
+                        .orElse(null));
         }
         return activeItemName;
     }
 
     @Override
+    @Nullable
     public String getAccessibilityLabel() {
         return accessibilityLabel;
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
@@ -27,6 +27,7 @@ import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
@@ -47,9 +48,11 @@ public class TabsImpl extends PanelContainerImpl implements Tabs {
     public final static String RESOURCE_TYPE = "core/wcm/components/tabs/v1/tabs";
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String activeItem;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String accessibilityLabel;
 
     @SlingObject

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -95,6 +95,7 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
 
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
     @JsonIgnore
+    @Nullable
     protected Style currentStyle;
 
     @Self

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TextImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TextImpl.java
@@ -26,6 +26,7 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
@@ -40,6 +41,7 @@ public class TextImpl extends AbstractComponentImpl implements Text {
     protected static final String RESOURCE_TYPE_V2 = "core/wcm/components/text/v2/text";
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String text;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TitleImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TitleImpl.java
@@ -28,6 +28,7 @@ import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
@@ -64,15 +65,19 @@ public class TitleImpl extends AbstractComponentImpl implements Title {
 
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
     @JsonIgnore
+    @Nullable
     private Style currentStyle;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL, name = JcrConstants.JCR_TITLE)
+    @Nullable
     private String title;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String type;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String linkURL;
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
@@ -82,20 +82,20 @@ public class ContentFragmentImpl implements ContentFragment {
     @ScriptVariable
     private Resource resource;
 
-    @ValueMapValue(name = ContentFragment.PN_PATH,
-                   injectionStrategy = InjectionStrategy.OPTIONAL)
+    @ValueMapValue(name = ContentFragment.PN_PATH, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String fragmentPath;
 
-    @ValueMapValue(name = ContentFragment.PN_ELEMENT_NAMES,
-                   injectionStrategy = InjectionStrategy.OPTIONAL)
+    @ValueMapValue(name = ContentFragment.PN_ELEMENT_NAMES, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String[] elementNames;
 
-    @ValueMapValue(name = ContentFragment.PN_VARIATION_NAME,
-                   injectionStrategy = InjectionStrategy.OPTIONAL)
+    @ValueMapValue(name = ContentFragment.PN_VARIATION_NAME, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String variationName;
 
-    @ValueMapValue(name = ContentFragment.PN_DISPLAY_MODE,
-                   injectionStrategy = InjectionStrategy.OPTIONAL)
+    @ValueMapValue(name = ContentFragment.PN_DISPLAY_MODE, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String displayMode;
 
     private DAMContentFragment damContentFragment = new EmptyContentFragment();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentListImpl.java
@@ -33,6 +33,7 @@ import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +68,7 @@ public class ContentFragmentListImpl implements ContentFragmentList {
     public static final String RESOURCE_TYPE = "core/wcm/components/contentfragmentlist/v1/contentfragmentlist";
 
     public static final String DEFAULT_DAM_PARENT_PATH = "/content/dam";
-    
+
     public static final int DEFAULT_MAX_ITEMS = -1;
 
     @Self(injectionStrategy = InjectionStrategy.REQUIRED)
@@ -80,15 +81,19 @@ public class ContentFragmentListImpl implements ContentFragmentList {
     private ResourceResolver resourceResolver;
 
     @ValueMapValue(name = ContentFragmentList.PN_MODEL_PATH, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String modelPath;
 
     @ValueMapValue(name = ContentFragmentList.PN_ELEMENT_NAMES, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String[] elementNames;
 
     @ValueMapValue(name = ContentFragmentList.PN_TAG_NAMES, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String[] tagNames;
 
     @ValueMapValue(name = ContentFragmentList.PN_PARENT_PATH, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String parentPath;
 
     @ValueMapValue(name = ContentFragmentList.PN_MAX_ITEMS, injectionStrategy = InjectionStrategy.OPTIONAL)
@@ -96,12 +101,14 @@ public class ContentFragmentListImpl implements ContentFragmentList {
     private int maxItems;
 
     @ValueMapValue(name = ContentFragmentList.PN_ORDER_BY, injectionStrategy = InjectionStrategy.OPTIONAL)
-    private String orderBy = JcrConstants.JCR_CREATED;
+    @Default(values = JcrConstants.JCR_CREATED)
+    private String orderBy;
 
     @ValueMapValue(name = ContentFragmentList.PN_SORT_ORDER, injectionStrategy = InjectionStrategy.OPTIONAL)
-    private String sortOrder = Predicate.SORT_ASCENDING;
+    @Default(values = Predicate.SORT_ASCENDING)
+    private String sortOrder;
 
-    private List<DAMContentFragment> items = new ArrayList<>();
+    private final List<DAMContentFragment> items = new ArrayList<>();
 
     @PostConstruct
     private void initModel() {
@@ -159,7 +166,7 @@ public class ContentFragmentListImpl implements ContentFragmentList {
 
         PredicateGroup predicateGroup = PredicateGroup.create(queryParameterMap);
         Query query = queryBuilder.createQuery(predicateGroup, session);
-        
+
         SearchResult searchResult = query.getResult();
 
         LOG.debug("Query statement: '{}'", searchResult.getQueryStatement());

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/AbstractFieldImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/AbstractFieldImpl.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.wcm.core.components.models.form.Field;
 import com.day.cq.commons.jcr.JcrConstants;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Abstract class which can be used as base class for {@link Field} implementations.
@@ -32,17 +33,23 @@ import com.day.cq.commons.jcr.JcrConstants;
 public abstract class AbstractFieldImpl implements Field {
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     protected String id;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL, name = JcrConstants.JCR_TITLE)
+    @Nullable
     protected String title;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     protected String name;
 
     @ValueMapValue
     @Default(values = "")
     protected String value;
+
+    @SlingObject
+    private Resource resource;
 
     /**
      * @return a prefix String which will be used for generating {@link #id} through {@link #getId()}
@@ -54,9 +61,6 @@ public abstract class AbstractFieldImpl implements Field {
     protected abstract String getDefaultValue();
 
     protected abstract String getDefaultTitle();
-
-    @SlingObject
-    private Resource resource;
 
     @Override
     public String getId() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ButtonImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ButtonImpl.java
@@ -32,6 +32,7 @@ import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.internal.form.FormConstants;
 import com.adobe.cq.wcm.core.components.models.form.Button;
 import com.day.cq.i18n.I18n;
+import org.jetbrains.annotations.Nullable;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class},
        adapters = {Button.class, ComponentExporter.class},
@@ -50,9 +51,11 @@ public class ButtonImpl extends AbstractFieldImpl implements Button {
     private Type type;
 
     @Self(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private SlingHttpServletRequest request;
 
     @Self(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private Resource resource;
 
     private I18n i18n;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ButtonImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ButtonImpl.java
@@ -54,10 +54,6 @@ public class ButtonImpl extends AbstractFieldImpl implements Button {
     @Nullable
     private SlingHttpServletRequest request;
 
-    @Self(injectionStrategy = InjectionStrategy.OPTIONAL)
-    @Nullable
-    private Resource resource;
-
     private I18n i18n;
 
     @PostConstruct

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImpl.java
@@ -35,6 +35,7 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.*;
 import org.apache.sling.models.factory.ModelFactory;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,6 +86,7 @@ public class ContainerImpl implements Container {
     private String id;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String actionType;
 
     @ValueMapValue(name = ResourceResolver.PROPERTY_RESOURCE_TYPE)
@@ -92,6 +94,7 @@ public class ContainerImpl implements Container {
     private String dropAreaResourceType;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String redirect;
 
     private String name;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/OptionsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/OptionsImpl.java
@@ -33,7 +33,12 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.injectorspecific.*;
+import org.apache.sling.models.annotations.injectorspecific.ChildResource;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,21 +63,27 @@ public class OptionsImpl extends AbstractFieldImpl implements Options {
     private static final String ID_PREFIX = "form-options";
 
     @ChildResource(injectionStrategy = InjectionStrategy.OPTIONAL) @Named(OPTION_ITEMS_PATH)
+    @Nullable
     private List<Resource> itemResources;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String helpMessage;
 
     @ValueMapValue(name = OptionsImpl.PN_TYPE, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String typeString;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String listPath;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String datasourceRT;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL, name = "source")
+    @Nullable
     private String sourceString;
 
     @ScriptVariable

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
@@ -74,8 +74,8 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     @ScriptVariable
     private ComponentContext componentContext;
 
-    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL,
-                   name = PN_REDIRECT_TARGET)
+    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL, name = PN_REDIRECT_TARGET)
+    @Nullable
     private String redirectTargetValue;
 
     private String appResourcesPath;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
@@ -15,12 +15,14 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v2;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.PostConstruct;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -49,61 +51,102 @@ import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
 import com.adobe.granite.ui.clientlibs.LibraryType;
 import com.day.cq.wcm.api.components.ComponentContext;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.Lists;
 
+/**
+ * V2 Page model implementation.
+ */
 @Model(adaptables = SlingHttpServletRequest.class, adapters = {Page.class, ContainerExporter.class}, resourceType = PageImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v1.PageImpl implements Page {
 
+    /**
+     * The resource type.
+     */
     protected static final String RESOURCE_TYPE = "core/wcm/components/page/v2/page";
+
+    /**
+     * Head JS client library style property name.
+     */
     protected static final String PN_CLIENTLIBS_JS_HEAD = "clientlibsJsHead";
+
+    /**
+     * Redirect target property name.
+     */
     public static final String PN_REDIRECT_TARGET = "cq:redirectTarget";
+
+    /**
+     * Main content selector style property name.
+     */
     public static final String PN_MAIN_CONTENT_SELECTOR_PROP = "mainContentSelector";
 
+    /**
+     * Flag indicating if cloud configuration support is enabled.
+     */
     private Boolean hasCloudconfigSupport;
 
+    /**
+     * The HtmlLibraryManager (client library) service.
+     */
     @OSGiService
     private HtmlLibraryManager htmlLibraryManager;
 
+    /**
+     * The ProductInfoProvider service.
+     */
     @OSGiService
     private ProductInfoProvider productInfoProvider;
 
+    /**
+     * The current request.
+     */
     @Self
     protected SlingHttpServletRequest request;
 
+    /**
+     * The current component context.
+     */
     @ScriptVariable
     private ComponentContext componentContext;
 
+    /**
+     * The redirect target if set, null if not.
+     */
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL, name = PN_REDIRECT_TARGET)
     @Nullable
     private String redirectTargetValue;
 
+    /**
+     * The proxy path of the first client library listed in the style under the
+     * &quot;{@value Page#PN_APP_RESOURCES_CLIENTLIB}&quot; property.
+     */
     private String appResourcesPath;
+
+    /**
+     * The redirect target as a NavigationItem.
+     */
     private NavigationItem redirectTarget;
 
-    protected String[] clientLibCategoriesJsBody = new String[0];
-    protected String[] clientLibCategoriesJsHead = new String[0];
+    /**
+     * Body JS client library categories.
+     */
+    private String[] clientLibCategoriesJsBody;
+
+    /**
+     * Head JS client library categories.
+     */
+    private String[] clientLibCategoriesJsHead;
 
     @PostConstruct
     protected void initModel() {
         super.initModel();
-        String resourcesClientLibrary = currentStyle.get(PN_APP_RESOURCES_CLIENTLIB, String.class);
-        if (resourcesClientLibrary != null) {
-            Collection<ClientLibrary> clientLibraries =
-                    htmlLibraryManager.getLibraries(new String[]{resourcesClientLibrary}, LibraryType.CSS, true, true);
-            ArrayList<ClientLibrary> clientLibraryList = Lists.newArrayList(clientLibraries.iterator());
-            if (!clientLibraryList.isEmpty()) {
-                appResourcesPath = getProxyPath(clientLibraryList.get(0));
-            }
-        }
-        populateClientLibCategoriesJs();
-        setRedirect();
-    }
-
-    private void setRedirect() {
-        if (StringUtils.isNotEmpty(redirectTargetValue)) {
-            redirectTarget = new RedirectItemImpl(redirectTargetValue, request);
-        }
+        this.appResourcesPath = Optional.ofNullable(currentStyle)
+            .map(style -> style.get(PN_APP_RESOURCES_CLIENTLIB, String.class))
+            .map(resourcesClientLibrary -> htmlLibraryManager.getLibraries(new String[]{resourcesClientLibrary}, LibraryType.CSS, true, true))
+            .map(Collection::stream)
+            .orElse(Stream.empty())
+            .findFirst()
+            .map(this::getProxyPath)
+            .orElse(null);
     }
 
     private String getProxyPath(ClientLibrary lib) {
@@ -125,15 +168,6 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
         return path;
     }
 
-    protected void populateClientLibCategoriesJs() {
-        if (currentStyle != null) {
-            clientLibCategoriesJsHead = currentStyle.get(PN_CLIENTLIBS_JS_HEAD, ArrayUtils.EMPTY_STRING_ARRAY);
-            LinkedHashSet<String> categories = new LinkedHashSet<>(Arrays.asList(clientLibCategories));
-            categories.removeAll(Arrays.asList(clientLibCategoriesJsHead));
-            clientLibCategoriesJsBody = categories.toArray(new String[0]);
-        }
-    }
-
     @Override
     protected void loadFavicons(String designPath) {
     }
@@ -148,12 +182,27 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     @Override
     @JsonIgnore
     public String[] getClientLibCategoriesJsBody() {
+        if (clientLibCategoriesJsBody == null) {
+            List<String> headLibs = Arrays.asList(getClientLibCategoriesJsHead());
+            clientLibCategoriesJsBody = Arrays.stream(clientLibCategories)
+                .distinct()
+                .filter(item -> !headLibs.contains(item))
+                .toArray(String[]::new);
+        }
         return Arrays.copyOf(clientLibCategoriesJsBody, clientLibCategoriesJsBody.length);
     }
 
     @Override
     @JsonIgnore
     public String[] getClientLibCategoriesJsHead() {
+        if (clientLibCategoriesJsHead == null) {
+            clientLibCategoriesJsHead = Optional.ofNullable(currentStyle)
+                .map(style -> style.get(PN_CLIENTLIBS_JS_HEAD, String[].class))
+                .map(Arrays::stream)
+                .orElseGet(Stream::empty)
+                .distinct()
+                .toArray(String[]::new);
+        }
         return Arrays.copyOf(clientLibCategoriesJsHead, clientLibCategoriesJsHead.length);
     }
 
@@ -183,6 +232,9 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     @Nullable
     @Override
     public NavigationItem getRedirectTarget() {
+        if (redirectTarget == null && StringUtils.isNotEmpty(redirectTargetValue)) {
+            redirectTarget = new RedirectItemImpl(redirectTargetValue, request);
+        }
         return redirectTarget;
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/resource/ImageResourceWrapper.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/resource/ImageResourceWrapper.java
@@ -68,6 +68,7 @@ public class ImageResourceWrapper extends ResourceWrapper {
     }
 
     @Override
+    @NotNull
     public String getResourceType() {
         return resourceType;
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/CoreFormHandlingServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/CoreFormHandlingServlet.java
@@ -28,6 +28,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.commons.osgi.PropertiesUtil;
+import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -86,11 +87,7 @@ public class CoreFormHandlingServlet
     static final String EXTENSION = "html";
     private static final Boolean PROP_ALLOW_EXPRESSION_DEFAULT = true;
 
-    private String[] dataNameWhitelist;
-
     private transient FormsHandlingServletHelper formsHandlingServletHelper;
-
-    private boolean allowExpressions;
 
     @Reference
     private transient SaferSlingPostValidator validator;
@@ -101,18 +98,17 @@ public class CoreFormHandlingServlet
     @Activate
     protected void activate(Configuration configuration) {
 
-        dataNameWhitelist = PropertiesUtil.toStringArray(configuration.name_whitelist());
-        allowExpressions = PropertiesUtil.toBoolean(configuration.allow_expressions(), PROP_ALLOW_EXPRESSION_DEFAULT);
+        String[] dataNameWhitelist = PropertiesUtil.toStringArray(configuration.name_whitelist());
+        boolean allowExpressions = PropertiesUtil.toBoolean(configuration.allow_expressions(), PROP_ALLOW_EXPRESSION_DEFAULT);
         formsHandlingServletHelper = new FormsHandlingServletHelper(dataNameWhitelist, validator, FormConstants.RT_ALL_CORE_FORM_CONTAINER,
-                allowExpressions, formStructureHelperFactory);
+            allowExpressions, formStructureHelperFactory);
     }
 
     /**
      * @see org.apache.sling.api.servlets.SlingAllMethodsServlet#doPost(org.apache.sling.api.SlingHttpServletRequest, org.apache.sling.api.SlingHttpServletResponse)
      */
     @Override
-    protected void doPost(SlingHttpServletRequest request,
-                          final SlingHttpServletResponse response)
+    protected void doPost(@NotNull SlingHttpServletRequest request, @NotNull final SlingHttpServletResponse response)
             throws ServletException, IOException {
         formsHandlingServletHelper.doPost(request, response);
     }
@@ -130,7 +126,7 @@ public class CoreFormHandlingServlet
     /**
      * @see Filter#init(FilterConfig)
      */
-    public void init(final FilterConfig config) throws ServletException {
+    public void init(final FilterConfig config) {
         // nothing to do!
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbeddablesDataSourceServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbeddablesDataSourceServlet.java
@@ -158,15 +158,12 @@ public class EmbeddablesDataSourceServlet extends SlingSafeMethodsServlet {
         /**
          * @see java.lang.Comparable#compareTo(java.lang.Object)
          */
-        public int compareTo(EmbeddableDescription o) {
-            if (o == null) {
-                return 0;
-            }
-            final EmbeddableDescription obj = (EmbeddableDescription) o;
-            if (this.order < obj.order) {
+        @Override
+        public int compareTo(@NotNull final EmbeddableDescription o) {
+            if (this.order < o.order) {
                 return -1;
-            } else if (this.order == obj.order) {
-                return this.title.compareTo(obj.title);
+            } else if (this.order == o.order) {
+                return this.title.compareTo(o.title);
             }
             return 1;
         }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImplTest.java
@@ -15,9 +15,10 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
+import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -25,20 +26,18 @@ import org.junit.Test;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.Container;
 import com.adobe.cq.wcm.core.components.models.ListItem;
-import com.adobe.cq.wcm.core.components.testing.Utils;
 import io.wcm.testing.mock.aem.junit.AemContext;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class AbstractContainerImplTest {
 
     private static final String TEST_BASE = "/container";
     private static final String CONTENT_ROOT = "/content";
-    private static final String CONTEXT_PATH = "/core";
-    private static final String TEST_ROOT_PAGE = "/content/container";
-    private static final String TEST_ROOT_PAGE_GRID = "/jcr:content/root/responsivegrid";
-    private static final String CONTAINER_1 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/container-1";
+    // private static final String CONTEXT_PATH = "/core";
+    // private static final String TEST_ROOT_PAGE = "/content/container";
+    // private static final String TEST_ROOT_PAGE_GRID = "/jcr:content/root/responsivegrid";
+    // private static final String CONTAINER_1 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/container-1";
     private static final String TEST_APPS_ROOT = "/apps/core/wcm/components";
 
     @ClassRule
@@ -53,48 +52,15 @@ public class AbstractContainerImplTest {
     public void testEmptyContainer() {
         Container container = new ContainerImpl();
         List<ListItem> items = container.getItems();
-        assertTrue("", items == null || items.size() == 0);
+        assertEquals(0, items.size());
     }
 
-    @Test
-    public void testContainerWithItems() {
-        Container container = getContainerUnderTest(CONTAINER_1);
-        Object[][] expectedItems = {
-            {"Teaser 1 description", "item_1", "/content/container/jcr:content/root/responsivegrid/container-1/item_1", "Teaser 1"},
-            {"Teaser 2 description", "item_2", "/content/container/jcr:content/root/responsivegrid/container-1/item_2", "Teaser 2"},
-        };
-        verifyContainerItems(expectedItems, container.getItems());
-    }
 
-    private Container getContainerUnderTest(String resourcePath) {
-        Resource resource = AEM_CONTEXT.resourceResolver().getResource(resourcePath);
-        if (resource == null) {
-            throw new IllegalStateException("Does the test resource " + resourcePath + " exist?");
+    private static class ContainerImpl extends AbstractContainerImpl {
+        @Override
+        @NotNull
+        protected List<ListItem> readItems() {
+            return new ArrayList<>();
         }
-        AEM_CONTEXT.currentResource(resource);
-        AEM_CONTEXT.request().setContextPath(CONTEXT_PATH);
-        Container container = new ContainerImpl();
-        Utils.setInternalState(container, "resource", resource);
-        Utils.setInternalState(container, "request", AEM_CONTEXT.request());
-        return container;
-    }
-
-    private void verifyContainerItems(Object[][] expectedItems, List<ListItem> items) {
-        assertEquals("The container has a different number of items than expected.", expectedItems.length, items.size());
-        int index = 0;
-        for (ListItem item : items) {
-            assertEquals("The container item's description is not what was expected: " + item.getDescription(),
-                expectedItems[index][0], item.getDescription());
-            assertEquals("The container item's name is not what was expected: " + item.getName(),
-                expectedItems[index][1], item.getName());
-            assertEquals("The container item's path is not what was expected: " + item.getPath(),
-                expectedItems[index][2], item.getPath());
-            assertEquals("The container item's title is not what was expected: " + item.getTitle(),
-                expectedItems[index][3], item.getTitle());
-            index++;
-        }
-    }
-
-    private class ContainerImpl extends AbstractContainerImpl {
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImplTest.java
@@ -40,6 +40,8 @@ class AccordionImplTest {
     private static final String ACCORDION_1 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/accordion-1";
     private static final String ACCORDION_2 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/accordion-2";
     private static final String ACCORDION_3 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/accordion-3";
+    private static final String ACCORDION_EMPTY = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/accordion-empty";
+
     private static final String TEST_APPS_ROOT = "/apps/core/wcm/components";
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
@@ -52,9 +54,7 @@ class AccordionImplTest {
 
     @Test
     void testEmptyAccordion() {
-        Accordion accordion = new AccordionImpl();
-        List<ListItem> items = accordion.getItems();
-        assertEquals(0, items.size());
+        assertEquals(0, getAccordionUnderTest(ACCORDION_EMPTY).getItems().size());
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImplTest.java
@@ -16,7 +16,10 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.List;
+import java.util.Objects;
 
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,6 +42,7 @@ class CarouselImplTest {
     private static final String TEST_ROOT_PAGE = "/content/carousel";
     private static final String TEST_ROOT_PAGE_GRID = "/jcr:content/root/responsivegrid";
     private static final String CAROUSEL_1 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/carousel-1";
+    private static final String CAROUSEL_EMPTY = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/carousel-empty";
     private static final String TEST_APPS_ROOT = "/apps/core/wcm/components";
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
@@ -51,14 +55,12 @@ class CarouselImplTest {
 
     @Test
     void testEmptyCarousel() {
-        Carousel carousel = new CarouselImpl();
-        List<ListItem> items = carousel.getItems();
-        assertEquals("", 0, items.size());
+        Assertions.assertEquals(0, getCarouselUnderTest(CAROUSEL_EMPTY).getItems().size());
     }
 
     @Test
     void testCarouselWithItems() {
-        Carousel carousel = getCarouselUnderTest();
+        Carousel carousel = getCarouselUnderTest(CAROUSEL_1);
         Object[][] expectedItems = {
                 { "item_1", "Teaser 1", "core/wcm/components/teaser/v1/teaser",
                         "/content/carousel/jcr:content/root/responsivegrid/carousel-1/item_1" },
@@ -72,15 +74,15 @@ class CarouselImplTest {
 
     @Test
     void testCarouselProperties() {
-        Carousel carousel = getCarouselUnderTest();
+        Carousel carousel = getCarouselUnderTest(CAROUSEL_1);
         assertTrue(carousel.getAutoplay());
         assertEquals(Long.valueOf(7000), carousel.getDelay());
         assertTrue(carousel.getAutopauseDisabled());
     }
 
-    private Carousel getCarouselUnderTest() {
+    private Carousel getCarouselUnderTest(@NotNull final String resourcePath) {
         Utils.enableDataLayer(context, true);
-        context.currentResource(CarouselImplTest.CAROUSEL_1);
+        context.currentResource(Objects.requireNonNull(context.resourceResolver().getResource(resourcePath)));
         return context.request().adaptTo(Carousel.class);
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImplTest.java
@@ -42,6 +42,7 @@ class TabsImplTest {
     private static final String TABS_1 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/tabs-1";
     private static final String TABS_2 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/tabs-2";
     private static final String TABS_3 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/tabs-3";
+    private static final String TABS_EMPTY = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/tabs-empty";
     private static final String TEST_APPS_ROOT = "/apps/core/wcm/components";
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
@@ -54,9 +55,8 @@ class TabsImplTest {
 
     @Test
     void testEmptyTabs() {
-        Tabs tabs = new TabsImpl();
-        List<ListItem> items = tabs.getItems();
-        Assert.assertTrue("", items == null || items.size() == 0);
+        Tabs tabs = getTabsUnderTest(TABS_EMPTY);
+        Assert.assertEquals(0, tabs.getItems().size());
     }
 
     @Test

--- a/bundles/core/src/test/resources/accordion/test-content.json
+++ b/bundles/core/src/test/resources/accordion/test-content.json
@@ -12,6 +12,10 @@
                 "responsivegrid"    : {
                     "jcr:primaryType"   : "nt:unstructured",
                     "sling:resourceType": "wcm/foundation/components/responsivegrid",
+                    "accordion-empty"          : {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "core/wcm/components/accordion/v1/accordion"
+                    },
                     "accordion-1"          : {
                         "jcr:primaryType"   : "nt:unstructured",
                         "sling:resourceType": "core/wcm/components/accordion/v1/accordion",

--- a/bundles/core/src/test/resources/carousel/test-content.json
+++ b/bundles/core/src/test/resources/carousel/test-content.json
@@ -12,6 +12,10 @@
                 "responsivegrid"    : {
                     "jcr:primaryType"   : "nt:unstructured",
                     "sling:resourceType": "wcm/foundation/components/responsivegrid",
+                    "carousel-empty"          : {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "core/wcm/components/carousel/v1/carousel"
+                    },
                     "carousel-1"          : {
                         "jcr:primaryType"   : "nt:unstructured",
                         "sling:resourceType": "core/wcm/components/carousel/v1/carousel",

--- a/bundles/core/src/test/resources/tabs/test-content.json
+++ b/bundles/core/src/test/resources/tabs/test-content.json
@@ -12,6 +12,10 @@
                 "responsivegrid"    : {
                     "jcr:primaryType"   : "nt:unstructured",
                     "sling:resourceType": "wcm/foundation/components/responsivegrid",
+                    "tabs-empty": {
+                        "jcr:primaryType"   : "nt:unstructured",
+                        "sling:resourceType": "core/wcm/components/tabs/v1/tabs"
+                    },
                     "tabs-1"          : {
                         "jcr:primaryType"   : "nt:unstructured",
                         "sling:resourceType": "core/wcm/components/tabs/v1/tabs",

--- a/extensions/amp/bundle/src/main/java/com/adobe/cq/wcm/core/extensions/amp/internal/models/v1/ClientLibraryImpl.java
+++ b/extensions/amp/bundle/src/main/java/com/adobe/cq/wcm/core/extensions/amp/internal/models/v1/ClientLibraryImpl.java
@@ -33,6 +33,7 @@ import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,21 +48,27 @@ public class ClientLibraryImpl implements ClientLibrary {
     private static final Logger LOG = LoggerFactory.getLogger(ClientLibraryImpl.class);
 
     @OSGiService
+    @Nullable
     private ClientLibraryAggregatorService aggregatorService;
 
     @Inject
+    @Nullable
     private String categories;
 
     @ScriptVariable
+    @Nullable
     private Page currentPage;
 
     @Inject
+    @Nullable
     private String fallbackPath;
 
     @Inject
+    @Nullable
     private String primaryPath;
 
     @Inject
+    @Nullable
     private String type;
 
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1030 
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

Annotates any field injected into a sling model with the injection strategy of OPTIONAL as `@Nullable` unless a default is also provided.

Having done this, several potential NPEs are revealed. These NPEs are resolved with the basic formula being to wrap the potentially null field in an `Optional.ofNullable(field)` and handling the optional field through the Optional interface. 

In some instances useless null checks are removed, and deep nested if statements are converted to a flat optional mapping.

