### PR TITLE
[Navigation] Fix inconsistent `isActive` behaviour caused by redirect chains + cleanup

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
@@ -44,7 +44,6 @@ import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
-import com.adobe.cq.wcm.core.components.internal.models.v2.PageImpl;
 import com.adobe.cq.wcm.core.components.models.Navigation;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.*;
@@ -304,10 +303,10 @@ public class NavigationImpl extends AbstractComponentImpl implements Navigation 
      * @param page The page to check.
      * @return True if the page is selected, false if not.
      */
-    private boolean checkSelected(final Page page) {
-        return this.currentPage.equals(page) ||
-                this.currentPage.getPath().startsWith(page.getPath() + "/") ||
-                currentPageIsRedirectTarget(page);
+    private boolean checkSelected(@NotNull final Page page) {
+        return this.currentPage.equals(page)
+            || this.currentPage.getPath().startsWith(page.getPath() + "/")
+            || currentPageIsRedirectTarget(page);
     }
 
     /**
@@ -316,23 +315,10 @@ public class NavigationImpl extends AbstractComponentImpl implements Navigation 
      * @param page The page to check.
      * @return True if the specified page redirects to the current page.
      */
-    private boolean currentPageIsRedirectTarget(final Page page) {
-        boolean currentPageIsRedirectTarget = false;
-        Resource contentResource = page.getContentResource();
-        if (contentResource != null) {
-            ValueMap valueMap = contentResource.getValueMap();
-            String redirectTarget = valueMap.get(PageImpl.PN_REDIRECT_TARGET, String.class);
-            if(StringUtils.isNotBlank(redirectTarget)) {
-                PageManager pageManager = resourceResolver.adaptTo(PageManager.class);
-                if (pageManager != null) {
-                    Page redirectPage = pageManager.getPage(redirectTarget);
-                    if (currentPage.equals(redirectPage)) {
-                        currentPageIsRedirectTarget = true;
-                    }
-                }
-            }
-        }
-        return currentPageIsRedirectTarget;
+    private boolean currentPageIsRedirectTarget(@NotNull final Page page) {
+        return NavigationItemImpl.getRedirectTarget(page)
+            .filter(target -> target.equals(currentPage))
+            .isPresent();
     }
 
     private int getLevel(Page page) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
@@ -33,7 +33,12 @@ import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.injectorspecific.*;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
@@ -119,11 +119,6 @@ public class NavigationImpl extends AbstractComponentImpl implements Navigation 
     private String navigationRootPage;
 
     /**
-     * Flag indicating if the navigation root should be skipped.
-     */
-    private boolean skipNavigationRoot;
-
-    /**
      * Flag indicating if showing is disabled.
      * If shadowing is enabled, then the navigation will traverse redirects - where possible - to present information
      * relevant to the target page that the user would navigate to if selected.
@@ -151,7 +146,7 @@ public class NavigationImpl extends AbstractComponentImpl implements Navigation 
             //workaround to maintain the content of Navigation component of users in case they update to the current i.e. the `structureStart` version.
             structureStart = properties.get(PN_STRUCTURE_START, currentStyle.get(PN_STRUCTURE_START, 1));
         } else {
-            skipNavigationRoot = properties.get(PN_SKIP_NAVIGATION_ROOT, currentStyle.get(PN_SKIP_NAVIGATION_ROOT, true));
+            boolean skipNavigationRoot = properties.get(PN_SKIP_NAVIGATION_ROOT, currentStyle.get(PN_SKIP_NAVIGATION_ROOT, true));
             if (skipNavigationRoot) {
                 structureStart = 1;
             } else {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
@@ -28,7 +28,6 @@ import javax.jcr.RangeIterator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Exporter;
@@ -37,7 +36,6 @@ import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
-import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -70,12 +68,6 @@ public class NavigationImpl extends AbstractComponentImpl implements Navigation 
      */
     @Self
     private SlingHttpServletRequest request;
-
-    /**
-     * The resource resolver.
-     */
-    @SlingObject
-    private ResourceResolver resourceResolver;
 
     /**
      * The current page.
@@ -225,7 +217,7 @@ public class NavigationImpl extends AbstractComponentImpl implements Navigation 
     @NotNull
     @Override
     public String getExportedType() {
-        return request.getResource().getResourceType();
+        return this.resource.getResourceType();
     }
 
     /**
@@ -368,7 +360,7 @@ public class NavigationImpl extends AbstractComponentImpl implements Navigation 
                     .map(Page::getContentResource)
                     .map(Resource::getParent)
                     // if content resource is missing, resolve resource at page path
-                    .orElseGet(() -> resourceResolver.getResource(this.page.getPath())));
+                    .orElseGet(() -> resource.getResourceResolver().getResource(this.page.getPath())));
         }
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
@@ -32,11 +32,9 @@ import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
-import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -64,6 +62,11 @@ public class NavigationImpl extends AbstractComponentImpl implements Navigation 
     public static final String RESOURCE_TYPE = "core/wcm/components/navigation/v1/navigation";
 
     /**
+     * Name of the resource / configuration policy property that defines the accessibility label.
+     */
+    private static final String PN_ACCESSIBILITY_LABEL = "accessibilityLabel";
+
+    /**
      * The current request.
      */
     @Self
@@ -74,12 +77,6 @@ public class NavigationImpl extends AbstractComponentImpl implements Navigation 
      */
     @ScriptVariable
     private Page currentPage;
-
-    /**
-     * The current resource properties.
-     */
-    @ScriptVariable
-    private ValueMap properties;
 
     /**
      * The current style.
@@ -102,7 +99,6 @@ public class NavigationImpl extends AbstractComponentImpl implements Navigation 
     /**
      * The accessibility label.
      */
-    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
     @Nullable
     private String accessibilityLabel;
 
@@ -144,6 +140,7 @@ public class NavigationImpl extends AbstractComponentImpl implements Navigation 
      */
     @PostConstruct
     private void initModel() {
+        ValueMap properties = this.resource.getValueMap();
         structureDepth = properties.get(PN_STRUCTURE_DEPTH, currentStyle.get(PN_STRUCTURE_DEPTH, -1));
         boolean collectAllPages = properties.get(PN_COLLECT_ALL_PAGES, currentStyle.get(PN_COLLECT_ALL_PAGES, true));
         if (collectAllPages) {
@@ -210,8 +207,12 @@ public class NavigationImpl extends AbstractComponentImpl implements Navigation 
     }
 
     @Override
+    @Nullable
     public String getAccessibilityLabel() {
-        return accessibilityLabel;
+        if (this.accessibilityLabel == null) {
+            this.accessibilityLabel = this.resource.getValueMap().get(PN_ACCESSIBILITY_LABEL, String.class);
+        }
+        return this.accessibilityLabel;
     }
 
     @NotNull

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageListItemImpl.java
@@ -17,6 +17,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.Calendar;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -53,9 +54,11 @@ public class PageListItemImpl extends AbstractListItemImpl implements ListItem {
         this.request = request;
         this.page = page;
         this.parentId = parentId;
-        Page redirectTarget = getRedirectTarget(page);
-        if (shouldSetRedirectTargetAsPage(page, redirectTarget, isShadowingDisabled)) {
-            this.page = redirectTarget;
+
+        if (!isShadowingDisabled) {
+            this.page = getRedirectTarget(page)
+                .filter(redirectTarget -> !redirectTarget.equals(page))
+                .orElse(page);
         }
     }
 
@@ -100,12 +103,15 @@ public class PageListItemImpl extends AbstractListItemImpl implements ListItem {
         return page.getName();
     }
 
-    private boolean shouldSetRedirectTargetAsPage(@NotNull Page page, Page redirectTarget,
-                                                  boolean isShadowingDisabled) {
-        return !isShadowingDisabled && redirectTarget != null && !redirectTarget.equals(page);
-    }
-
-    private Page getRedirectTarget(@NotNull Page page) {
+    /**
+     * Get the redirect target for the specified page.
+     * This method will follow a chain or redirects to the final target.
+     *
+     * @param page The page for which to get the redirect target.
+     * @return The redirect target if found, empty if not.
+     */
+    @NotNull
+    static Optional<Page> getRedirectTarget(@NotNull final Page page) {
         Page result = page;
         String redirectTarget;
         PageManager pageManager = page.getPageManager();
@@ -121,7 +127,7 @@ public class PageListItemImpl extends AbstractListItemImpl implements ListItem {
                 }
             }
         }
-        return result;
+        return Optional.ofNullable(result);
     }
 
     /*

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImplTest.java
@@ -79,6 +79,8 @@ class NavigationImplTest {
     private static final String NAV_COMPONENT_15 = "/content/navigation-livecopy/jcr:content/root/navigation-component-15";
     private static final String NAV_COMPONENT_16 = TEST_ROOT + "/jcr:content/root/navigation-component-16";
     private static final String NAV_COMPONENT_17 = TEST_ROOT + "/jcr:content/root/navigation-component-17";
+    private static final String NAV_COMPONENT_18 = "/content/navigation-redirect-chain/jcr:content/root/navigation-component-18";
+
 
     @BeforeEach
     void setUp() throws WCMException {
@@ -315,6 +317,22 @@ class NavigationImplTest {
         Utils.testJSONExport(navigation, Utils.getTestExporterJSONPath(TEST_BASE, "navigation9"));
     }
 
+    /**
+     * Tests that a chain of redirects that eventually point to the current page are all marked active.
+     */
+    @Test
+    void activeRedirectChainTest() {
+        Navigation navigation = getNavigationUnderTest(NAV_COMPONENT_18);
+        Object[][] expectedPages = {
+            {"/content/navigation-redirect-chain", 0, true, "/content/navigation-redirect-chain.html"},
+            {"/content/navigation-redirect-chain", 1, true, "/content/navigation-redirect-chain.html"},
+            {"/content/navigation-redirect-chain", 2, true, "/content/navigation-redirect-chain.html"},
+            {"/content/navigation-redirect-chain", 1, true, "/content/navigation-redirect-chain.html"},
+            {"/content/navigation-redirect-chain", 1, true, "/content/navigation-redirect-chain.html"},
+        };
+        verifyNavigationItems(expectedPages, getNavigationItems(navigation));
+        Utils.testJSONExport(navigation, Utils.getTestExporterJSONPath(TEST_BASE, "navigation18"));
+    }
     /**
      * Test to verify #945: if shadowing is disabled Redirecting pages should be displayed instead of redirect targets
      */

--- a/bundles/core/src/test/resources/navigation/exporter-navigation18.json
+++ b/bundles/core/src/test/resources/navigation/exporter-navigation18.json
@@ -1,0 +1,98 @@
+{
+    "id": "navigation-87ad2f6ddb",
+    "items": [
+        {
+            "id": "navigation-87ad2f6ddb-item-71ce9edd7d",
+            "path": "/content/navigation-redirect-chain",
+            "children": [
+                {
+                    "id": "navigation-87ad2f6ddb-item-0dcd59a74a",
+                    "path": "/content/navigation-redirect-chain",
+                    "children": [
+                        {
+                            "id": "navigation-87ad2f6ddb-item-f4917f2146",
+                            "path": "/content/navigation-redirect-chain",
+                            "children": [],
+                            "level": 2,
+                            "active": true,
+                            "url": "/core/content/navigation-redirect-chain.html",
+                            "title": "Navigation",
+                            "dataLayer": {
+                                "navigation-87ad2f6ddb-item-f4917f2146": {
+                                    "@type": "cq:PageContent",
+                                    "xdm:linkURL": "/core/content/navigation-redirect-chain.html",
+                                    "dc:title": "Navigation"
+                                }
+                            },
+                            ":type": "cq:PageContent"
+                        }
+                    ],
+                    "level": 1,
+                    "active": true,
+                    "url": "/core/content/navigation-redirect-chain.html",
+                    "title": "Navigation",
+                    "dataLayer": {
+                        "navigation-87ad2f6ddb-item-0dcd59a74a": {
+                            "@type": "cq:PageContent",
+                            "xdm:linkURL": "/core/content/navigation-redirect-chain.html",
+                            "dc:title": "Navigation"
+                        }
+                    },
+                    ":type": "cq:PageContent"
+                },
+                {
+                    "id": "navigation-87ad2f6ddb-item-f767ff6915",
+                    "path": "/content/navigation-redirect-chain",
+                    "children": [],
+                    "level": 1,
+                    "active": true,
+                    "url": "/core/content/navigation-redirect-chain.html",
+                    "title": "Navigation",
+                    "dataLayer": {
+                        "navigation-87ad2f6ddb-item-f767ff6915": {
+                            "@type": "cq:PageContent",
+                            "xdm:linkURL": "/core/content/navigation-redirect-chain.html",
+                            "dc:title": "Navigation"
+                        }
+                    },
+                    ":type": "cq:PageContent"
+                },
+                {
+                    "id": "navigation-87ad2f6ddb-item-810ae9b516",
+                    "path": "/content/navigation-redirect-chain",
+                    "children": [],
+                    "level": 1,
+                    "active": true,
+                    "url": "/core/content/navigation-redirect-chain.html",
+                    "title": "Navigation",
+                    "dataLayer": {
+                        "navigation-87ad2f6ddb-item-810ae9b516": {
+                            "@type": "cq:PageContent",
+                            "xdm:linkURL": "/core/content/navigation-redirect-chain.html",
+                            "dc:title": "Navigation"
+                        }
+                    },
+                    ":type": "cq:PageContent"
+                }
+            ],
+            "level": 0,
+            "active": true,
+            "url": "/core/content/navigation-redirect-chain.html",
+            "title": "Navigation",
+            "dataLayer": {
+                "navigation-87ad2f6ddb-item-71ce9edd7d": {
+                    "@type": "cq:PageContent",
+                    "xdm:linkURL": "/core/content/navigation-redirect-chain.html",
+                    "dc:title": "Navigation"
+                }
+            },
+            ":type": "cq:PageContent"
+        }
+    ],
+    ":type": "core/wcm/components/navigation/v1/navigation",
+    "dataLayer": {
+        "navigation-87ad2f6ddb": {
+            "@type": "core/wcm/components/navigation/v1/navigation"
+        }
+    }
+}

--- a/bundles/core/src/test/resources/navigation/test-content.json
+++ b/bundles/core/src/test/resources/navigation/test-content.json
@@ -520,6 +520,60 @@
             }
         }
     },
