### PR TITLE
[LayoutContainer] Fix possible NPE in `LayoutContainerImpl` + cleanup

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
@@ -29,16 +29,31 @@ import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.wcm.core.components.models.LayoutContainer;
 
+/**
+ * Layout container model implementation.
+ */
 @Model(adaptables = SlingHttpServletRequest.class, adapters = LayoutContainer.class, resourceType = LayoutContainerImpl.RESOURCE_TYPE_V1)
 public class LayoutContainerImpl extends AbstractContainerImpl implements LayoutContainer {
 
+    /**
+     * The resource type.
+     */
     protected static final String RESOURCE_TYPE_V1 = "core/wcm/components/container/v1/container";
 
+    /**
+     * The current resource.
+     */
     @ScriptVariable
     private Resource resource;
 
+    /**
+     * The layout type.
+     */
     private LayoutType layout;
 
+    /**
+     * Initialize the model.
+     */
     @PostConstruct
     protected void initModel() {
         // Note: this can be simplified using Optional.or() in JDK 11

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
@@ -71,7 +71,7 @@ public class LayoutContainerImpl extends AbstractContainerImpl implements Layout
     @NotNull
     protected List<ResourceListItemImpl> readItems() {
         return getChildren().stream()
-            .map(res -> new ResourceListItemImpl(request, res, getId()))
+            .map(res -> new ResourceListItemImpl(res, getId()))
             .collect(Collectors.toList());
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
-public class PanelContainerImpl extends AbstractContainerImpl implements Container {
+public abstract class PanelContainerImpl extends AbstractContainerImpl implements Container {
 
     @Override
     @NotNull

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
@@ -37,7 +37,7 @@ public class PanelContainerImpl extends AbstractContainerImpl implements Contain
     @NotNull
     protected List<PanelContainerItemImpl> readItems() {
         return getChildren().stream()
-            .map(res -> new PanelContainerItemImpl(request, res, getId()))
+            .map(res -> new PanelContainerItemImpl(res, getId()))
             .collect(Collectors.toList());
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
@@ -31,6 +31,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
+/**
+ * Abstract panel container model.
+ */
 public abstract class PanelContainerImpl extends AbstractContainerImpl implements Container {
 
     @Override
@@ -42,8 +45,8 @@ public abstract class PanelContainerImpl extends AbstractContainerImpl implement
     }
 
     @Override
-    protected Map<String, ComponentExporter> getItemModels(@NotNull SlingHttpServletRequest request,
-                                                           @NotNull Class<ComponentExporter> modelClass) {
+    protected Map<String, ComponentExporter> getItemModels(@NotNull final SlingHttpServletRequest request,
+                                                           @NotNull final Class<ComponentExporter> modelClass) {
         Map<String, ComponentExporter> models = super.getItemModels(request, modelClass);
         models.entrySet().forEach(entry ->
             getItems().stream()
@@ -57,20 +60,34 @@ public abstract class PanelContainerImpl extends AbstractContainerImpl implement
 
     /**
      * Wrapper class used to add specific properties of the container items to the JSON serialization of the underlying container item model
-     *
      */
     static class JsonWrapper implements ComponentExporter {
 
+        /**
+         * The wrapped ComponentExporter.
+         */
         @NotNull
         private final ComponentExporter inner;
+
+        /**
+         * The panel title.
+         */
         private final String panelTitle;
 
+        /**
+         * Construct the wrapper.
+         *
+         * @param inner The ComponentExporter to be wrapped.
+         * @param item The panel item.
+         */
         JsonWrapper(@NotNull final ComponentExporter inner, @NotNull final ListItem item) {
             this.inner = inner;
             this.panelTitle = item.getTitle();
         }
 
         /**
+         * Get the underlying ComponentExporter that is wrapped by this wrapper.
+         *
          * @return the underlying container item model
          */
         @JsonUnwrapped
@@ -80,6 +97,8 @@ public abstract class PanelContainerImpl extends AbstractContainerImpl implement
         }
 
         /**
+         * Get the panel title.
+         *
          * @return the container item title
          */
         @JsonProperty(PanelContainerItemImpl.PN_PANEL_TITLE)

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
@@ -60,10 +60,12 @@ public class PanelContainerImpl extends AbstractContainerImpl implements Contain
      *
      */
     static class JsonWrapper implements ComponentExporter {
-        private ComponentExporter inner;
-        private String panelTitle;
 
-        JsonWrapper(@NotNull ComponentExporter inner, ListItem item) {
+        @NotNull
+        private final ComponentExporter inner;
+        private final String panelTitle;
+
+        JsonWrapper(@NotNull final ComponentExporter inner, @NotNull final ListItem item) {
             this.inner = inner;
             this.panelTitle = item.getTitle();
         }
@@ -72,27 +74,24 @@ public class PanelContainerImpl extends AbstractContainerImpl implements Contain
          * @return the underlying container item model
          */
         @JsonUnwrapped
+        @NotNull
         public ComponentExporter getInner() {
-            return inner;
+            return this.inner;
         }
 
         /**
          * @return the container item title
          */
         @JsonProperty(PanelContainerItemImpl.PN_PANEL_TITLE)
-        @JsonInclude(JsonInclude.Include.ALWAYS)
+        @JsonInclude()
         public String getPanelTitle() {
-            return panelTitle;
+            return this.panelTitle;
         }
 
         @NotNull
         @Override
         public String getExportedType() {
-            if (inner != null) {
-                return inner.getExportedType();
-            } else {
-                return "";
-            }
+            return this.inner.getExportedType();
         }
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
@@ -23,10 +23,22 @@ import org.jetbrains.annotations.NotNull;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.day.cq.commons.jcr.JcrConstants;
 
+/**
+ * Panel container item implementation.
+ */
 public class PanelContainerItemImpl extends ResourceListItemImpl implements ListItem {
 
+    /**
+     * Name of the property that contains the panel item's title.
+     */
     public static final String PN_PANEL_TITLE = "cq:panelTitle";
 
+    /**
+     * Construct a panel item.
+     *
+     * @param resource The resource.
+     * @param parentId The ID of the containing component.
+     */
     public PanelContainerItemImpl(@NotNull final Resource resource, final String parentId) {
         super(resource, parentId);
         title = Optional.ofNullable(resource.getValueMap().get(PN_PANEL_TITLE, String.class))

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
@@ -17,7 +17,6 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.Optional;
 
-import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
 
@@ -28,8 +27,8 @@ public class PanelContainerItemImpl extends ResourceListItemImpl implements List
 
     public static final String PN_PANEL_TITLE = "cq:panelTitle";
 
-    public PanelContainerItemImpl(@NotNull SlingHttpServletRequest request, @NotNull Resource resource, String parentId) {
-        super(request, resource, parentId);
+    public PanelContainerItemImpl(@NotNull final Resource resource, final String parentId) {
+        super(resource, parentId);
         title = Optional.ofNullable(resource.getValueMap().get(PN_PANEL_TITLE, String.class))
             .orElseGet(() -> resource.getValueMap().get(JcrConstants.JCR_TITLE, String.class));
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
@@ -34,12 +34,10 @@ public class ResourceListItemImpl extends AbstractListItemImpl implements ListIt
 
     public ResourceListItemImpl(@NotNull SlingHttpServletRequest request, @NotNull Resource resource, String parentId) {
         super(parentId, resource);
-        ValueMap valueMap = resource.adaptTo(ValueMap.class);
-        if (valueMap != null) {
-            title = valueMap.get(JcrConstants.JCR_TITLE, String.class);
-            description = valueMap.get(JcrConstants.JCR_DESCRIPTION, String.class);
-            lastModified = valueMap.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class);
-        }
+        ValueMap valueMap = resource.getValueMap();
+        title = valueMap.get(JcrConstants.JCR_TITLE, String.class);
+        description = valueMap.get(JcrConstants.JCR_DESCRIPTION, String.class);
+        lastModified = valueMap.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class);
         path = resource.getPath();
         name = resource.getName();
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
@@ -21,17 +21,12 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.day.cq.commons.jcr.JcrConstants;
 
 public class ResourceListItemImpl extends AbstractListItemImpl implements ListItem {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceListItemImpl.class);
-
-    protected String url;
     protected String title;
     protected String description;
     protected Calendar lastModified;
@@ -47,12 +42,11 @@ public class ResourceListItemImpl extends AbstractListItemImpl implements ListIt
         }
         path = resource.getPath();
         name = resource.getName();
-        url = null;
     }
 
     @Override
     public String getURL() {
-        return url;
+        return null;
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
@@ -17,7 +17,6 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.Calendar;
 
-import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.jetbrains.annotations.NotNull;
@@ -32,7 +31,7 @@ public class ResourceListItemImpl extends AbstractListItemImpl implements ListIt
     protected Calendar lastModified;
     protected String name;
 
-    public ResourceListItemImpl(@NotNull SlingHttpServletRequest request, @NotNull Resource resource, String parentId) {
+    public ResourceListItemImpl(@NotNull final Resource resource, final String parentId) {
         super(parentId, resource);
         ValueMap valueMap = resource.getValueMap();
         title = valueMap.get(JcrConstants.JCR_TITLE, String.class);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
@@ -24,13 +24,37 @@ import org.jetbrains.annotations.NotNull;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.day.cq.commons.jcr.JcrConstants;
 
+/**
+ * Resource-backed list item implementation.
+ */
 public class ResourceListItemImpl extends AbstractListItemImpl implements ListItem {
 
+    /**
+     * The title.
+     */
     protected String title;
+
+    /**
+     * The description.
+     */
     protected String description;
+
+    /**
+     * The last modified date.
+     */
     protected Calendar lastModified;
+
+    /**
+     * The name.
+     */
     protected String name;
 
+    /**
+     * Construct a resource-backed list item.
+     *
+     * @param resource The resource.
+     * @param parentId The ID of the containing component.
+     */
     public ResourceListItemImpl(@NotNull final Resource resource, final String parentId) {
         super(parentId, resource);
         ValueMap valueMap = resource.getValueMap();


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1112 
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | None added, all pass
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

- Fixes a possible NPE in the `LayoutContainerImpl.initModel()` method.
- Clean up `ResourceListItemImpl` by removing the unused `url` field and unused `request` constructor parameter.
- For classes that were touched in this PR, javadocs are added for any undocumented members.