### PR TITLE
[Teaser] Fix inconsistent `linkURL` behaviour + cleanup

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -304,15 +304,15 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
 
         private static final String CTA_ID_PREFIX = "cta";
 
-        private Resource ctaResource;
-        private String ctaTitle;
-        private String ctaUrl;
-        private String ctaPath;
-        private Page ctaPage;
-        private String ctaParentId;
+        private final Resource ctaResource;
+        private final String ctaTitle;
+        private final String ctaUrl;
+        private final String ctaPath;
+        private final Page ctaPage;
+        private final String ctaParentId;
         private String ctaId;
 
-        private Action(Resource actionRes, String parentId) {
+        private Action(final Resource actionRes, final String parentId) {
             super(parentId, actionRes);
             ctaParentId = parentId;
             ctaResource = actionRes;
@@ -322,6 +322,8 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
             ctaPath = actionRes.getPath();
             if (ctaUrl != null && ctaUrl.startsWith("/")) {
                 ctaPage = pageManager.getPage(ctaUrl);
+            } else {
+                ctaPage = null;
             }
         }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -33,7 +33,6 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
@@ -54,7 +53,6 @@ import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.components.Component;
 import com.day.cq.wcm.api.designer.Style;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import static com.adobe.cq.wcm.core.components.internal.Utils.ID_SEPARATOR;
@@ -93,9 +91,10 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
     @ScriptVariable
     private PageManager pageManager;
 
-    @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
-    @JsonIgnore
-    @Nullable
+    /**
+     * The current style.
+     */
+    @ScriptVariable
     protected Style currentStyle;
 
     @Self
@@ -114,22 +113,17 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
     @PostConstruct
     private void initModel() {
         ValueMap properties = resource.getValueMap();
-        actionsEnabled = properties.get(Teaser.PN_ACTIONS_ENABLED, actionsEnabled);
 
-        if (currentStyle != null) {
-            pretitleHidden = currentStyle.get(Teaser.PN_PRETITLE_HIDDEN, pretitleHidden);
-            titleHidden = currentStyle.get(Teaser.PN_TITLE_HIDDEN, titleHidden);
-            descriptionHidden = currentStyle.get(Teaser.PN_DESCRIPTION_HIDDEN, descriptionHidden);
-            titleType = currentStyle.get(Teaser.PN_TITLE_TYPE, titleType);
-            imageLinkHidden = currentStyle.get(Teaser.PN_IMAGE_LINK_HIDDEN, imageLinkHidden);
-            titleLinkHidden = currentStyle.get(Teaser.PN_TITLE_LINK_HIDDEN, titleLinkHidden);
-            if (imageLinkHidden) {
-                hiddenImageResourceProperties.add(ImageResource.PN_LINK_URL);
-            }
-            if (currentStyle.get(Teaser.PN_ACTIONS_DISABLED, false)) {
-                actionsEnabled = false;
-            }
+        pretitleHidden = currentStyle.get(Teaser.PN_PRETITLE_HIDDEN, pretitleHidden);
+        titleHidden = currentStyle.get(Teaser.PN_TITLE_HIDDEN, titleHidden);
+        descriptionHidden = currentStyle.get(Teaser.PN_DESCRIPTION_HIDDEN, descriptionHidden);
+        titleType = currentStyle.get(Teaser.PN_TITLE_TYPE, titleType);
+        imageLinkHidden = currentStyle.get(Teaser.PN_IMAGE_LINK_HIDDEN, imageLinkHidden);
+        titleLinkHidden = currentStyle.get(Teaser.PN_TITLE_LINK_HIDDEN, titleLinkHidden);
+        if (imageLinkHidden) {
+            hiddenImageResourceProperties.add(ImageResource.PN_LINK_URL);
         }
+        actionsEnabled = !currentStyle.get(Teaser.PN_ACTIONS_DISABLED, !properties.get(Teaser.PN_ACTIONS_ENABLED, actionsEnabled));
 
         titleFromPage = properties.get(Teaser.PN_TITLE_FROM_PAGE, titleFromPage);
         descriptionFromPage = properties.get(Teaser.PN_DESCRIPTION_FROM_PAGE, descriptionFromPage);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -135,37 +135,32 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
             }
         }
 
-        if (pretitleHidden) {
-            pretitle = null;
-        } else {
+        if (!pretitleHidden) {
             pretitle = properties.get("pretitle", String.class);
         }
-        if (titleHidden) {
-            title = null;
-        } else {
-            title = properties.get(JcrConstants.JCR_TITLE, String.class);
+
+        if (!titleHidden) {
             if (titleFromPage) {
                 if (targetPage != null) {
                     title = StringUtils.defaultIfEmpty(targetPage.getPageTitle(), targetPage.getTitle());
                 } else if (actionsEnabled && !actions.isEmpty()) {
                     title = actions.get(0).getTitle();
-                } else {
-                    title = null;
                 }
+            } else {
+                title = properties.get(JcrConstants.JCR_TITLE, String.class);
             }
         }
-        if (descriptionHidden) {
-            description = null;
-        } else {
-            description = properties.get(JcrConstants.JCR_DESCRIPTION, String.class);
+
+        if (!descriptionHidden) {
             if (descriptionFromPage) {
                 if (targetPage != null) {
                     description = targetPage.getDescription();
-                } else {
-                    description = null;
                 }
+            } else {
+                description = properties.get(JcrConstants.JCR_DESCRIPTION, String.class);
             }
         }
+
         String fileReference = properties.get(DownloadResource.PN_REFERENCE, String.class);
         boolean hasImage = true;
         if (StringUtils.isEmpty(linkURL)) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -125,11 +125,15 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
             if (!actions.isEmpty()) {
                 ListItem firstAction = actions.get(0);
                 if (firstAction != null) {
+                    linkURL = firstAction.getURL();
                     targetPage = pageManager.getPage(firstAction.getPath());
                 }
             }
         } else {
             targetPage = pageManager.getPage(linkURL);
+        }
+        if (targetPage != null) {
+            linkURL = Utils.getURL(request, targetPage);
         }
 
         if (pretitleHidden) {
@@ -146,7 +150,6 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
                     title = StringUtils.defaultIfEmpty(targetPage.getPageTitle(), targetPage.getTitle());
                 } else if (actionsEnabled && !actions.isEmpty()) {
                     title = actions.get(0).getTitle();
-                    linkURL = actions.get(0).getURL();
                 } else {
                     title = null;
                 }
@@ -184,9 +187,6 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
         }
         if (hasImage) {
             setImageResource(component, request.getResource(), hiddenImageResourceProperties);
-        }
-        if (targetPage != null) {
-            linkURL = Utils.getURL(request, targetPage);
         }
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -57,37 +57,121 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import static com.adobe.cq.wcm.core.components.internal.Utils.ID_SEPARATOR;
 
+/**
+ * Teaser model implementation.
+ */
 @Model(adaptables = SlingHttpServletRequest.class, adapters = {Teaser.class, ComponentExporter.class}, resourceType = TeaserImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME , extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
 
+    /**
+     * The resource type.
+     */
     public final static String RESOURCE_TYPE = "core/wcm/components/teaser/v1/teaser";
 
+    /**
+     * The pre-title text.
+     */
     private String pretitle;
+
+    /**
+     * The title.
+     */
     private String title;
+
+    /**
+     * The description.
+     */
     private String description;
+
+    /**
+     * The main teaser link.
+     */
     private String linkURL;
+
+    /**
+     * The title heading level.
+     */
     private String titleType;
+
+    /**
+     * The target page.
+     */
+    private Page targetPage;
+
+    /**
+     * The image src.
+     */
+    private String imageSrc;
+
+    /**
+     * Flag indicating if CTA actions are enabled.
+     */
     private boolean actionsEnabled = false;
+
+    /**
+     * Flag indicating if the title should be hidden.
+     */
     private boolean titleHidden = false;
+
+    /**
+     * Flag indicating if the description should be hidden.
+     */
     private boolean descriptionHidden = false;
+
+    /**
+     * Flag indicating if the image should not be linked.
+     */
     private boolean imageLinkHidden = false;
+
+    /**
+     * Flag indicating if the pre-title should be hidden.
+     */
     private boolean pretitleHidden = false;
+
+    /**
+     * Flag indicating if the title should not be linked.
+     */
     private boolean titleLinkHidden = false;
+
+    /**
+     * Flag indicating if the title should be inherited from the target page.
+     */
     private boolean titleFromPage = false;
+
+    /**
+     * Flag indicating if the description should be inherited from the target page.
+     */
     private boolean descriptionFromPage = false;
+
+    /**
+     * List of CTA actions.
+     */
     private List<Action> actions;
+
+    /**
+     * List of properties that should be suppressed on image delegation.
+     */
     private final List<String> hiddenImageResourceProperties = new ArrayList<String>() {{
         add(JcrConstants.JCR_TITLE);
         add(JcrConstants.JCR_DESCRIPTION);
     }};
 
+    /**
+     * The current component.
+     */
     @ScriptVariable
     private Component component;
 
+    /**
+     * The current resource.
+     */
     @Inject
     private Resource resource;
 
+    /**
+     * The page manager.
+     */
     @ScriptVariable
     private PageManager pageManager;
 
@@ -97,19 +181,21 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
     @ScriptVariable
     protected Style currentStyle;
 
+    /**
+     * The current request.
+     */
     @Self
     private SlingHttpServletRequest request;
 
+    /**
+     * The model factory service.
+     */
     @OSGiService
     private ModelFactory modelFactory;
 
-    private Page targetPage;
-
     /**
-     * The image src.
+     * Initialize the model.
      */
-    private String imageSrc;
-
     @PostConstruct
     private void initModel() {
         ValueMap properties = resource.getValueMap();
@@ -151,7 +237,6 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
     public boolean isActionsEnabled() {
         return actionsEnabled;
     }
-
 
     /**
      * Get the target page.
@@ -319,19 +404,54 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
     }
 
 
+    /**
+     * Teaser CTA.
+     */
     @JsonIgnoreProperties({"path", "description", "lastModified", "name"})
     public class Action extends AbstractListItemImpl implements ListItem {
 
+        /**
+         * ID prefix.
+         */
         private static final String CTA_ID_PREFIX = "cta";
 
+        /**
+         * The resource for this CTA.
+         */
         @NotNull
         private final Resource ctaResource;
+
+        /**
+         * The CTA title.
+         */
         private final String ctaTitle;
+
+        /**
+         * The CTA target URL.
+         */
         private final String ctaUrl;
+
+        /**
+         * The page referenced by the `ctaURL` if it is internal.
+         */
         private final Page ctaPage;
+
+        /**
+         * The ID of the teaser that contains this action.
+         */
         private final String ctaParentId;
+
+        /**
+         * The ID of this action.
+         */
         private String ctaId;
 
+        /**
+         * Create a CTA.
+         *
+         * @param actionRes The action resource.
+         * @param parentId The ID of the containing Teaser.
+         */
         private Action(@NotNull final Resource actionRes, final String parentId) {
             super(parentId, actionRes);
             ctaParentId = parentId;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -116,11 +116,9 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
 
         titleFromPage = properties.get(Teaser.PN_TITLE_FROM_PAGE, titleFromPage);
         descriptionFromPage = properties.get(Teaser.PN_DESCRIPTION_FROM_PAGE, descriptionFromPage);
-        linkURL = properties.get(ImageResource.PN_LINK_URL, String.class);
 
         if (actionsEnabled) {
             hiddenImageResourceProperties.add(ImageResource.PN_LINK_URL);
-            linkURL = null;
             populateActions();
             if (!actions.isEmpty()) {
                 ListItem firstAction = actions.get(0);
@@ -130,10 +128,11 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
                 }
             }
         } else {
+            linkURL = properties.get(ImageResource.PN_LINK_URL, String.class);
             targetPage = pageManager.getPage(linkURL);
-        }
-        if (targetPage != null) {
-            linkURL = Utils.getURL(request, targetPage);
+            if (targetPage != null) {
+                linkURL = Utils.getURL(request, targetPage);
+            }
         }
 
         if (pretitleHidden) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
@@ -133,24 +133,18 @@ class TeaserImplTest {
     @Test
     void testInvalidFileReference() {
         Teaser teaser = getTeaserUnderTest(TEASER_2);
-        assertThat(testLogger.getLoggingEvents(), hasItem(error(
-            "Asset /content/dam/core/images/Adobe_Systems_logo_and_wordmark configured for the teaser component from /content/teasers/jcr:content/root/responsivegrid/teaser-2 doesn't exist.")));
         assertNull(teaser.getImageResource());
     }
 
     @Test
     void testEmptyFileReference() {
         Teaser teaser = getTeaserUnderTest(TEASER_3);
-        assertThat(testLogger.getLoggingEvents(), hasItem(debug(
-            "Teaser component from /content/teasers/jcr:content/root/responsivegrid/teaser-3 does not have an asset or an image file configured.")));
         assertNull(teaser.getImageResource());
     }
 
     @Test
     void testTeaserWithoutLink() {
         Teaser teaser = getTeaserUnderTest(TEASER_4);
-        assertThat(testLogger.getLoggingEvents(),
-            hasItem(debug("Teaser component from /content/teasers/jcr:content/root/responsivegrid/teaser-4 does not define a link.")));
         assertNull(teaser.getLinkURL());
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
@@ -157,6 +157,12 @@ class TeaserImplTest {
     }
 
     @Test
+    void testTeaserWithExternalLinkFromAction() {
+        Teaser teaser = getTeaserUnderTest(TEASER_7);
+        assertEquals("http://www.adobe.com", teaser.getLinkURL());
+    }
+
+    @Test
     void testTeaserWithHiddenElements() {
         Teaser teaser = getTeaserUnderTest(TEASER_5,
             Teaser.PN_TITLE_HIDDEN, true,

--- a/bundles/core/src/test/resources/teaser/exporter-teaser9.json
+++ b/bundles/core/src/test/resources/teaser/exporter-teaser9.json
@@ -1,6 +1,7 @@
 {
   "title": "Teaser",
   "description": "Description",
+  "linkURL": "http://www.adobe.com",
   "actionsEnabled": true,
   "imageLinkHidden": false,
   "titleLinkHidden": false,
@@ -38,6 +39,7 @@
     "teaser-6a61ad8d2f": {
       "dc:description": "Description",
       "@type": "core/wcm/components/teaser/v1/teaser",
+      "xdm:linkURL": "http://www.adobe.com",
       "dc:title": "Teaser"
     }
   },


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1102 
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

- Modifies the `TeaserImpl` class such that, when the title link is derived from the first CTA, it does not matter if the CTA link URL points to an internal or external page (alternative solution to PR #1103).
- Adds javadoc comments to private members of TeaserImpl.
- Significant rewrite of field initialization/getters so that the initialization logic for each field is contained within its own getter instead of all in the `initModel()`. The intent of this change is to make it easier to see how a field is set at a glance instead of having to trace through the entire `initModel()` method where fields may be set and subsequently unset and reset.