### PR TITLE
[List] Use local-sensitive collator when sorting by title #1055

### DIFF
--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
@@ -63,6 +63,7 @@ public class ListImplTest {
     private static final String LIST_13 = "/content/list/listTypes/staticOrderByModificationDateListTypeWithNoModificationDateForOneItem";
     private static final String LIST_14 = "/content/list/listTypes/staticOrderByTitleListTypeWithNoTitle";
     private static final String LIST_15 = "/content/list/listTypes/staticOrderByTitleListTypeWithNoTitleForOneItem";
+    private static final String LIST_16 = "/content/list/listTypes/staticOrderByTitleListTypeWithAccent";
 
     @ClassRule
     public static final AemContext CONTEXT = CoreComponentTestContext.createContext(TEST_BASE, "/content/list");
@@ -198,6 +199,12 @@ public class ListImplTest {
     public void testOrderByTitleWithNoTitleForOneItem() {
         List list = getListUnderTest(LIST_15);
         checkListConsistencyByPaths(list, new String[]{"/content/list/pages/page_1", "/content/list/pages/page_2", "/content/list/pages/page_4"});
+    }
+
+    @Test
+    public void testOrderByTitleWithAccent() {
+        List list = getListUnderTest(LIST_16);
+        checkListConsistencyByPaths(list, new String[]{"/content/list/pages/page_1", "/content/list/pages/page_5", "/content/list/pages/page_2"});
     }
 
     private List getListUnderTest(String resourcePath) {

--- a/bundles/core/src/test/resources/list/test-content.json
+++ b/bundles/core/src/test/resources/list/test-content.json
@@ -77,6 +77,21 @@
                 "/content/list/pages/page_2"
             ]
         },
+        "staticOrderByTitleListTypeWithAccent": {
+            "jcr:primaryType"     : "nt:unstructured",
+            "sling:resourceType"  : "core/wcm/components/list",
+            "listFrom"            : "static",
+            "showThumbnail"       : "true",
+            "linkItems"           : "true",
+            "showDescription"     : "true",
+            "showModificationDate": "true",
+            "orderBy"             : "title",
+            "pages"               : [
+                "/content/list/pages/page_1",
+                "/content/list/pages/page_5",
+                "/content/list/pages/page_2"
+            ]
+        },
         "staticOrderByModificationDateListType"    : {
             "jcr:primaryType"     : "nt:unstructured",
             "sling:resourceType"  : "core/wcm/components/list",
@@ -244,6 +259,14 @@
             "jcr:primaryType": "cq:Page",
             "jcr:content"    : {
                 "jcr:primaryType": "cq:PageContent"
+            }
+        },
+        "page_5": {
+            "jcr:primaryType": "cq:Page",
+            "jcr:content"    : {
+                "jcr:primaryType": "cq:PageContent",
+                "jcr:title"      : "Páge 1",
+                "cq:lastModified": "2016-09-21T16:12:45.000-07:00"
             }
         }
     },

--- a/bundles/core/src/test/resources/list/test-content.json
+++ b/bundles/core/src/test/resources/list/test-content.json
@@ -87,9 +87,9 @@
             "showModificationDate": "true",
             "orderBy"             : "title",
             "pages"               : [
+                "/content/list/pages/page_2",
                 "/content/list/pages/page_1",
-                "/content/list/pages/page_5",
-                "/content/list/pages/page_2"
+                "/content/list/pages/page_5"
             ]
         },
         "staticOrderByModificationDateListType"    : {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1055 
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

Updates the ListImpl to use a locale-sensitive collator when
sorting list items by title.

This corrects an issue where list items with accents are sorted
out of order.
