### PR TITLE
Issue/1045: Simplify and improve ListImpl performance

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImpl.java
@@ -194,7 +194,7 @@ public class ListImpl extends AbstractComponentImpl implements List {
     @Deprecated
     public Collection<Page> getItems() {
         if (listItems == null) {
-            this.listItems = getListItems(getListType());
+            this.listItems = getPages();
         }
         return listItems;
     }
@@ -236,7 +236,7 @@ public class ListImpl extends AbstractComponentImpl implements List {
      * @return The list type.
      */
     @NotNull
-    protected Source getListType() {
+    private Source getListType() {
         // Note: this can be done a lot cleaner in JDK 11.
         return Optional.ofNullable(
             // get the source from the properties
@@ -251,15 +251,14 @@ public class ListImpl extends AbstractComponentImpl implements List {
     }
 
     /**
-     * Get the list of pages for the given list type.
+     * Get the list of pages.
      *
-     * @param listType The list type.
      * @return The list of pages.
      */
-    protected java.util.List<Page> getListItems(Source listType) {
+    protected java.util.List<Page> getPages() {
         // get the list item stream
         Stream<Page> itemStream;
-        switch (listType) {
+        switch (getListType()) {
             case STATIC:
                 itemStream = getStaticListItems();
                 break;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImpl.java
@@ -16,130 +16,185 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.io.Serializable;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.PostConstruct;
 import javax.jcr.RepositoryException;
 
+import com.day.cq.search.result.SearchResult;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.models.List;
-import com.day.cq.commons.RangeIterator;
 import com.day.cq.search.Predicate;
 import com.day.cq.search.SimpleSearch;
-import com.day.cq.search.result.Hit;
-import com.day.cq.search.result.SearchResult;
 import com.day.cq.tagging.TagManager;
 import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.api.Page;
-import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.designer.Style;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * List model implementation.
+ */
 @Model(adaptables = SlingHttpServletRequest.class, adapters = {List.class, ComponentExporter.class}, resourceType = ListImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class ListImpl extends AbstractComponentImpl implements List {
 
+    /**
+     * The resource type.
+     */
     protected static final String RESOURCE_TYPE = "core/wcm/components/list/v1/list";
 
+    /**
+     * Standard logger.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(ListImpl.class);
 
-    private static final int LIMIT_DEFAULT = 100;
+    /**
+     * Property name for the maximum search results if the source type is search.
+     * Note: this is not the maximum number of list items returned.
+     */
+    private static final String PN_SEARCH_LIMIT = "limit";
+
+    /**
+     * Max items property name.
+     */
+    private static final String PN_MAX_ITEMS = "maxItems";
+
+    /**
+     * Children depth property name (only used if the source type is children).
+     */
+    private static final String PN_CHILD_DEPTH = "childDepth";
+
+    /**
+     * Search query property name.
+     */
+    private static final String PN_SEARCH_QUERY = "query";
+
+    /**
+     * Default flag indicating if the description should be shown.
+     */
     private static final boolean SHOW_DESCRIPTION_DEFAULT = false;
+
+    /**
+     * Default flag indicating if the date should be shown.
+     */
     private static final boolean SHOW_MODIFICATION_DATE_DEFAULT = false;
+
+    /**
+     * Default flag indicating if list items should be linked.
+     */
     private static final boolean LINK_ITEMS_DEFAULT = false;
-    private static final int PN_DEPTH_DEFAULT = 1;
-    private static final String PN_DATE_FORMAT_DEFAULT = "yyyy-MM-dd";
+
+    /**
+     * The default maximum search results if the source type is search.
+     * Note: this is not the maximum number of list items returned.
+     */
+    private static final int SEARCH_LIMIT_DEFAULT = 100;
+
+    /**
+     * Default children depth if the source type is children.
+     */
+    private static final int CHILD_DEPTH_DEFAULT = 1;
+
+    /**
+     * Default date format.
+     */
+    private static final String DATE_FORMAT_DEFAULT = "yyyy-MM-dd";
+
+    /**
+     * Default tag match requirement.
+     */
     private static final String TAGS_MATCH_ANY_VALUE = "any";
 
+    /**
+     * Max items default.
+     */
+    private static final int MAX_ITEMS_DEFAULT = 0;
+
+    /**
+     * Component properties.
+     */
     @ScriptVariable
     private ValueMap properties;
 
+    /**
+     * The current style.
+     */
     @ScriptVariable
     private Style currentStyle;
 
+    /**
+     * The current page.
+     */
     @ScriptVariable
     private Page currentPage;
 
-    @SlingObject
-    private ResourceResolver resourceResolver;
-
-    @Self
-    private SlingHttpServletRequest request;
-
-    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
-    @Default(intValues = LIMIT_DEFAULT)
-    private int limit;
-
-    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
-    @Default(intValues = PN_DEPTH_DEFAULT)
-    private int childDepth;
-
-    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
-    @Default(values = StringUtils.EMPTY)
-    private String query;
-
-    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
-    @Default(intValues = 0)
-    private int maxItems;
-
-    private String startIn;
-    private SortOrder sortOrder;
-    private OrderBy orderBy;
+    /**
+     * Date format string.
+     */
     private String dateFormatString;
 
+    /**
+     * Flag indicating if description should be shown.
+     */
     private boolean showDescription;
+
+    /**
+     * Flag indicating if modification date should be shown.
+     */
     private boolean showModificationDate;
+
+    /**
+     * Flag indicating if items should be linked.
+     */
     private boolean linkItems;
 
-    private PageManager pageManager;
-    protected java.util.List<Page> listItems;
+    /**
+     * The list items.
+     */
+    private java.util.List<Page> listItems;
 
+    /**
+     * Initialize the model.
+     */
     @PostConstruct
     private void initModel() {
-        pageManager = resourceResolver.adaptTo(PageManager.class);
-        readProperties();
-    }
-
-    private void readProperties() {
-        // read edit config properties
-        startIn = properties.get(PN_SEARCH_IN, currentPage.getPath());
-        sortOrder = SortOrder.fromString(properties.get(PN_SORT_ORDER, SortOrder.ASC.value));
-        orderBy = OrderBy.fromString(properties.get(PN_ORDER_BY, StringUtils.EMPTY));
-
         // read design config properties
         showDescription = properties.get(PN_SHOW_DESCRIPTION, currentStyle.get(PN_SHOW_DESCRIPTION, SHOW_DESCRIPTION_DEFAULT));
         showModificationDate = properties.get(
-                PN_SHOW_MODIFICATION_DATE, currentStyle.get(PN_SHOW_MODIFICATION_DATE, SHOW_MODIFICATION_DATE_DEFAULT));
+            PN_SHOW_MODIFICATION_DATE, currentStyle.get(PN_SHOW_MODIFICATION_DATE, SHOW_MODIFICATION_DATE_DEFAULT));
         linkItems = properties.get(PN_LINK_ITEMS, currentStyle.get(PN_LINK_ITEMS, LINK_ITEMS_DEFAULT));
-        dateFormatString = properties.get(PN_DATE_FORMAT, currentStyle.get(PN_DATE_FORMAT, PN_DATE_FORMAT_DEFAULT));
-
+        dateFormatString = properties.get(PN_DATE_FORMAT, currentStyle.get(PN_DATE_FORMAT, DATE_FORMAT_DEFAULT));
     }
 
     @Override
     @Deprecated
     public Collection<Page> getItems() {
         if (listItems == null) {
-            Source listType = getListType();
-            populateListItems(listType);
+            this.listItems = getListItems(getListType());
         }
         return listItems;
     }
@@ -173,142 +228,212 @@ public class ListImpl extends AbstractComponentImpl implements List {
         return resource.getResourceType();
     }
 
+    /**
+     * Get the list source.
+     * The list source will be determined from the component properties, or the style policy if not present in the
+     * component properties.
+     *
+     * @return The list type.
+     */
+    @NotNull
     protected Source getListType() {
-        String listFromValue = properties.get(PN_SOURCE, currentStyle.get(PN_SOURCE, StringUtils.EMPTY));
-        return Source.fromString(listFromValue);
+        // Note: this can be done a lot cleaner in JDK 11.
+        return Optional.ofNullable(
+            // get the source from the properties
+            Optional.ofNullable(properties.get(PN_SOURCE, String.class))
+                // or get it from the style
+                .orElseGet(() -> Optional.ofNullable(currentStyle.get(PN_SOURCE, String.class))
+                    .orElse(null)))
+            // convert the value to a source enum
+            .map(Source::fromString)
+            // default to empty if no value is found
+            .orElse(Source.EMPTY);
     }
 
-    protected void populateListItems(Source listType) {
+    /**
+     * Get the list of pages for the given list type.
+     *
+     * @param listType The list type.
+     * @return The list of pages.
+     */
+    protected java.util.List<Page> getListItems(Source listType) {
+        // get the list item stream
+        Stream<Page> itemStream;
         switch (listType) {
             case STATIC:
-                populateStaticListItems();
+                itemStream = getStaticListItems();
                 break;
             case CHILDREN:
-                populateChildListItems();
+                itemStream = getChildListItems();
                 break;
             case TAGS:
-                populateTagListItems();
+                itemStream = getTagListItems();
                 break;
             case SEARCH:
-                populateSearchListItems();
+                itemStream = getSearchListItems();
                 break;
             default:
-                listItems = new ArrayList<>();
+                itemStream = Stream.empty();
                 break;
         }
-        sortListItems();
-        setMaxItems();
-    }
 
-
-    private void populateStaticListItems() {
-        listItems = new ArrayList<>();
-        String[] pagesPaths = properties.get(PN_PAGES, new String[0]);
-        for (String path : pagesPaths) {
-            Page page = pageManager.getContainingPage(path);
-            if (page != null) {
-                listItems.add(page);
-            }
+        // order the results
+        OrderBy orderBy = OrderBy.fromString(properties.get(PN_ORDER_BY, StringUtils.EMPTY));
+        if (orderBy != null) {
+            SortOrder sortOrder = SortOrder.fromString(properties.get(PN_SORT_ORDER, SortOrder.ASC.value));
+            itemStream = itemStream.sorted(new ListSort(orderBy, sortOrder));
         }
-    }
 
-    private void populateChildListItems() {
-        listItems = new ArrayList<>();
-        Page rootPage = getRootPage(PN_PARENT_PAGE);
-        if (rootPage != null) {
-            collectChildren(rootPage.getDepth(), rootPage);
+        int maxItems = properties.get(PN_MAX_ITEMS, MAX_ITEMS_DEFAULT);
+        // limit the results
+        if (maxItems != 0) {
+            itemStream = itemStream.limit(maxItems);
         }
+
+        // collect the results
+        return itemStream.collect(Collectors.toList());
     }
 
-    private void collectChildren(int startLevel, Page parent) {
+
+    /**
+     * Get the list items if using a static source.
+     *
+     * @return The static list items.
+     */
+    private Stream<Page> getStaticListItems() {
+        return Arrays.stream(this.properties.get(PN_PAGES, new String[0]))
+            .map(this.currentPage.getPageManager()::getContainingPage)
+            .filter(Objects::nonNull);
+    }
+
+    /**
+     * Get the list items if using children source.
+     *
+     * @return The child list items.
+     */
+    private Stream<Page> getChildListItems() {
+        int childDepth = properties.get(PN_CHILD_DEPTH, CHILD_DEPTH_DEFAULT);
+        return getRootPage(PN_PARENT_PAGE)
+            .map(rootPage -> collectChildren(childDepth, rootPage))
+            .orElseGet(Stream::empty);
+    }
+
+    /**
+     * Get a stream of all children of the specified parent page not deeper than the specified max depth.
+     * This call is recursive and expects that the caller uses startLevel = parent.getDepth().
+     *
+     * @param depth  The number of levels under the root page to be included.
+     * @param parent The root page.
+     * @return Stream of all children of the specified parent that are not deeper than the end level.
+     */
+    private static Stream<Page> collectChildren(int depth, @NotNull final Page parent) {
+        if (depth <= 0) {
+            return Stream.empty();
+        }
         Iterator<Page> childIterator = parent.listChildren();
-        while (childIterator.hasNext()) {
-            Page child = childIterator.next();
-            listItems.add(child);
-            if (child.getDepth() - startLevel < childDepth) {
-                collectChildren(startLevel, child);
-            }
-        }
+        return StreamSupport.stream(((Iterable<Page>) () -> childIterator).spliterator(), false)
+            .flatMap(child -> Stream.concat(Stream.of(child), collectChildren(depth - 1, child)));
     }
 
-    private void populateTagListItems() {
-        listItems = new ArrayList<>();
-        String[] tags = properties.get(PN_TAGS, new String[0]);
+    /**
+     * Get the list items if using tag source.
+     *
+     * @return The tag list items.
+     */
+    private Stream<Page> getTagListItems() {
         boolean matchAny = properties.get(PN_TAGS_MATCH, TAGS_MATCH_ANY_VALUE).equals(TAGS_MATCH_ANY_VALUE);
-        if (ArrayUtils.isNotEmpty(tags)) {
-            Page rootPage = getRootPage(PN_TAGS_PARENT_PAGE);
-            if (rootPage != null) {
-                TagManager tagManager = resourceResolver.adaptTo(TagManager.class);
-                if (tagManager != null) {
-                    RangeIterator<Resource> resourceRangeIterator = tagManager.find(rootPage.getPath(), tags, matchAny);
-                    if (resourceRangeIterator != null) {
-                        while (resourceRangeIterator.hasNext()) {
-                            Page containingPage = pageManager.getContainingPage(resourceRangeIterator.next());
-                            if (containingPage != null) {
-                                listItems.add(containingPage);
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        return Optional.ofNullable(properties.get(PN_TAGS, String[].class))
+            // only continue if there are tags
+            .filter(ArrayUtils::isNotEmpty)
+            // get the root page
+            .flatMap(tags -> getRootPage(PN_TAGS_PARENT_PAGE)
+                .flatMap(rootPage ->
+                    // get the tag manager
+                    Optional.ofNullable(resource.getResourceResolver().adaptTo(TagManager.class))
+                        // find content tagged with the tags
+                        .map(tagManager -> tagManager.find(rootPage.getPath(), tags, matchAny))
+                        // convert the hits into pages
+                        .map(iterator -> StreamSupport.stream(((Iterable<Resource>) () -> iterator).spliterator(), false)
+                            .map(currentPage.getPageManager()::getContainingPage)
+                            .filter(Objects::nonNull))))
+            .orElseGet(Stream::empty);
     }
 
-    private void populateSearchListItems() {
-        listItems = new ArrayList<>();
-        if (!StringUtils.isBlank(query)) {
+    /**
+     * Get the list items if using the search source type.
+     *
+     * @return The search list items.
+     */
+    private Stream<Page> getSearchListItems() {
+        Optional<Page> searchRoot = getRootPage(PN_SEARCH_IN);
+        String query = properties.get(PN_SEARCH_QUERY, String.class);
+
+        if (!StringUtils.isBlank(query) && searchRoot.isPresent()) {
             SimpleSearch search = resource.adaptTo(SimpleSearch.class);
             if (search != null) {
                 search.setQuery(query);
-                search.setSearchIn(startIn);
+                search.setSearchIn(searchRoot.get().getPath());
                 search.addPredicate(new Predicate("type", "type").set("type", NameConstants.NT_PAGE));
+                int limit = properties.get(PN_SEARCH_LIMIT, SEARCH_LIMIT_DEFAULT);
                 search.setHitsPerPage(limit);
-                try {
-                    collectSearchResults(search.getResult());
-                } catch (RepositoryException e) {
-                    LOGGER.error("Unable to retrieve search results for query.", e);
-                }
+                return safeGetSearchResult(search)
+                    .map(SearchResult::getResources)
+                    .map(it -> (Iterable<Resource>) () -> it)
+                    .map(it -> StreamSupport.stream(it.spliterator(), false))
+                    .orElseGet(Stream::empty)
+                    .filter(Objects::nonNull)
+                    .map(currentPage.getPageManager()::getContainingPage)
+                    .filter(Objects::nonNull);
             }
         }
+        return Stream.empty();
     }
 
-    private void collectSearchResults(SearchResult result) throws RepositoryException {
-        for (Hit hit : result.getHits()) {
-            Page containingPage = pageManager.getContainingPage(hit.getResource());
-            if (containingPage != null) {
-                listItems.add(containingPage);
-            }
+    /**
+     * Gets the search result, or empty if an exception occurs.
+     *
+     * @param search The search for which to get the results.
+     * @return The search result, or empty if {@link RepositoryException} occurs.
+     */
+    @NotNull
+    private Optional<SearchResult> safeGetSearchResult(@NotNull final SimpleSearch search) {
+        try {
+            return Optional.of(search.getResult());
+        } catch (RepositoryException e) {
+            LOGGER.error("Unable to retrieve search results for query.", e);
         }
+        return Optional.empty();
     }
 
-    private void sortListItems() {
-        if (orderBy != null) {
-            listItems.sort(new ListSort(orderBy, sortOrder));
+    /**
+     * Get the root page.
+     *
+     * The root page is the page referenced by the fieldName property, or the current page if the fieldName property
+     * is not set or is blank. This function will return empty only if the fieldName property is set, but the referenced
+     * page does not exist.
+     *
+     * @param fieldName The name of the property containing the path of the root page.
+     * @return The root page, or empty if the page does not exist.
+     */
+    @NotNull
+    private Optional<Page> getRootPage(@NotNull final String fieldName) {
+        Optional<String> parentPath = Optional.ofNullable(this.properties.get(fieldName, String.class))
+            .filter(StringUtils::isNotBlank);
+
+        // no path is specified, use current page
+        if (!parentPath.isPresent()) {
+            return Optional.of(this.currentPage);
         }
+
+        // a path is specified, get that page or return null
+        return parentPath
+            .map(resource.getResourceResolver()::getResource)
+            .map(currentPage.getPageManager()::getContainingPage);
     }
 
-    private void setMaxItems() {
-        if (maxItems != 0) {
-            java.util.List<Page> tmpListItems = new ArrayList<>();
-            for (Page item : listItems) {
-                if (tmpListItems.size() < maxItems) {
-                    tmpListItems.add(item);
-                } else {
-                    break;
-                }
-            }
-            listItems = tmpListItems;
-        }
-    }
-
-    private Page getRootPage(String fieldName) {
-        String parentPath = properties.get(fieldName, currentPage.getPath());
-        if (StringUtils.isBlank(parentPath)) {
-            parentPath = currentPage.getPath();
-        }
-        return pageManager.getContainingPage(resourceResolver.getResource(parentPath));
-    }
-
+    /**
+     * Sources.
+     */
     protected enum Source {
         CHILDREN("children"),
         STATIC("static"),
@@ -316,12 +441,19 @@ public class ListImpl extends AbstractComponentImpl implements List {
         TAGS("tags"),
         EMPTY(StringUtils.EMPTY);
 
-        private String value;
+        private final String value;
 
         Source(String value) {
             this.value = value;
         }
 
+        /**
+         * Get the source from the string value.
+         *
+         * @param value The value.
+         * @return The source if it exists, or null if no source has a matching value.
+         */
+        @Nullable
         public static Source fromString(String value) {
             for (Source s : values()) {
                 if (StringUtils.equals(value, s.value)) {
@@ -332,16 +464,33 @@ public class ListImpl extends AbstractComponentImpl implements List {
         }
     }
 
+    /**
+     * Sort orders.
+     */
     private enum SortOrder {
+        /**
+         * Ascending.
+         */
         ASC("asc"),
+
+        /**
+         * Descending.
+         */
         DESC("desc");
 
-        private String value;
+        private final String value;
 
         SortOrder(String value) {
             this.value = value;
         }
 
+        /**
+         * Get the sort order from string value.
+         *
+         * @param value The string value.
+         * @return The sort order, or ascending if not found.
+         */
+        @NotNull
         public static SortOrder fromString(String value) {
             for (SortOrder s : values()) {
                 if (StringUtils.equals(value, s.value)) {
@@ -352,16 +501,33 @@ public class ListImpl extends AbstractComponentImpl implements List {
         }
     }
 
+    /**
+     * Order by options.
+     */
     private enum OrderBy {
+        /**
+         * Order by page title.
+         */
         TITLE("title"),
+
+        /**
+         * Order by last modified date.
+         */
         MODIFIED("modified");
 
-        private String value;
+        private final String value;
 
         OrderBy(String value) {
             this.value = value;
         }
 
+        /**
+         * Get the order by from string value.
+         *
+         * @param value The string value.
+         * @return The order by field, or null if not found.
+         */
+        @Nullable
         public static OrderBy fromString(String value) {
             for (OrderBy s : values()) {
                 if (StringUtils.equals(value, s.value)) {
@@ -372,20 +538,32 @@ public class ListImpl extends AbstractComponentImpl implements List {
         }
     }
 
+    /**
+     * Comparator for sorting pages.
+     */
     private static class ListSort implements Comparator<Page>, Serializable {
 
-
         private static final long serialVersionUID = 204096578105548876L;
-        private SortOrder sortOrder;
-        private OrderBy orderBy;
 
-        ListSort(OrderBy orderBy, SortOrder sortOrder) {
+        /**
+         * The sort order
+         */
+        @Nullable
+        private final SortOrder sortOrder;
+
+        /**
+         * The order by field.
+         */
+        @Nullable
+        private final OrderBy orderBy;
+
+        ListSort(@Nullable final OrderBy orderBy, @Nullable final SortOrder sortOrder) {
             this.orderBy = orderBy;
             this.sortOrder = sortOrder;
         }
 
         @Override
-        public int compare(Page item1, Page item2) {
+        public int compare(final Page item1, final Page item2) {
             int i = 0;
             if (orderBy == OrderBy.MODIFIED) {
                 // getLastModified may return null, define null to be after nonnull values

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ListImpl.java
@@ -15,8 +15,9 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v2;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Exporter;
@@ -29,7 +30,6 @@ import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.internal.models.v1.PageListItemImpl;
 import com.adobe.cq.wcm.core.components.models.List;
 import com.adobe.cq.wcm.core.components.models.ListItem;
-import com.day.cq.wcm.api.Page;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Model(adaptables = SlingHttpServletRequest.class, adapters = {List.class, ComponentExporter.class}, resourceType = ListImpl.RESOURCE_TYPE)
@@ -41,25 +41,21 @@ public class ListImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     @Self
     private SlingHttpServletRequest request;
 
+    /**
+     * Result list.
+     */
+    private Collection<ListItem> listItems;
+
     @Override
     @NotNull
     @JsonProperty("items")
     public Collection<ListItem> getListItems() {
-        Collection<ListItem> listItems = new ArrayList<>();
-        Collection<Page> pages = getPages();
-        for (Page page : pages) {
-            if (page != null) {
-                listItems.add(new PageListItemImpl(request, page, getId(), PageListItemImpl.PROP_DISABLE_SHADOWING_DEFAULT));
-            }
+        if (this.listItems == null) {
+            this.listItems = super.getListItems(getListType()).stream()
+                .filter(Objects::nonNull)
+                .map(page -> new PageListItemImpl(request, page, getId(), PageListItemImpl.PROP_DISABLE_SHADOWING_DEFAULT))
+                .collect(Collectors.toList());
         }
-        return listItems;
-    }
-
-    private Collection<Page> getPages() {
-        if (listItems == null) {
-            Source listType = getListType();
-            populateListItems(listType);
-        }
-        return listItems;
+        return this.listItems;
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ListImpl.java
@@ -51,7 +51,7 @@ public class ListImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     @JsonProperty("items")
     public Collection<ListItem> getListItems() {
         if (this.listItems == null) {
-            this.listItems = super.getListItems(getListType()).stream()
+            this.listItems = super.getPages().stream()
                 .filter(Objects::nonNull)
                 .map(page -> new PageListItemImpl(request, page, getId(), PageListItemImpl.PROP_DISABLE_SHADOWING_DEFAULT))
                 .collect(Collectors.toList());

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
@@ -38,6 +38,7 @@ import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.designer.Style;
 import io.wcm.testing.mock.aem.junit.AemContext;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -131,48 +132,48 @@ public class ListImplTest {
     @Test
     public void testOrderBy() {
         List list = getListUnderTest(LIST_7);
-        checkListConsistency(list, new String[]{"Page 1", "Page 2"});
+        checkListConsistencyByTitle(list, new String[]{"Page 1", "Page 2"});
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_7));
     }
 
     @Test
     public void testOrderDescBy() {
         List list = getListUnderTest(LIST_8);
-        checkListConsistency(list, new String[]{"Page 2", "Page 1"});
+        checkListConsistencyByTitle(list, new String[]{"Page 2", "Page 1"});
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_8));
     }
 
     @Test
     public void testOrderByModificationDate() {
         List list = getListUnderTest(LIST_9);
-        checkListConsistency(list, new String[]{"Page 2", "Page 1"});
+        checkListConsistencyByTitle(list, new String[]{"Page 2", "Page 1"});
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_9));
     }
 
     @Test
     public void testOrderByModificationDateDesc() {
         List list = getListUnderTest(LIST_10);
-        checkListConsistency(list, new String[]{"Page 1", "Page 2"});
+        checkListConsistencyByTitle(list, new String[]{"Page 1", "Page 2"});
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_10));
     }
 
     @Test
     public void testMaxItems() {
         List list = getListUnderTest(LIST_11);
-        checkListConsistency(list, new String[]{"Page 1"});
+        checkListConsistencyByTitle(list, new String[]{"Page 1"});
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_11));
     }
 
     @Test
     public void testOrderByModificationDateWithNoModificationDate() {
         List list = getListUnderTest(LIST_12);
-        checkListConsistency(list, new String[]{"Page 1.1", "Page 1.2"});
+        checkListConsistencyByTitle(list, new String[]{"Page 1.1", "Page 1.2"});
     }
 
     @Test
     public void testOrderByModificationDateWithNoModificationDateForOneItem() {
         List list = getListUnderTest(LIST_13);
-        checkListConsistency(list, new String[]{"Page 2", "Page 1", "Page 1.2"});
+        checkListConsistencyByTitle(list, new String[]{"Page 2", "Page 1", "Page 1.2"});
     }
 
     @Test
@@ -209,21 +210,11 @@ public class ListImplTest {
         return request.adaptTo(List.class);
     }
 
-    private void checkListConsistency(List list, String[] expectedPages) {
-        assertTrue("Expected that the returned list will contain " + expectedPages.length + " items",
-                list.getItems().size() == expectedPages.length);
-        int index = 0;
-        for (Page item : list.getItems()) {
-            assertEquals(expectedPages[index++], item.getTitle());
-        }
+    private void checkListConsistencyByTitle(List list, String[] expectedPageTitles) {
+        assertArrayEquals(expectedPageTitles, list.getItems().stream().map(Page::getTitle).toArray());
     }
 
     private void checkListConsistencyByPaths(List list, String[] expectedPagePaths) {
-        assertTrue("Expected that the returned list will contain " + expectedPagePaths.length + " items",
-                list.getItems().size() == expectedPagePaths.length);
-        int index = 0;
-        for (Page item : list.getItems()) {
-            assertEquals(expectedPagePaths[index++], item.getPath());
-        }
+        assertArrayEquals(expectedPagePaths, list.getItems().stream().map(Page::getPath).toArray());
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
@@ -16,6 +16,7 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.Collections;
+import java.util.Objects;
 
 import javax.jcr.Session;
 
@@ -32,7 +33,6 @@ import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.List;
 import com.day.cq.search.SimpleSearch;
-import com.day.cq.search.result.Hit;
 import com.day.cq.search.result.SearchResult;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.designer.Style;
@@ -129,12 +129,12 @@ public class ListImplTest {
         CONTEXT.registerAdapter(ResourceResolver.class, Session.class, mockSession);
         CONTEXT.registerAdapter(Resource.class, SimpleSearch.class, mockSimpleSearch);
         SearchResult searchResult = mock(SearchResult.class);
-        Hit hit = mock(Hit.class);
 
         when(mockSimpleSearch.getResult()).thenReturn(searchResult);
-        when(searchResult.getHits()).thenReturn(Collections.singletonList(hit));
-        Resource contentResource = CONTEXT.resourceResolver().getResource("/content/list/pages/page_1/jcr:content");
-        when(hit.getResource()).thenReturn(contentResource);
+        when(searchResult.getResources()).thenReturn(
+            Collections.singletonList(Objects.requireNonNull(
+                CONTEXT.resourceResolver().getResource("/content/list/pages/page_1/jcr:content")))
+                .iterator());
 
         List list = getListUnderTest(LIST_6);
         checkListConsistencyByPaths(list, new String[]{"/content/list/pages/page_1"});

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
@@ -39,7 +39,6 @@ import com.day.cq.wcm.api.designer.Style;
 import io.wcm.testing.mock.aem.junit.AemContext;
 
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -85,28 +84,41 @@ public class ListImplTest {
     @Test
     public void testStaticListType() {
         List list = getListUnderTest(LIST_2);
-        assertEquals(2, list.getItems().size());
+        checkListConsistencyByPaths(list, new String[]{
+            "/content/list/pages/page_1",
+            "/content/list/pages/page_2",
+        });
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_2));
     }
 
     @Test
     public void testChildrenListType() {
         List list = getListUnderTest(LIST_3);
-        assertEquals(3, list.getItems().size());
+        checkListConsistencyByPaths(list, new String[]{
+            "/content/list/pages/page_1/page_1_1",
+            "/content/list/pages/page_1/page_1_2",
+            "/content/list/pages/page_1/page_1_3",
+        });
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_3));
     }
 
     @Test
     public void testChildrenListTypeWithDepth() {
         List list = getListUnderTest(LIST_4);
-        assertEquals(4, list.getItems().size());
+        checkListConsistencyByPaths(list, new String[]{
+            "/content/list/pages/page_1/page_1_1",
+            "/content/list/pages/page_1/page_1_2",
+            "/content/list/pages/page_1/page_1_2/page_1_2_1",
+            "/content/list/pages/page_1/page_1_3",
+
+        });
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_4));
     }
 
     @Test
     public void testTagsListType() {
         List list = getListUnderTest(LIST_5);
-        assertEquals(1, list.getItems().size());
+        checkListConsistencyByPaths(list, new String[]{"/content/list/pages/page_1/page_1_3"});
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_5));
     }
 
@@ -125,7 +137,7 @@ public class ListImplTest {
         when(hit.getResource()).thenReturn(contentResource);
 
         List list = getListUnderTest(LIST_6);
-        assertEquals(1, list.getItems().size());
+        checkListConsistencyByPaths(list, new String[]{"/content/list/pages/page_1"});
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_6));
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
@@ -40,7 +40,7 @@ import io.wcm.testing.mock.aem.junit.AemContext;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
@@ -68,12 +68,12 @@ public class ListImplTest {
     public static final AemContext CONTEXT = CoreComponentTestContext.createContext(TEST_BASE, "/content/list");
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         CONTEXT.load().json("/list/test-etc.json", "/etc/tags/list");
     }
 
     @Test
-    public void testProperties() throws Exception {
+    public void testProperties() {
         List list = getListUnderTest(LIST_1);
         assertTrue(list.showDescription());
         assertTrue(list.showModificationDate());
@@ -89,21 +89,21 @@ public class ListImplTest {
     }
 
     @Test
-    public void testChildrenListType() throws Exception {
+    public void testChildrenListType() {
         List list = getListUnderTest(LIST_3);
         assertEquals(3, list.getItems().size());
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_3));
     }
 
     @Test
-    public void testChildrenListTypeWithDepth() throws Exception {
+    public void testChildrenListTypeWithDepth() {
         List list = getListUnderTest(LIST_4);
         assertEquals(4, list.getItems().size());
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_4));
     }
 
     @Test
-    public void testTagsListType() throws Exception {
+    public void testTagsListType() {
         List list = getListUnderTest(LIST_5);
         assertEquals(1, list.getItems().size());
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_5));
@@ -129,60 +129,60 @@ public class ListImplTest {
     }
 
     @Test
-    public void testOrderBy() throws Exception {
+    public void testOrderBy() {
         List list = getListUnderTest(LIST_7);
         checkListConsistency(list, new String[]{"Page 1", "Page 2"});
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_7));
     }
 
     @Test
-    public void testOrderDescBy() throws Exception {
+    public void testOrderDescBy() {
         List list = getListUnderTest(LIST_8);
         checkListConsistency(list, new String[]{"Page 2", "Page 1"});
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_8));
     }
 
     @Test
-    public void testOrderByModificationDate() throws Exception {
+    public void testOrderByModificationDate() {
         List list = getListUnderTest(LIST_9);
         checkListConsistency(list, new String[]{"Page 2", "Page 1"});
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_9));
     }
 
     @Test
-    public void testOrderByModificationDateDesc() throws Exception {
+    public void testOrderByModificationDateDesc() {
         List list = getListUnderTest(LIST_10);
         checkListConsistency(list, new String[]{"Page 1", "Page 2"});
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_10));
     }
 
     @Test
-    public void testMaxItems() throws Exception {
+    public void testMaxItems() {
         List list = getListUnderTest(LIST_11);
         checkListConsistency(list, new String[]{"Page 1"});
         Utils.testJSONExport(list, Utils.getTestExporterJSONPath(TEST_BASE, LIST_11));
     }
 
     @Test
-    public void testOrderByModificationDateWithNoModificationDate() throws Exception {
+    public void testOrderByModificationDateWithNoModificationDate() {
         List list = getListUnderTest(LIST_12);
         checkListConsistency(list, new String[]{"Page 1.1", "Page 1.2"});
     }
 
     @Test
-    public void testOrderByModificationDateWithNoModificationDateForOneItem() throws Exception {
+    public void testOrderByModificationDateWithNoModificationDateForOneItem() {
         List list = getListUnderTest(LIST_13);
         checkListConsistency(list, new String[]{"Page 2", "Page 1", "Page 1.2"});
     }
 
     @Test
-    public void testOrderByTitleWithNoTitle() throws Exception {
+    public void testOrderByTitleWithNoTitle() {
         List list = getListUnderTest(LIST_14);
         checkListConsistencyByPaths(list, new String[]{"/content/list/pages/page_3", "/content/list/pages/page_4"});
     }
 
     @Test
-    public void testOrderByTitleWithNoTitleForOneItem() throws Exception {
+    public void testOrderByTitleWithNoTitleForOneItem() {
         List list = getListUnderTest(LIST_15);
         checkListConsistencyByPaths(list, new String[]{"/content/list/pages/page_1", "/content/list/pages/page_2", "/content/list/pages/page_4"});
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentMockAdapter.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentMockAdapter.java
@@ -48,7 +48,7 @@ import static com.day.cq.commons.jcr.JcrConstants.JCR_TITLE;
 import static com.day.cq.dam.api.DamConstants.NT_DAM_ASSET;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ListImplTest.java
@@ -31,7 +31,7 @@ import io.wcm.testing.mock.aem.junit.AemContext;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ListImplTest.java
@@ -46,12 +46,12 @@ public class ListImplTest {
     public static final AemContext CONTEXT = CoreComponentTestContext.createContext(TEST_BASE, "/content/list");
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         CONTEXT.load().json("/list/test-etc.json", "/etc/tags/list");
     }
 
     @Test
-    public void testProperties() throws Exception {
+    public void testProperties() {
         List list = getListUnderTest(LIST_1);
         assertTrue(list.showDescription());
         assertTrue(list.showModificationDate());

--- a/testing/junit/core/src/main/java/com/adobe/cq/wcm/core/components/testing/MockExternalizerFactory.java
+++ b/testing/junit/core/src/main/java/com/adobe/cq/wcm/core/components/testing/MockExternalizerFactory.java
@@ -19,8 +19,8 @@ import org.apache.sling.api.resource.ResourceResolver;
 
 import com.day.cq.commons.Externalizer;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1045
| Patch: Bug Fix?          |  yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

- Cleans up `ListImpl` tests
- Improves `ListImpl` tests to test the items and orders of results instead of just the number of results
- Removes/replaces use of deprecated `Matchers.any()` across the project
- Refactors `ListImpl` to eliminate "populate" methods and clarify the flow of how the `listItems` filed is initialized
- Refactors `ListItem` source result getters (previously the "populate" methods) so that they return a stream of results that are lazy-loading where possible so that large traversals are reduced
- Adds javadocs to private/protected methods and fields that are not present in the interface
- Does not change the behaviour or functionality of the List component

