### PR TITLE
[Image] Allow lazy threshold to be set in design policy #1090

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageAreaImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageAreaImpl.java
@@ -17,16 +17,57 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import com.adobe.cq.wcm.core.components.models.ImageArea;
 
-public class ImageAreaImpl implements ImageArea {
+/**
+ * Image area implementation.
+ */
+public final class ImageAreaImpl implements ImageArea {
 
-    private String shape;
-    private String coordinates;
-    private String relativeCoordinates;
-    private String href;
-    private String target;
-    private String alt;
+    /**
+     * The shape of the area.
+     */
+    private final String shape;
 
-    public ImageAreaImpl(String shape, String coordinates, String relativeCoordinates, String href, String target, String alt) {
+    /**
+     * The coordinates of the area.
+     */
+    private final String coordinates;
+
+    /**
+     * a relative unit representation of the {@code coords}.
+     */
+    private final String relativeCoordinates;
+
+    /**
+     * The image area anchor {@code href} value.
+     */
+    private final String href;
+
+    /**
+     * The image area anchor {@code target} value.
+     */
+    private final String target;
+
+    /**
+     * The image area anchor {@code alt} value
+     */
+    private final String alt;
+
+    /**
+     * Construct an Image Area.
+     *
+     * @param shape The shape of the area.
+     * @param coordinates The coordinates of the area.
+     * @param relativeCoordinates The relative unit representation of the {@code coords}.
+     * @param href The image area anchor href.
+     * @param target The image area anchor target.
+     * @param alt The image area anchor alt text.
+     */
+    public ImageAreaImpl(final String shape,
+                         final String coordinates,
+                         final String relativeCoordinates,
+                         final String href,
+                         final String target,
+                         final String alt) {
         this.shape = shape;
         this.coordinates = coordinates;
         this.relativeCoordinates = relativeCoordinates;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
@@ -53,6 +53,7 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
     private String srcUriTemplate;
     private List<ImageArea> areas;
     private boolean uuidDisabled;
+    private int lazyThreshold;
 
     public ImageImpl() {
         selector = AdaptiveImageServlet.CORE_DEFAULT_SELECTOR;
@@ -122,6 +123,8 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
             }
             buildJson();
         }
+
+        this.lazyThreshold = currentStyle.get(PN_DESIGN_LAZY_THRESHOLD, 0);
     }
 
     @NotNull
@@ -138,6 +141,11 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
     @Override
     public boolean isLazyEnabled() {
         return !disableLazyLoading;
+    }
+
+    @Override
+    public int getLazyThreshold() {
+        return this.lazyThreshold;
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
@@ -52,7 +52,6 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
 
     private String srcUriTemplate;
     private List<ImageArea> areas;
-    private boolean uuidDisabled;
     private int lazyThreshold;
 
     public ImageImpl() {
@@ -67,7 +66,7 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
         boolean altValueFromDAM = properties.get(PN_ALT_VALUE_FROM_DAM, currentStyle.get(PN_ALT_VALUE_FROM_DAM, true));
         boolean titleValueFromDAM = properties.get(PN_TITLE_VALUE_FROM_DAM, currentStyle.get(PN_TITLE_VALUE_FROM_DAM, true));
         displayPopupTitle = properties.get(PN_DISPLAY_POPUP_TITLE, currentStyle.get(PN_DISPLAY_POPUP_TITLE, true));
-        uuidDisabled = currentStyle.get(PN_UUID_DISABLED, false);
+        boolean uuidDisabled = currentStyle.get(PN_UUID_DISABLED, false);
         if (StringUtils.isNotEmpty(fileReference)) {
             // the image is coming from DAM
             final Resource assetResource = request.getResourceResolver().getResource(fileReference);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
@@ -41,25 +41,68 @@ import com.adobe.cq.wcm.core.components.models.ImageArea;
 import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.DamConstants;
 
-@Model(adaptables = SlingHttpServletRequest.class, adapters = {Image.class, ComponentExporter.class}, resourceType = ImageImpl.RESOURCE_TYPE)
+/**
+ * V2 Image model implementation.
+ */
+@Model(adaptables = SlingHttpServletRequest.class,
+    adapters = {Image.class, ComponentExporter.class},
+    resourceType = ImageImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.v1.ImageImpl implements Image {
 
+    /**
+     * The resource type.
+     */
     public static final String RESOURCE_TYPE = "core/wcm/components/image/v2/image";
+
+    /**
+     * Standard logger.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(ImageImpl.class);
+
+    /**
+     * The width variable to use when building {@link #srcUriTemplate}.
+     */
     private static final String SRC_URI_TEMPLATE_WIDTH_VAR = "{.width}";
+
+    /**
+     * The path of the delegated content policy.
+     */
     private static final String CONTENT_POLICY_DELEGATE_PATH = "contentPolicyDelegatePath";
 
+    /**
+     * Placeholder for the SRC URI template.
+     */
     private String srcUriTemplate;
+
+    /**
+     * Placeholder for the areas.
+     */
     private List<ImageArea> areas;
+
+    /**
+     * Placeholder for the number of pixels, in advance of becoming visible, at which point this image should load.
+     */
     private int lazyThreshold;
 
+    /**
+     * Placeholder for the referenced assed ID.
+     */
+    protected String uuid;
+
+    /**
+     * Construct the model.
+     *
+     * Note: Using this constructor does not imply constructor injection, it does not initialize the model.
+     * The model must be initialized via the {@link org.apache.sling.models.factory.ModelFactory}.
+     */
     public ImageImpl() {
         selector = AdaptiveImageServlet.CORE_DEFAULT_SELECTOR;
     }
 
-    protected String uuid;
-
+    /**
+     * Initialize the model.
+     */
     @PostConstruct
     protected void initModel() {
         super.initModel();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
@@ -53,6 +53,12 @@ public interface Image extends Component {
     String PN_DESIGN_LAZY_LOADING_ENABLED = "disableLazyLoading";
 
     /**
+     * Name of the configuration policy property that indicate the number of pixels, in advance of becoming visible,
+     * that a lazy loading image should load.
+     */
+    String PN_DESIGN_LAZY_THRESHOLD = "lazyThreshold";
+
+    /**
      * Name of the resource property that will indicate if the image is decorative.
      *
      * @since com.adobe.cq.wcm.core.components.models 11.0.0
@@ -271,6 +277,16 @@ public interface Image extends Component {
     }
 
     /**
+     * Returns the number of pixels in advance of an image becoming visible that a lazy
+     * loading image should load.
+     *
+     * @return The number of pixels.
+     */
+    default int getLazyThreshold() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Returns a list of image map areas.
      *
      * @return the image map areas
@@ -298,5 +314,5 @@ public interface Image extends Component {
      */
     default boolean isDecorative() {
         throw new UnsupportedOperationException();
-    };
+    }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImplTest.java
@@ -242,4 +242,12 @@ class ImageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.
         assertEquals(0, image.getWidths().length);
     }
 
+
+    @Test
+    void testImageWithLazyThreshold() {
+        context.contentPolicyMapping(ImageImpl.RESOURCE_TYPE, Image.PN_DESIGN_LAZY_THRESHOLD, 100);
+        Image image = getImageUnderTest(AbstractImageTest.IMAGE3_PATH);
+        assertEquals(100, image.getLazyThreshold());
+        Utils.testJSONExport(image, Utils.getTestExporterJSONPath(TEST_BASE, AbstractImageTest.IMAGE3_PATH + "-with-lazy-threshold"));
+    }
 }

--- a/bundles/core/src/test/resources/image/v2/exporter-image0.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image0.json
@@ -5,6 +5,7 @@
     "src": "/core/content/test/_jcr_content/root/image0.coreimg.png/1490005239000/adobe-systems-logo-and-wordmark.png",
     "srcUriTemplate": "/core/content/test/_jcr_content/root/image0.coreimg.82{.width}.png/1490005239000/adobe-systems-logo-and-wordmark.png",
     "areas": [],
+    "lazyThreshold": 0,
     "uuid": "60a1a56e-f3f4-4021-a7bf-ac7a51f0ffe5",
     "widths": [
         600,

--- a/bundles/core/src/test/resources/image/v2/exporter-image15.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image15.json
@@ -4,6 +4,7 @@
     "src": "/core/content/test/_jcr_content/root/image15.coreimg.png/1494867377756/adobe-systems-logo-and-wordmark.png",
     "srcUriTemplate": "/core/content/test/_jcr_content/root/image15.coreimg{.width}.png/1494867377756/adobe-systems-logo-and-wordmark.png",
     "areas": [],
+    "lazyThreshold": 0,
     "widths": [],
     "lazyEnabled": false,
     "dataLayer": {

--- a/bundles/core/src/test/resources/image/v2/exporter-image16.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image16.json
@@ -3,6 +3,7 @@
     "src": "/core/content/test/_jcr_content/root/image16.coreimg.jpeg/1500299989000/adobe-systems-logo-and-wordmark.jpeg",
     "srcUriTemplate": "/core/content/test/_jcr_content/root/image16.coreimg{.width}.jpeg/1500299989000/adobe-systems-logo-and-wordmark.jpeg",
     "areas": [],
+    "lazyThreshold": 0,
     "widths": [],
     "lazyEnabled": false,
     "dataLayer": {

--- a/bundles/core/src/test/resources/image/v2/exporter-image18.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image18.json
@@ -3,6 +3,7 @@
     "src": "/core/content/test/_jcr_content/root/image18.coreimg.png/1490005239000/adobe-systems-logo-and-wordmark.png",
     "srcUriTemplate": "/core/content/test/_jcr_content/root/image18.coreimg.82{.width}.png/1490005239000/adobe-systems-logo-and-wordmark.png",
     "areas": [],
+    "lazyThreshold": 0,
     "widths": [
         128,
         256,

--- a/bundles/core/src/test/resources/image/v2/exporter-image24.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image24.json
@@ -30,6 +30,7 @@
             "alt": ""
         }
     ],
+    "lazyThreshold": 0,
     "widths": [],
     "lazyEnabled": false,
     "dataLayer": {

--- a/bundles/core/src/test/resources/image/v2/exporter-image27.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image27.json
@@ -5,6 +5,7 @@
     "src": "/core/content/test/_jcr_content/root/image27.coreimg.82.600.png/1490005239000.png",
     "srcUriTemplate": "/core/content/test/_jcr_content/root/image27.coreimg.82{.width}.png/1490005239000.png",
     "areas": [],
+    "lazyThreshold": 0,
     "widths": [
         600
     ],

--- a/bundles/core/src/test/resources/image/v2/exporter-image3-with-lazy-threshold.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image3-with-lazy-threshold.json
@@ -2,13 +2,11 @@
     "id": "image-4fdb43cd81",
     "alt": "Adobe Logo",
     "title": "Adobe Logo",
-    "src": "/core/content/test/_jcr_content/root/image3.coreimg.82.600.png",
-    "srcUriTemplate": "/core/content/test/_jcr_content/root/image3.coreimg.82{.width}.png",
+    "src": "/core/content/test/_jcr_content/root/image3.coreimg.png",
+    "srcUriTemplate": "/core/content/test/_jcr_content/root/image3.coreimg{.width}.png",
     "areas": [],
-    "lazyThreshold": 0,
-    "widths": [
-        600
-    ],
+    "lazyThreshold": 100,
+    "widths": [],
     "lazyEnabled": false,
     "link": "https://www.adobe.com",
     "dataLayer": {

--- a/bundles/core/src/test/resources/image/v2/exporter-image3-with-policy-delegate.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image3-with-policy-delegate.json
@@ -5,6 +5,7 @@
     "src": "/core/content/test/_jcr_content/root/image3.coreimg.82.600.png?contentPolicyDelegatePath=/content/test/jcr:content/root/image0",
     "srcUriTemplate": "/core/content/test/_jcr_content/root/image3.coreimg.82{.width}.png?contentPolicyDelegatePath=/content/test/jcr:content/root/image0",
     "areas": [],
+    "lazyThreshold": 0,
     "widths": [
         600
     ],

--- a/bundles/core/src/test/resources/image/v2/exporter-image4.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image4.json
@@ -4,6 +4,7 @@
     "src": "/core/content/test/_jcr_content/root/image4.coreimg.png/1494867377756/adobe-systems-logo-and-wordmark.png",
     "srcUriTemplate": "/core/content/test/_jcr_content/root/image4.coreimg{.width}.png/1494867377756/adobe-systems-logo-and-wordmark.png",
     "areas": [],
+    "lazyThreshold": 0,
     "widths": [],
     "lazyEnabled": false,
     "dataLayer": {

--- a/bundles/core/src/test/resources/image/v2/exporter-image_template.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image_template.json
@@ -6,6 +6,7 @@
     "srcUriTemplate": "/core/conf/coretest/settings/wcm/templates/testtemplate/structure.coreimg.82{.width}.png/structure/jcr:content/root/image_template/1490005239000/adobe-systems-logo-and-wordmark.png",
     "areas": [],
     "uuid": "60a1a56e-f3f4-4021-a7bf-ac7a51f0ffe5",
+    "lazyThreshold": 0,
     "widths": [
         600,
         700,

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_design_dialog/.content.xml
@@ -51,6 +51,16 @@
                                         checked="{Boolean}false"
                                         uncheckedValue="true"
                                         value="{Boolean}false"/>
+                                    <lazyThreshold
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                        fieldDescription="The number of pixels to begin loading an image in advance of it becoming visible."
+                                        fieldLabel="Lazy Threshold"
+                                        name="./lazyThreshold"
+                                        typeHint="Long"
+                                        required="{Boolean}false"
+                                        min="{Long}0"
+                                        deleteHint="{Boolean}true"/>
                                     <decorative
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -20,7 +20,7 @@
     var IS = "image";
 
     var EMPTY_PIXEL = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
-    var LAZY_THRESHOLD = 0;
+    var LAZY_THRESHOLD_DEFAULT = 0;
     var SRC_URI_TEMPLATE_WIDTH_VAR = "{.width}";
 
     var selectors = {
@@ -71,6 +71,25 @@
             "default": false,
             "transform": function(value) {
                 return !(value === null || typeof value === "undefined");
+            }
+        },
+        /**
+         * The lazy threshold.
+         * This is the number of pixels, in advance of becoming visible, when an lazy-loading image should begin
+         * to load.
+         *
+         * @memberof Image
+         * @type {Number}
+         * @default 0
+         */
+        "lazythreshold": {
+            "default": 0,
+            "transform": function(value) {
+                const val =  parseInt(value);
+                if (isNaN(val)) {
+                    return LAZY_THRESHOLD_DEFAULT;
+                }
+                return val;
             }
         },
         /**
@@ -255,7 +274,7 @@
             var et = that._elements.container.getBoundingClientRect().top + wt;
             var eb = et + that._elements.container.clientHeight;
 
-            return eb >= wt - LAZY_THRESHOLD && et <= wb + LAZY_THRESHOLD;
+            return eb >= wt - that._properties.lazythreshold && et <= wb + that._properties.lazythreshold;
         }
 
         function resizeAreas() {

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/image.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/image.html
@@ -19,6 +19,7 @@
      data-sly-test="${image.src}"
      data-cmp-is="image"
      data-cmp-lazy="${image.lazyEnabled}"
+     data-cmp-lazythreshold="${image.lazyThreshold}"
      data-cmp-src="${image.srcUriTemplate ? image.srcUriTemplate : image.src}"
      data-cmp-widths="${image.widths}"
      data-asset="${image.fileReference}"


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1090 
| Patch: Bug Fix?          | No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Allows template author to set the lazy threshold value so that lazy-loading images can be loaded slightly in advance of being visible on the page in order to reduce delay and jarring image loads and give a more seamless/smooth experience.

Note: someone may want to review the wording of the dialog field name/description to make sure that it makes sense.