### PR TITLE
Fix possible NPE in `PdfViewerImpl#getDocumentFileName()`

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PdfViewerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PdfViewerImpl.java
@@ -34,9 +34,11 @@ import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.internal.services.pdfviewer.PdfViewerCaConfig;
 import com.adobe.cq.wcm.core.components.models.PdfViewer;
+import org.jetbrains.annotations.Nullable;
 
-@Model(adaptables = SlingHttpServletRequest.class, adapters = { PdfViewer.class,
-        ComponentExporter.class }, resourceType = { PdfViewerImpl.RESOURCE_TYPE })
+@Model(adaptables = SlingHttpServletRequest.class,
+    adapters = { PdfViewer.class, ComponentExporter.class },
+    resourceType = { PdfViewerImpl.RESOURCE_TYPE })
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class PdfViewerImpl extends AbstractComponentImpl implements PdfViewer {
 
@@ -44,12 +46,15 @@ public class PdfViewerImpl extends AbstractComponentImpl implements PdfViewer {
     protected static final String FIELD_EMBED_MODE = "embedMode";
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String documentPath;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String type;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
     private String defaultViewMode;
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
@@ -100,22 +105,27 @@ public class PdfViewerImpl extends AbstractComponentImpl implements PdfViewer {
     }
 
     @Override
+    @Nullable
     public String getDocumentPath() {
         return documentPath;
     }
 
-    @Override 
+    @Override
     public String getDocumentFileName() {
-        int index = documentPath.lastIndexOf("/");
-        return documentPath.substring(index + 1);
+        if (this.documentPath != null) {
+            return StringUtils.substringAfterLast(this.documentPath, "/");
+        }
+        return null;
     }
 
     @Override
+    @Nullable
     public String getType() {
         return type;
     }
 
     @Override
+    @Nullable
     public String getDefaultViewMode() {
         return defaultViewMode;
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PdfViewerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PdfViewerImplTest.java
@@ -26,7 +26,9 @@ import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 class PdfViewerImplTest {
@@ -37,8 +39,10 @@ class PdfViewerImplTest {
     private static final String GRID = ROOT_PAGE + "/jcr:content/root/responsivegrid";
     private static final String DCV_1 = "/pdfviewer-1";
     private static final String DCV_2 = "/pdfviewer-2";
+    private static final String DCV_3 = "/pdfviewer-3";
     private static final String PATH_DCV_1 = GRID + DCV_1;
     private static final String PATH_DCV_2 = GRID + DCV_2;
+    private static final String PATH_DCV_3 = GRID + DCV_3;
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
 
@@ -54,13 +58,13 @@ class PdfViewerImplTest {
         assertEquals("SIZED_CONTAINER", dcv.getType());
         assertEquals("https://pdfviewer.test/Test Document2.pdf", dcv.getDocumentPath());
         assertEquals("Test Document2.pdf", dcv.getDocumentFileName());
-        assertEquals(false, dcv.isBorderless());
-        assertEquals(false, dcv.isShowLeftHandPanel());
-        assertEquals(false, dcv.isShowFullScreen());
-        assertEquals(false, dcv.isShowFullScreen());
-        assertEquals(false, dcv.isShowPrintPdf());
-        assertEquals(false, dcv.isShowPageControls());
-        assertEquals(false, dcv.isDockPageControls());
+        assertFalse(dcv.isBorderless());
+        assertFalse(dcv.isShowLeftHandPanel());
+        assertFalse(dcv.isShowFullScreen());
+        assertFalse(dcv.isShowFullScreen());
+        assertFalse(dcv.isShowPrintPdf());
+        assertFalse(dcv.isShowPageControls());
+        assertFalse(dcv.isDockPageControls());
         assertEquals(PdfViewer.CSS_SIZED_CONTAINER, dcv.getContainerClass());
         String json = "{\"embedMode\":\"SIZED_CONTAINER\",\"showFullScreen\":false,\"showPageControls\":false,\"dockPageControls\":false,\"showDownloadPDF\":false,\"showPrintPDF\":false}";
         assertEquals(json, dcv.getViewerConfigJson());
@@ -85,9 +89,21 @@ class PdfViewerImplTest {
     }
 
     @Test
+    void testGetDocumentPathNotSet() {
+        PdfViewer dcv = getDcvUnderTest(PATH_DCV_3);
+        assertNull(dcv.getDocumentPath());
+    }
+
+    @Test
     void testGetDocumentFileName() {
         PdfViewer dcv = getDcvUnderTest(PATH_DCV_1);
         assertEquals("Test Document.pdf", dcv.getDocumentFileName());
+    }
+
+    @Test
+    void testGetDocumentFileNameNotSet() {
+        PdfViewer dcv = getDcvUnderTest(PATH_DCV_3);
+        assertNull(dcv.getDocumentFileName());
     }
 
     @Test
@@ -99,51 +115,51 @@ class PdfViewerImplTest {
     @Test
     void testGetBorderless() {
         PdfViewer dcv = getDcvUnderTest(PATH_DCV_1);
-        assertEquals(false, dcv.isBorderless());
+        assertFalse(dcv.isBorderless());
     }
 
     @Test
     void testGetShowAnnotationTools() {
         PdfViewer dcv = getDcvUnderTest(PATH_DCV_1);
-        assertEquals(true, dcv.isShowAnnotationTools());
+        assertTrue(dcv.isShowAnnotationTools());
     }
 
     @Test
     void testGetShowLeftHandPanel() {
         PdfViewer dcv = getDcvUnderTest(PATH_DCV_1);
-        assertEquals(true, dcv.isShowLeftHandPanel());
+        assertTrue(dcv.isShowLeftHandPanel());
     }
 
     @Test
     void testGetShowFullScreen() {
         PdfViewer dcv = getDcvUnderTest(PATH_DCV_1);
-        assertEquals(true, dcv.isShowFullScreen());
+        assertTrue(dcv.isShowFullScreen());
     }
 
     @Test
     void testGetShowDownloadPdf() {
         PdfViewer dcv = getDcvUnderTest(PATH_DCV_1);
-        assertEquals(true, dcv.isShowDownloadPdf());
+        assertTrue(dcv.isShowDownloadPdf());
     }
 
     @Test
     void testGetShowPrintPdf() {
         PdfViewer dcv = getDcvUnderTest(PATH_DCV_1);
-        assertEquals(true, dcv.isShowPrintPdf());
+        assertTrue(dcv.isShowPrintPdf());
     }
 
     @Test
     void testGetShowPageControls() {
         PdfViewer dcv = getDcvUnderTest(PATH_DCV_1);
-        assertEquals(true, dcv.isShowPageControls());
+        assertTrue(dcv.isShowPageControls());
     }
 
     @Test
     void testGetDockPageControls() {
         PdfViewer dcv = getDcvUnderTest(PATH_DCV_1);
-        assertEquals(true, dcv.isDockPageControls());
+        assertTrue(dcv.isDockPageControls());
     }
-    
+
     @Test
     void testGetContainerClass() {
         PdfViewer dcv = getDcvUnderTest(PATH_DCV_1);

--- a/bundles/core/src/test/resources/pdfviewer/test-content.json
+++ b/bundles/core/src/test/resources/pdfviewer/test-content.json
@@ -40,6 +40,10 @@
                         "showPrintPdf": false,
                         "showPageControls": false,
                         "dockPageControls": false
+                    },
+                    "pdfviewer-3" : {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "core/wcm/components/pdfviewer/v1/pdfviewer"
                     }
                 }
             }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixed #1071 
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | yes
| Documentation Provided   | N/A
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Corrects a possible NPE in `PdfViewerImpl#getDocumentFileName()`
that occurs if the `documentPath` property is not set.

A unit test is added to cover this condition.