### PR TITLE
Fixes #1043 Context-Aware configuration for data layer is not registered as Sling-ContextAware-Configuration-Classes

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -57,8 +57,12 @@
                 <configuration>
                     <exportScr>true</exportScr>
                     <instructions>
-                        <!-- Enable registration of Sling Models classes via bnd plugin -->
-                        <_plugin>org.apache.sling.bnd.models.ModelsScannerPlugin</_plugin>
+                        <_plugin>
+                            <!-- Enable registration of Sling Models classes via bnd plugin -->
+                            org.apache.sling.bnd.models.ModelsScannerPlugin,
+                            <!-- Generate bundle header containing all configuration annotation classes -->
+                            org.apache.sling.caconfig.bndplugin.ConfigurationClassScannerPlugin
+                        </_plugin>
                         <!-- Enable processing of OSGI DS component annotations -->
                         <_dsannotations>*</_dsannotations>
                         <!-- Enable processing of OSGI metatype annotations -->
@@ -75,6 +79,11 @@
                         <groupId>org.apache.sling</groupId>
                         <artifactId>org.apache.sling.bnd.models</artifactId>
                         <version>1.0.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.sling</groupId>
+                        <artifactId>org.apache.sling.caconfig.bnd-plugin</artifactId>
+                        <version>1.0.2</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/DataLayerConfig.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/DataLayerConfig.java
@@ -21,7 +21,7 @@ import org.apache.sling.caconfig.annotation.Property;
 /**
  * Context Aware Configuration Class of the Data Layer
  */
-@Configuration(label="Data Layer Context Aware Configuration")
+@Configuration(label="Data Layer", description="Configure support for Adobe Client Data Layer")
 public @interface DataLayerConfig {
 
     /**


### PR DESCRIPTION
Fixes #1043
Ensure bundle header are set for caconfig configuration classes
Improve the title and description for DataLayerConfig