### PR TITLE
Ensure service resource resolvers are closed

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
@@ -21,8 +21,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -223,13 +221,19 @@ public class Utils {
      * @return a set of the inherited resource types.
      */
     @NotNull
-    public static Set<String> getSuperTypes(@NotNull String resourceType, @NotNull final ResourceResolver resourceResolver) {
-        return Optional.ofNullable(resourceResolver.getResource(resourceType))
-            .map(Resource::getResourceSuperType)
-            .filter(StringUtils::isNotEmpty)
-            .map(superType -> Stream.concat(Stream.of(superType), getSuperTypes(superType, resourceResolver).stream()))
-            .orElseGet(Stream::empty)
-            .collect(Collectors.toSet());
+    public static Set<String> getSuperTypes(@NotNull final String resourceType, @NotNull final ResourceResolver resourceResolver) {
+        Set<String> superTypes = new HashSet<>();
+        String superType = resourceType;
+        while (superType != null) {
+            superType = Optional.ofNullable(resourceResolver.getResource(superType))
+                .map(Resource::getResourceSuperType)
+                .filter(StringUtils::isNotEmpty)
+                .orElse(null);
+            if (superType != null) {
+                superTypes.add(superType);
+            }
+        }
+        return superTypes;
     }
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
@@ -136,7 +136,8 @@ public class Utils {
      * @param page the {@link Page}
      * @param request the current request
      * @param modelFactory the {@link ModelFactory}
-     * @return
+     *
+     * @return The set of resource types for components used to render a page.
      */
     @NotNull
     public static Set<String> getPageResourceTypes(@NotNull Page page, @NotNull SlingHttpServletRequest request, @NotNull ModelFactory modelFactory) {
@@ -182,12 +183,9 @@ public class Utils {
         if (experienceFragment != null) {
             String fragmentPath = experienceFragment.getLocalizedFragmentVariationPath();
             if (StringUtils.isNotEmpty(fragmentPath)) {
-                ResourceResolver resolver = resource.getResourceResolver();
-                if (resolver != null) {
-                    Resource fragmentResource = resolver.getResource(fragmentPath);
-                    if (fragmentResource != null) {
-                        return getResourceTypes(fragmentResource, request, modelFactory);
-                    }
+                Resource fragmentResource = resource.getResourceResolver().getResource(fragmentPath);
+                if (fragmentResource != null) {
+                    return getResourceTypes(fragmentResource, request, modelFactory);
                 }
             }
         }
@@ -208,12 +206,9 @@ public class Utils {
         Template template = page.getTemplate();
         if (template != null) {
             String templatePath = template.getPath() + AllowedComponentList.STRUCTURE_JCR_CONTENT;
-            ResourceResolver resolver = page.getContentResource().getResourceResolver();
-            if (resolver != null) {
-                Resource templateResource = resolver.getResource(templatePath);
-                if (templateResource != null) {
-                    return getResourceTypes(templateResource, request, modelFactory);
-                }
+            Resource templateResource = request.getResourceResolver().getResource(templatePath);
+            if (templateResource != null) {
+                return getResourceTypes(templateResource, request, modelFactory);
             }
         }
         return Collections.emptySet();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -194,7 +195,7 @@ public class ClientLibrariesImpl implements ClientLibraries {
                 }
             }
         } catch (IOException e) {
-            LOG.error("Failed to include client libraries {}", categoriesArray);
+            LOG.error("Failed to include client libraries {}", Arrays.toString(categoriesArray));
         }
 
         String html = sw.toString();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentFilesImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentFilesImpl.java
@@ -16,6 +16,7 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -27,24 +28,33 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
-import org.apache.sling.models.annotations.injectorspecific.Self;
 
 import com.adobe.cq.wcm.core.components.internal.Utils;
 import com.adobe.cq.wcm.core.components.models.ComponentFiles;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Model(
         adaptables = SlingHttpServletRequest.class,
         adapters = ComponentFiles.class
 )
 public class ComponentFilesImpl implements ComponentFiles {
+    private static final Logger LOG = LoggerFactory.getLogger(ComponentFilesImpl.class);
 
-    @Self
-    SlingHttpServletRequest request;
+    /**
+     * Name of the subservice used to authenticate as in order to be able to read details about components and
+     * client libraries.
+     */
+    public static final String COMPONENTS_SERVICE = "components-service";
 
     @Inject
     @Named(OPTION_RESOURCE_TYPES)
@@ -75,11 +85,15 @@ public class ComponentFilesImpl implements ComponentFiles {
     @Override
     public List<String> getPaths() {
         if (paths == null) {
-            paths = new LinkedList<>();
+            try (ResourceResolver resourceResolver = resolverFactory.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, COMPONENTS_SERVICE))) {
+                paths = new LinkedList<>();
 
-            Set<String> seenResourceTypes = new HashSet<>();
-            for (String resourceType : resourceTypeSet) {
-                addPaths(resourceType, paths, seenResourceTypes);
+                Set<String> seenResourceTypes = new HashSet<>();
+                for (String resourceType : resourceTypeSet) {
+                    addPaths(resourceType, paths, seenResourceTypes, resourceResolver);
+                }
+            } catch (LoginException e) {
+                LOG.error("Cannot login as a service user", e);
             }
         }
         return paths;
@@ -91,10 +105,14 @@ public class ComponentFilesImpl implements ComponentFiles {
      * @param resourceType - the resource type of the component to look into for files matching the defined pattern
      * @param paths - the given collection of file paths
      * @param seenResourceTypes - a set of resource types that were previously searched into, to avoid inheritance loops
+     * @param resourceResolver - The resource resolver.
      */
-    private void addPaths(String resourceType, Collection<String> paths, Set<String> seenResourceTypes) {
-        if (!seenResourceTypes.contains(resourceType)) {
-            Resource resource = Utils.getResource(resourceType, request, resolverFactory);
+    private void addPaths(@Nullable final String resourceType,
+                          @NotNull final Collection<String> paths,
+                          @NotNull final Set<String> seenResourceTypes,
+                          @NotNull final ResourceResolver resourceResolver) {
+        if (resourceType != null && !seenResourceTypes.contains(resourceType)) {
+            Resource resource = resourceResolver.getResource(resourceType);
             if (resource != null) {
                 boolean matched = false;
                 for (Resource child : resource.getChildren()) {
@@ -104,7 +122,7 @@ public class ComponentFilesImpl implements ComponentFiles {
                     }
                 }
                 if (inherited && !matched) {
-                    addPaths(resource.getResourceSuperType(), paths, seenResourceTypes);
+                    addPaths(resource.getResourceSuperType(), paths, seenResourceTypes, resourceResolver);
                 }
             }
         }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentFilesImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentFilesImpl.java
@@ -85,9 +85,9 @@ public class ComponentFilesImpl implements ComponentFiles {
     @Override
     public List<String> getPaths() {
         if (paths == null) {
-            try (ResourceResolver resourceResolver = resolverFactory.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, COMPONENTS_SERVICE))) {
-                paths = new LinkedList<>();
+            paths = new LinkedList<>();
 
+            try (ResourceResolver resourceResolver = resolverFactory.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, COMPONENTS_SERVICE))) {
                 Set<String> seenResourceTypes = new HashSet<>();
                 for (String resourceType : resourceTypeSet) {
                     addPaths(resourceType, paths, seenResourceTypes, resourceResolver);

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/UtilsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/UtilsTest.java
@@ -126,5 +126,8 @@ class UtilsTest {
             add("test");
         }};
         assertEquals(reference, Utils.getStrings("test"));
+
+        // Test null
+        assertEquals(new LinkedHashSet<String>(), Utils.getStrings(null));
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
@@ -25,10 +25,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.models.factory.ModelFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,8 +55,10 @@ import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -270,16 +275,35 @@ class ClientLibrariesImplTest {
 
     @Test
     void testGetCategories() {
-        PageManager pageManager = context.resourceResolver().adaptTo(PageManager.class);
+        PageManager pageManager = context.pageManager();
         Page page = pageManager.getPage(ROOT_PAGE);
         Map<String, Object> attributes = new HashMap<>();
         attributes.put(ClientLibraries.OPTION_RESOURCE_TYPES, Utils.getPageResourceTypes(page, context.request(), mock(ModelFactory.class)));
-        ClientLibraries clientlibs = getClientLibrariesUnderTest(ROOT_PAGE, attributes);
+        ClientLibrariesImpl clientlibs = Objects.requireNonNull((ClientLibrariesImpl) getClientLibrariesUnderTest(ROOT_PAGE, attributes));
+
         Set<String> categories = new HashSet<>();
         categories.add(TEASER_CATEGORY);
         categories.add(ACCORDION_CATEGORY);
         categories.add(CAROUSEL_CATEGORY);
-        assertEquals(categories, ((ClientLibrariesImpl)clientlibs).getCategoriesFromComponents());
+        assertEquals(categories, clientlibs.getCategoriesFromComponents());
+    }
+
+    /**
+     * Same as {@link #testGetCategories()} however a login exception will occur when fetching the
+     * resource resolver.
+     */
+    @Test
+    void testGetCategoriesWithLoginException() throws Exception {
+        PageManager pageManager = context.pageManager();
+        Page page = pageManager.getPage(ROOT_PAGE);
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put(ClientLibraries.OPTION_RESOURCE_TYPES, Utils.getPageResourceTypes(page, context.request(), mock(ModelFactory.class)));
+        ClientLibrariesImpl clientlibs = Objects.requireNonNull((ClientLibrariesImpl) getClientLibrariesUnderTest(ROOT_PAGE, attributes));
+
+        ResourceResolverFactory factory = mock(ResourceResolverFactory.class);
+        doThrow(new LoginException()).when(factory).getServiceResourceResolver(anyMap());
+        clientlibs.resolverFactory = factory;
+        assertEquals(new HashSet<>(), clientlibs.getCategoriesFromComponents());
     }
 
     @Test


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1118 
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | none added
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

@vladbailescu Sorry I already had this staged when i saw you pushed #1120. I should have clarified that I would suggest a solution. I'll offer it up anyway if there is any interest in it.
 
- Removes utility for creating service resource resolvers with elevated permissions; requires caller to provide resource resolver
- Uses try-with-resource from caller (`ComponentFilesImpl` & `ClientLibrariesImpl`) to ensure that the resource resolver is closed, this also opens the potential to use different service users for different tasks in the future.
- Fixes a theoretical NPE in `Utils` due to page content resource potentially being null
- Reworks `ClientLibrariesImpl` a bit to have less deep nesting of conditions/loops (no functional change)
