### PR TITLE
[Experience Fragment] Edit Config REFRESH PAGE on insert (#1069)

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_editConfig.xml
@@ -25,9 +25,6 @@
             propertyName="./fragmentVariationPath"
             groups="[content]"/>
     </cq:dropTargets>
-    <cq:listeners
-        jcr:primaryType="nt:unstructured"
-        afterinsert="REFRESH_PAGE"/>
     <cq:actionConfigs
         jcr:primaryType="nt:unstructured">
         <editInNewTab


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1069 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | N/A
| Documentation Provided   | N/A (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Updated editconfig for experience fragment to stop page refresh on insert