+    "navigation-redirect-chain": {
+        "jcr:primaryType": "cq:Page",
+        "jcr:content": {
+            "jcr:primaryType": "cq:PageContent",
+            "jcr:title": "Navigation",
+            "jcr:created": "Thu Jun 29 2017 12:13:52 GMT+0200",
+            "root": {
+                "jcr:primaryType": "nt:unstructured",
+                "navigation-component-18": {
+                    "jcr:primaryType"   : "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/navigation/v1/navigation",
+                    "navigationRoot"    : "/content/navigation-redirect-chain",
+                    "disableShadowing"  : false,
+                    "skipNavigationRoot": false
+                }
+            }
+        },
+        "redirect-page-1": {
+            "jcr:primaryType": "cq:Page",
+            "jcr:content": {
+                "jcr:primaryType": "cq:PageContent",
+                "jcr:title": "Navigation",
+                "jcr:created": "Thu Jun 29 2017 12:13:52 GMT+0200",
+                "cq:redirectTarget": "/content/navigation-redirect-chain"
+            },
+            "redirect-page-1-1": {
+                "jcr:primaryType": "cq:Page",
+                "jcr:content": {
+                    "jcr:primaryType": "cq:PageContent",
+                    "jcr:title": "Navigation",
+                    "jcr:created": "Thu Jun 29 2017 12:13:52 GMT+0200",
+                    "cq:redirectTarget": "/content/navigation-redirect-chain/redirect-page-3"
+                }
+            }
+        },
+        "redirect-page-2": {
+            "jcr:primaryType": "cq:Page",
+            "jcr:content": {
+                "jcr:primaryType": "cq:PageContent",
+                "jcr:title": "Navigation",
+                "jcr:created": "Thu Jun 29 2017 12:13:52 GMT+0200",
+                "cq:redirectTarget": "/content/navigation-redirect-chain/redirect-page-1"
+            }
+        },
+        "redirect-page-3": {
+            "jcr:primaryType": "cq:Page",
+            "jcr:content": {
+                "jcr:primaryType": "cq:PageContent",
+                "jcr:title": "Navigation",
+                "jcr:created": "Thu Jun 29 2017 12:13:52 GMT+0200",
+                "cq:redirectTarget": "/content/navigation-redirect-chain/redirect-page-2"
+            }
+        }
+    },
     "navigation-missing-jcr-content"         : {
         "jcr:primaryType": "cq:Page",
         "navigation-1"   : {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1079 
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

* Modifies `NavigationImpl` to reuse redirect target logic from `PageListItemImpl` to ensure consistent `isActive` behaviour, regardless of length of redirect chain.
* Adds javadoc comments to private members of `NavigationImpl` to aid future development (mostly for me :) )
* Reworks `NavigationImpl` to avoid the need for the inner class `NavigationImpl.NavigationRoot`
* Splits the logic for getting the effective navigation root out of the `NavigationImpl#getItems()` method to make the behaviour for generating the navigation items/tree easier to understand. 
* Removes various injected fields that can be obtained from other injected fields
* Update `PageListItemImpl` constructor to eliminate determining the redirect target if shadowing is disabled (minor performance optimization)