### PR TITLE
[Testing] Convert all tests to use Junit5

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -499,23 +499,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Only required for junit 4 -->
-        <dependency>
-            <groupId>io.wcm</groupId>
-            <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/childreneditor/Item.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/childreneditor/Item.java
@@ -25,6 +25,8 @@ import com.day.cq.wcm.api.components.Component;
 import com.day.cq.wcm.api.components.ComponentManager;
 import com.day.text.Text;
 
+import java.util.Optional;
+
 /**
  * Defines an {@code Item} class, used by the children editor {@code Editor} Sling Model.
  *
@@ -75,11 +77,9 @@ public class Item {
         I18n i18n = new I18n(request);
         if (resource != null) {
             name = resource.getName();
-            ValueMap vm = resource.adaptTo(ValueMap.class);
-            if (vm != null) {
-                String jcrTitle = vm.get(JcrConstants.JCR_TITLE, String.class);
-                value = vm.get(PN_PANEL_TITLE, jcrTitle);
-            }
+            ValueMap vm = resource.getValueMap();
+            value = Optional.ofNullable(vm.get(PN_PANEL_TITLE, String.class))
+                .orElseGet(() -> vm.get(JcrConstants.JCR_TITLE, String.class));
         }
         ComponentManager componentManager = request.getResourceResolver().adaptTo(ComponentManager.class);
         if (componentManager != null) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/ContentFragmentModelsCommonsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/ContentFragmentModelsCommonsTest.java
@@ -15,7 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.adobe.cq.wcm.core.components.testing.AbstractModelTest;
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/ModelsCommonsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/ModelsCommonsTest.java
@@ -15,7 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.adobe.cq.wcm.core.components.testing.AbstractModelTest;
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/Utils.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/Utils.java
@@ -34,8 +34,8 @@ import com.adobe.cq.wcm.core.components.internal.jackson.PageModuleProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 /**
@@ -105,21 +105,6 @@ public class Utils {
      * @param enabled {@code true} to enable the data layer, {@code false} to disable it
      */
     public static void enableDataLayer(AemContext context, boolean enabled) {
-        ConfigurationBuilder builder = Mockito.mock(ConfigurationBuilder.class);
-        DataLayerConfig dataLayerConfig = Mockito.mock(DataLayerConfig.class);
-        when(dataLayerConfig.enabled()).thenReturn(enabled);
-        when(builder.as(DataLayerConfig.class)).thenReturn(dataLayerConfig);
-        context.registerAdapter(Resource.class, ConfigurationBuilder.class, builder);
-    }
-
-    /**
-     * Sets the data layer context aware configuration of the AEM test context to enabled/disabled
-     * for older test context (before io.wcm.testing.mock.aem.junit5.AemContext was introduced)
-     *
-     * @param context The non-junit5 AEM test context
-     * @param enabled {@code true} to enable the data layer, {@code false} to disable it
-     */
-    public static void enableDataLayerForOldAemContext(io.wcm.testing.mock.aem.junit.AemContext context, boolean enabled) {
         ConfigurationBuilder builder = Mockito.mock(ConfigurationBuilder.class);
         DataLayerConfig dataLayerConfig = Mockito.mock(DataLayerConfig.class);
         when(dataLayerConfig.enabled()).thenReturn(enabled);

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/childreneditor/EditorTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/childreneditor/EditorTest.java
@@ -36,8 +36,8 @@ import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(AemContextExtension.class)
 class EditorTest {
@@ -72,7 +72,7 @@ class EditorTest {
     void testGetItems() {
         Editor childrenEditor = getItemsEditor(CAROUSEL_PATH);
         List<Item> items = childrenEditor.getItems();
-        assertEquals("Number of items is not the same.", 5, items.size());
+        assertEquals(5, items.size(), "Number of items is not the same.");
         Object[][] expectedItems = {
             {"item_1", "Teaser 1", "Teaser (v1)", "image", null, null},
             {"item_2", "Teaser 2", "Teaser Icon Abbreviation", null, null, "Aa"},
@@ -82,12 +82,12 @@ class EditorTest {
         };
         int index = 0;
         for (Item item : items) {
-            assertEquals("Item name does not match the expected.", expectedItems[index][0], item.getName());
-            assertEquals("Item value does not match the expected.", expectedItems[index][1], item.getValue());
-            assertEquals("Item title does not match the expected.", expectedItems[index][2], item.getTitle());
-            assertEquals("Item icon name does not match the expected.", expectedItems[index][3], item.getIconName());
-            assertEquals("Item icon path does not match the expected.", expectedItems[index][4], item.getIconPath());
-            assertEquals("Item icon abbreviation does not match the expected.", expectedItems[index][5], item.getIconAbbreviation());
+            assertEquals(expectedItems[index][0], item.getName(), "Item name does not match the expected.");
+            assertEquals(expectedItems[index][1], item.getValue(), "Item value does not match the expected.");
+            assertEquals(expectedItems[index][2], item.getTitle(), "Item title does not match the expected.");
+            assertEquals(expectedItems[index][3], item.getIconName(), "Item icon name does not match the expected.");
+            assertEquals(expectedItems[index][4], item.getIconPath(), "Item icon path does not match the expected.");
+            assertEquals(expectedItems[index][5], item.getIconAbbreviation(), "Item icon abbreviation does not match the expected.");
             index++;
         }
     }
@@ -101,7 +101,7 @@ class EditorTest {
         Resource r = childrenEditor.getContainer();
         Iterator<String> it = Arrays.asList("item_1", "item_2", "item_3", "item_4", "item_5", "item_6").iterator();
         for (Resource child : r.getChildren()) {
-            assertEquals("Child not found.", child.getName(), it.next());
+            assertEquals(child.getName(), it.next(), "Child not found.");
         }
     }
 
@@ -112,7 +112,7 @@ class EditorTest {
     void testEmptySuffix() {
         Editor childrenEditor = getItemsEditor("");
         Resource resource = childrenEditor.getContainer();
-        assertNull("For an empty suffix, expected container resource to be null.", resource);
+        assertNull(resource, "For an empty suffix, expected container resource to be null.");
     }
 
     /**
@@ -122,7 +122,7 @@ class EditorTest {
     void testInvalidSuffix() {
         Editor childrenEditor = getItemsEditor("/asdf/adf/asdf");
         Resource resource = childrenEditor.getContainer();
-        assertNull("For an invalid suffix, expected container resource to be null.", resource);
+        assertNull(resource, "For an invalid suffix, expected container resource to be null.");
     }
 
     private Editor getItemsEditor(String suffix) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/context/CoreComponentTestContext.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/context/CoreComponentTestContext.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.impl.ResourceTypeBasedResourcePicker;
 import org.apache.sling.models.spi.ImplementationPicker;
@@ -32,8 +31,7 @@ import com.adobe.cq.wcm.core.components.testing.MockResponsiveGrid;
 import com.adobe.cq.wcm.core.components.testing.MockSlingModelFilter;
 import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.msm.api.MSMNameConstants;
-import io.wcm.testing.mock.aem.junit.AemContext;
-import io.wcm.testing.mock.aem.junit.AemContextCallback;
+import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
 
 /**
@@ -52,38 +50,9 @@ public final class CoreComponentTestContext {
         // only static methods
     }
 
-    public static AemContext createContext() {
-        return createContext(null, null);
-    }
-
-    /**
-     * Creates a new instance of {@link AemContext}, adds the project specific Sling Models and loads test data from the JSON file
-     * "/test-content.json" in the current classpath
-     *
-     * @param testBase    Prefix of the classpath resource to load test data from. Optional, can be null. If null, test data will be
-     *                    loaded from /test-content.json
-     * @param contentRoot Path to import the JSON content to
-     * @return New instance of {@link AemContext}
-     */
-    public static AemContext createContext(final String testBase, final String contentRoot) {
-        return new AemContext(
-            (AemContextCallback) context -> {
-                context.registerService(ImplementationPicker.class, new ResourceTypeBasedResourcePicker());
-                if (testBase != null) {
-                    if (StringUtils.isNotEmpty(testBase)) {
-                        context.load().json(testBase + TEST_CONTENT_JSON, contentRoot);
-                    } else {
-                        context.load().json(TEST_CONTENT_JSON, contentRoot);
-                    }
-                }
-            },
-            ResourceResolverType.JCR_MOCK
-        );
-    }
-
-    public static io.wcm.testing.mock.aem.junit5.AemContext newAemContext() {
+    public static AemContext newAemContext() {
         return new AemContextBuilder().resourceResolverType(ResourceResolverType.JCR_MOCK)
-            .<io.wcm.testing.mock.aem.junit5.AemContext>afterSetUp(context -> {
+            .<AemContext>afterSetUp(context -> {
                     context.addModelsForClasses(MockResponsiveGrid.class);
                     context.addModelsForPackage("com.adobe.cq.wcm.core.components.models");
                     context.registerService(SlingModelFilter.class, new MockSlingModelFilter() {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/context/CoreComponentTestContext.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/context/CoreComponentTestContext.java
@@ -42,8 +42,10 @@ import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
 public final class CoreComponentTestContext {
 
     public static final String TEST_CONTENT_JSON = "/test-content.json";
+    public static final String TEST_TAGS_JSON = "/test-tags.json";
     public static final String TEST_CONTENT_DAM_JSON = "/test-content-dam.json";
     public static final String TEST_APPS_JSON = "/test-apps.json";
+    public static final String TEST_CONF_JSON = "/test-conf.json";
 
 
     private CoreComponentTestContext() {
@@ -65,48 +67,48 @@ public final class CoreComponentTestContext {
      */
     public static AemContext createContext(final String testBase, final String contentRoot) {
         return new AemContext(
-                (AemContextCallback) context -> {
-                    context.registerService(ImplementationPicker.class, new ResourceTypeBasedResourcePicker());
-                    if (testBase != null) {
-                        if (StringUtils.isNotEmpty(testBase)) {
-                            context.load().json(testBase + TEST_CONTENT_JSON, contentRoot);
-                        } else {
-                            context.load().json(TEST_CONTENT_JSON, contentRoot);
-                        }
+            (AemContextCallback) context -> {
+                context.registerService(ImplementationPicker.class, new ResourceTypeBasedResourcePicker());
+                if (testBase != null) {
+                    if (StringUtils.isNotEmpty(testBase)) {
+                        context.load().json(testBase + TEST_CONTENT_JSON, contentRoot);
+                    } else {
+                        context.load().json(TEST_CONTENT_JSON, contentRoot);
                     }
-                },
-                ResourceResolverType.JCR_MOCK
+                }
+            },
+            ResourceResolverType.JCR_MOCK
         );
     }
 
     public static io.wcm.testing.mock.aem.junit5.AemContext newAemContext() {
         return new AemContextBuilder().resourceResolverType(ResourceResolverType.JCR_MOCK)
-                .<io.wcm.testing.mock.aem.junit5.AemContext>afterSetUp(context -> {
-                            context.addModelsForClasses(MockResponsiveGrid.class);
-                            context.addModelsForPackage("com.adobe.cq.wcm.core.components.models");
-                            context.registerService(SlingModelFilter.class, new MockSlingModelFilter() {
-                                private final Set<String> IGNORED_NODE_NAMES = new HashSet<String>() {{
-                                    add(NameConstants.NN_RESPONSIVE_CONFIG);
-                                    add(MSMNameConstants.NT_LIVE_SYNC_CONFIG);
-                                    add("cq:annotations");
-                                }};
+            .<io.wcm.testing.mock.aem.junit5.AemContext>afterSetUp(context -> {
+                    context.addModelsForClasses(MockResponsiveGrid.class);
+                    context.addModelsForPackage("com.adobe.cq.wcm.core.components.models");
+                    context.registerService(SlingModelFilter.class, new MockSlingModelFilter() {
+                        private final Set<String> IGNORED_NODE_NAMES = new HashSet<String>() {{
+                            add(NameConstants.NN_RESPONSIVE_CONFIG);
+                            add(MSMNameConstants.NT_LIVE_SYNC_CONFIG);
+                            add("cq:annotations");
+                        }};
 
-                                @Override
-                                public Map<String, Object> filterProperties(Map<String, Object> map) {
-                                    return map;
-                                }
-
-                                @Override
-                                public Iterable<Resource> filterChildResources(Iterable<Resource> childResources) {
-                                    return StreamSupport
-                                            .stream(childResources.spliterator(), false)
-                                            .filter(r -> !IGNORED_NODE_NAMES.contains(r.getName()))
-                                            .collect(Collectors.toList());
-                                }
-                            });
-                            context.registerService(ImplementationPicker.class, new ResourceTypeBasedResourcePicker());
+                        @Override
+                        public Map<String, Object> filterProperties(Map<String, Object> map) {
+                            return map;
                         }
-                )
-                .build();
+
+                        @Override
+                        public Iterable<Resource> filterChildResources(Iterable<Resource> childResources) {
+                            return StreamSupport
+                                .stream(childResources.spliterator(), false)
+                                .filter(r -> !IGNORED_NODE_NAMES.contains(r.getName()))
+                                .collect(Collectors.toList());
+                        }
+                    });
+                    context.registerService(ImplementationPicker.class, new ResourceTypeBasedResourcePicker());
+                }
+            )
+            .build();
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtilsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtilsTest.java
@@ -31,12 +31,11 @@ import org.apache.sling.models.factory.ModelFactory;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.apache.sling.testing.resourceresolver.MockValueMap;
-import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.collection.IsIterableContainingInOrder;
-import org.hamcrest.collection.IsMapContaining;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.adobe.cq.dam.cfm.ContentElement;
@@ -60,7 +59,7 @@ public class ContentFragmentUtilsTest {
         String type = ContentFragmentUtils.getType(null);
 
         // THEN
-        Assert.assertThat(type, CoreMatchers.is(""));
+        Assertions.assertEquals(type, "");
     }
 
     @Test
@@ -75,7 +74,7 @@ public class ContentFragmentUtilsTest {
         String type = ContentFragmentUtils.getType(contentFragment);
 
         // THEN
-        Assert.assertThat(type, CoreMatchers.is("foobar"));
+        Assertions.assertEquals(type, "foobar");
     }
 
     @Test
@@ -95,7 +94,7 @@ public class ContentFragmentUtilsTest {
         String type = ContentFragmentUtils.getType(contentFragment);
 
         // THEN
-        Assert.assertThat(type, CoreMatchers.is("/foo/bar/qux"));
+        Assertions.assertEquals(type, "/foo/bar/qux");
     }
 
     @Test
@@ -118,7 +117,7 @@ public class ContentFragmentUtilsTest {
         String type = ContentFragmentUtils.getType(contentFragment);
 
         // THEN
-        Assert.assertThat(type, CoreMatchers.is("/foo/bar"));
+        Assertions.assertEquals(type, "/foo/bar");
     }
 
     @Test
@@ -144,7 +143,7 @@ public class ContentFragmentUtilsTest {
         String type = ContentFragmentUtils.getType(contentFragment);
 
         // THEN
-        Assert.assertThat(type, CoreMatchers.is("bar/models/waldo"));
+        Assertions.assertEquals(type, "bar/models/waldo");
     }
 
 
@@ -160,7 +159,7 @@ public class ContentFragmentUtilsTest {
         Iterator<ContentElement> elementIterator = ContentFragmentUtils.filterElements(contentFragment, null);
 
         // THEN
-        Assert.assertThat(elementIterator, CoreMatchers.is(contentElementIterator));
+        Assertions.assertEquals(elementIterator, contentElementIterator);
     }
 
     @Test
@@ -180,7 +179,7 @@ public class ContentFragmentUtilsTest {
                 new String[]{"foo", "bar", "qux"});
 
         // THEN
-        Assert.assertThat(() -> elementIterator, IsIterableContainingInOrder.contains(foo, qux));
+        MatcherAssert.assertThat(() -> elementIterator, IsIterableContainingInOrder.contains(foo, qux));
     }
 
     @Test
@@ -210,7 +209,7 @@ public class ContentFragmentUtilsTest {
                 new String[]{"foo", "bar"});
 
         // THEN
-        Assert.assertThat(expectedJsonOutput.replaceAll("[\n\t ]", ""), CoreMatchers.is(json));
+        Assertions.assertEquals(expectedJsonOutput.replaceAll("[\n\t ]", ""), json);
     }
 
     @Test
@@ -224,7 +223,7 @@ public class ContentFragmentUtilsTest {
         String defaultGridResourceType = ContentFragmentUtils.getGridResourceType(resource);
 
         // THEN
-        Assert.assertThat(defaultGridResourceType, CoreMatchers.is(ContentFragmentUtils.DEFAULT_GRID_TYPE));
+        Assertions.assertEquals(defaultGridResourceType, ContentFragmentUtils.DEFAULT_GRID_TYPE);
     }
 
     @Test
@@ -246,7 +245,7 @@ public class ContentFragmentUtilsTest {
         String defaultGridResourceType = ContentFragmentUtils.getGridResourceType(resource);
 
         // THEN
-        Assert.assertThat(defaultGridResourceType, CoreMatchers.is("foobar"));
+        Assertions.assertEquals(defaultGridResourceType, "foobar");
     }
 
     @Test
@@ -258,7 +257,7 @@ public class ContentFragmentUtilsTest {
         String[] itemsOrder = ContentFragmentUtils.getItemsOrder(items);
 
         // THEN
-        Assert.assertThat(itemsOrder, CoreMatchers.is(ArrayUtils.EMPTY_STRING_ARRAY));
+        Assertions.assertArrayEquals(itemsOrder, ArrayUtils.EMPTY_STRING_ARRAY);
     }
 
     @Test
@@ -273,7 +272,7 @@ public class ContentFragmentUtilsTest {
         String[] itemsOrder = ContentFragmentUtils.getItemsOrder(items);
 
         // THEN
-        Assert.assertThat(itemsOrder, CoreMatchers.is(new String[]{"first", "second", "third"}));
+        Assertions.assertArrayEquals(itemsOrder, new String[]{"first", "second", "third"});
     }
 
     @Test
@@ -297,8 +296,8 @@ public class ContentFragmentUtilsTest {
                         .getResource("/foo").listChildren(), modelFactory, slingHttpServletRequest);
 
         // THEN
-        Assert.assertThat(exporterMap, IsMapContaining.hasEntry("bar", componentExporter));
-        Assert.assertThat(exporterMap, IsMapContaining.hasEntry("qux", componentExporter));
+        Assertions.assertEquals(componentExporter, exporterMap.get("bar"));
+        Assertions.assertEquals(componentExporter, exporterMap.get("qux"));
     }
 
     /**

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtilsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtilsTest.java
@@ -15,20 +15,19 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal;
 
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.commons.io.IOUtils;
+import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.factory.ModelFactory;
-import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.apache.sling.testing.resourceresolver.MockValueMap;
 import org.hamcrest.MatcherAssert;
@@ -45,9 +44,13 @@ import com.adobe.cq.export.json.ComponentExporter;
 import com.day.cq.wcm.api.policies.ContentPolicy;
 import com.day.cq.wcm.api.policies.ContentPolicyManager;
 
+import javax.json.Json;
+import javax.json.JsonReader;
+
 import static com.adobe.cq.wcm.core.components.internal.ContentFragmentUtils.PN_CFM_GRID_TYPE;
 import static com.day.cq.commons.jcr.JcrConstants.JCR_CONTENT;
 import static com.day.cq.commons.jcr.JcrConstants.JCR_TITLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ContentFragmentUtilsTest {
 
@@ -183,10 +186,8 @@ public class ContentFragmentUtilsTest {
     }
 
     @Test
-    public void getEditorJsonOutputOfContentFragment() throws Exception {
+    public void getEditorJsonOutputOfContentFragment() {
         // GIVEN
-        InputStream expectedJsonResourceAsStream = this.getClass().getResourceAsStream("expectedJson.json");
-        String expectedJsonOutput = IOUtils.toString(expectedJsonResourceAsStream, StandardCharsets.UTF_8);
 
         Resource contentFragmentResource = Mockito.mock(Resource.class);
         ContentFragment contentFragment = Mockito.mock(ContentFragment.class);
@@ -209,7 +210,9 @@ public class ContentFragmentUtilsTest {
                 new String[]{"foo", "bar"});
 
         // THEN
-        Assertions.assertEquals(expectedJsonOutput.replaceAll("[\n\t ]", ""), json);
+        JsonReader expected = Json.createReader(this.getClass().getResourceAsStream("expectedJson.json"));
+        JsonReader actual = Json.createReader(new StringReader(json));
+        assertEquals(expected.read(), actual.read());
     }
 
     @Test
@@ -278,7 +281,7 @@ public class ContentFragmentUtilsTest {
     @Test
     public void getComponentExport() {
         // GIVEN
-        SlingContext slingContext = new SlingContext();
+        AemContext slingContext = CoreComponentTestContext.newAemContext();
         slingContext.load().json(this.getClass().getResourceAsStream("foo.json"), "/foo");
         MockSlingHttpServletRequest slingHttpServletRequest =
                 new MockSlingHttpServletRequest(slingContext.bundleContext());

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/form/FormConstantsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/form/FormConstantsTest.java
@@ -15,7 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.form;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.adobe.cq.wcm.core.components.testing.AbstractConstantTest;
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/jackson/DefaultMethodSkippingModuleProviderTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/jackson/DefaultMethodSkippingModuleProviderTest.java
@@ -17,21 +17,22 @@ package com.adobe.cq.wcm.core.components.internal.jackson;
 
 import com.customer.models.CustomerInterfaceWithDefaultMethod;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 import java.io.StringReader;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class DefaultMethodSkippingModuleProviderTest {
 
     private ObjectMapper objectMapper;
 
-    @Before
+    @BeforeEach
     public void setup() {
         objectMapper = new ObjectMapper();
         objectMapper.registerModule(new DefaultMethodSkippingModuleProvider().getModule());
@@ -41,7 +42,7 @@ public class DefaultMethodSkippingModuleProviderTest {
     public void testDefaultMethodIsSkipped() throws Exception {
         Object obj = new ClassUsingDefaultMethod();
         String result = objectMapper.writer().writeValueAsString(obj);
-        try (JsonReader jsonReader = Json.createReader(new StringReader(result));) {
+        try (JsonReader jsonReader = Json.createReader(new StringReader(result))) {
             JsonObject json = jsonReader.readObject();
             assertFalse(json.containsKey("defaultProperty"));
             assertEquals("fromcustomer", json.getString("customerDefaultProperty"));

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/jackson/PageModuleProviderTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/jackson/PageModuleProviderTest.java
@@ -18,7 +18,7 @@ package com.adobe.cq.wcm.core.components.internal.jackson;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.day.cq.wcm.api.Page;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.module.SimpleSerializers;
 import com.fasterxml.jackson.databind.type.ClassKey;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PageModuleProviderTest {
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/jackson/PageSerializerTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/jackson/PageSerializerTest.java
@@ -15,13 +15,16 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.jackson;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.day.cq.wcm.api.Page;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class PageSerializerTest {
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/PageTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/PageTest.java
@@ -19,29 +19,30 @@ import java.util.Calendar;
 import java.util.Map;
 
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.wcm.core.components.models.Page;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PageTest {
 
-    private Page underTest = new MockPage();
+    private final Page underTest = new MockPage();
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetFavicons() throws Exception {
-        underTest.getFavicons();
+    @Test
+    public void testGetFavicons() {
+        Assertions.assertThrows(UnsupportedOperationException.class, underTest::getFavicons);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetFaviconClientLibPath() throws Exception {
-        underTest.getAppResourcesPath();
+    @Test
+    public void testGetFaviconClientLibPath() {
+        Assertions.assertThrows(UnsupportedOperationException.class, underTest::getAppResourcesPath);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetRedirectTarget() throws Exception {
-        underTest.getRedirectTarget();
+    @Test
+    public void testGetRedirectTarget() {
+        Assertions.assertThrows(UnsupportedOperationException.class, underTest::getRedirectTarget);
     }
 
     private static class MockPage implements Page, ContainerExporter {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImplTest.java
@@ -19,17 +19,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
 
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.Container;
 import com.adobe.cq.wcm.core.components.models.ListItem;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(AemContextExtension.class)
 public class AbstractContainerImplTest {
 
     private static final String TEST_BASE = "/container";
@@ -40,12 +42,12 @@ public class AbstractContainerImplTest {
     // private static final String CONTAINER_1 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/container-1";
     private static final String TEST_APPS_ROOT = "/apps/core/wcm/components";
 
-    @ClassRule
-    public static final AemContext AEM_CONTEXT = CoreComponentTestContext.createContext(TEST_BASE, CONTENT_ROOT);
+    public final AemContext context = CoreComponentTestContext.newAemContext();
 
-    @BeforeClass
-    public static void init() {
-        AEM_CONTEXT.load().json(TEST_BASE + CoreComponentTestContext.TEST_APPS_JSON, TEST_APPS_ROOT);
+    @BeforeEach
+    public void setUp() {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, CONTENT_ROOT);
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_APPS_JSON, TEST_APPS_ROOT);
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImplTest.java
@@ -29,7 +29,10 @@ import com.adobe.cq.wcm.core.components.models.ListItem;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 class AccordionImplTest {
@@ -99,13 +102,11 @@ class AccordionImplTest {
     }
 
     private void verifyAccordionItems(Object[][] expectedItems, List<ListItem> items) {
-        assertEquals("The accordion contains a different number of items than expected.", expectedItems.length, items.size());
+        assertEquals(expectedItems.length, items.size(), "The accordion contains a different number of items than expected.");
         int index = 0;
         for (ListItem item : items) {
-            assertEquals("The accordion item's name is not what was expected.",
-                    expectedItems[index][0], item.getName());
-            assertEquals("The accordion item's title is not what was expected: " + item.getTitle(),
-                    expectedItems[index][1], item.getTitle());
+            assertEquals(expectedItems[index][0], item.getName(), "The accordion item's name is not what was expected.");
+            assertEquals(expectedItems[index][1], item.getTitle(), "The accordion item's title is not what was expected: " + item.getTitle());
             index++;
         }
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImplTest.java
@@ -28,7 +28,7 @@ import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(AemContextExtension.class)
 class BreadcrumbImplTest {
@@ -96,8 +96,8 @@ class BreadcrumbImplTest {
     }
 
     private void checkBreadcrumbConsistency(Breadcrumb breadcrumb, String[] expectedPages) {
-        assertEquals("Expected that the returned breadcrumb will contain " + expectedPages.length + " items", breadcrumb.getItems().size(),
-                expectedPages.length);
+        assertEquals(breadcrumb.getItems().size(), expectedPages.length,
+            "Expected that the returned breadcrumb will contain " + expectedPages.length + " items");
         int index = 0;
         for (NavigationItem item : breadcrumb.getItems()) {
             assertEquals(expectedPages[index++], item.getTitle());

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ButtonImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ButtonImplTest.java
@@ -27,7 +27,7 @@ import com.adobe.cq.wcm.core.components.models.Button;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(AemContextExtension.class)
 class ButtonImplTest {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImplTest.java
@@ -31,7 +31,9 @@ import com.adobe.cq.wcm.core.components.models.ListItem;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @ExtendWith(AemContextExtension.class)
@@ -87,26 +89,19 @@ class CarouselImplTest {
     }
 
     private void verifyCarouselItems(Object[][] expectedItems, List<ListItem> items, String carouselId) {
-        assertEquals("The carousel contains a different number of items than expected.", expectedItems.length,
-                items.size());
+        assertEquals(expectedItems.length, items.size(), "The carousel contains a different number of items than expected.");
         int index = 0;
         for (ListItem item : items) {
-            assertEquals("The carousel item's name is not what was expected.", expectedItems[index][0], item.getName());
-            assertEquals("The carousel item's title is not what was expected: " + item.getTitle(),
-                    expectedItems[index][1], item.getTitle());
-            assertEquals("The carousel item's path is not what was expected: " + item.getPath(),
-                    expectedItems[index][3], item.getPath());
+            assertEquals(expectedItems[index][0], item.getName(), "The carousel item's name is not what was expected.");
+            assertEquals(expectedItems[index][1], item.getTitle(), "The carousel item's title is not what was expected: " + item.getTitle());
+            assertEquals(expectedItems[index][3], item.getPath(), "The carousel item's path is not what was expected: " + item.getPath());
 
             if (item.getData() != null) {
-                assertNotEquals("The carousel item's data layer string is empty", item.getData().getJson(), "{}");
-
-                assertEquals("The carousel item's data layer title is not what was expected: " + item.getData().getTitle(),
-                        expectedItems[index][1], item.getData().getTitle());
-                assertEquals("The carousel item's data layer type is not what was expected: " + item.getData().getType(),
-                        expectedItems[index][2], item.getData().getType());
-                assertEquals("The carousel item's data layer id is not what was expected: " + item.getData().getId(),
-                        com.adobe.cq.wcm.core.components.internal.Utils.generateId(carouselId + "-item", (String) expectedItems[index][3]),
-                        item.getData().getId());
+                assertNotEquals(item.getData().getJson(), "{}", "The carousel item's data layer string is empty");
+                assertEquals(expectedItems[index][1], item.getData().getTitle(), "The carousel item's data layer title is not what was expected: " + item.getData().getTitle());
+                assertEquals(expectedItems[index][2], item.getData().getType(), "The carousel item's data layer type is not what was expected: " + item.getData().getType());
+                assertEquals(com.adobe.cq.wcm.core.components.internal.Utils.generateId(carouselId + "-item", (String) expectedItems[index][3]),
+                        item.getData().getId(), "The carousel item's data layer id is not what was expected: " + item.getData().getId());
             }
             index++;
         }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
@@ -49,7 +49,7 @@ import com.day.cq.wcm.api.PageManager;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyBoolean;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentImplTest.java
@@ -18,7 +18,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,13 +53,13 @@ public class ComponentImplTest {
     @Test
     public void testComponentId() {
         Component component = getComponentUnderTest(XF_COMPONENT_1);
-        Assert.assertEquals("ID mismatch", "experiencefragment-4d2d8fd496", component.getId());
+        Assertions.assertEquals("experiencefragment-4d2d8fd496", component.getId(), "ID mismatch");
     }
 
     @Test
     public void testReferencedComponentId() {
         Component component = getReferencedComponentUnderTest(XF_COMPONENT_1, TEST_PAGE_EN, XF_COMPONENT_10);
-        Assert.assertEquals("ID mismatch", "experiencefragment-789e0d5de3", component.getId());
+        Assertions.assertEquals("experiencefragment-789e0d5de3", component.getId(), "ID mismatch");
     }
 
     private Component getComponentUnderTest(String resourcePath, Object ... properties) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImplTest.java
@@ -30,7 +30,9 @@ import com.day.cq.wcm.api.designer.Style;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(AemContextExtension.class)
@@ -74,7 +76,7 @@ class DownloadImplTest {
     void setUp() {
         context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, CONTENT_ROOT);
         context.load().json(TEST_BASE + TEST_CONTENT_DAM_JSON, "/content/dam/core/documents");
-        context.load().binaryFile("/download/" + PDF_BINARY_NAME, PDF_ASSET_PATH + "/jcr:content/renditions/original");
+        context.load().binaryFile(TEST_BASE + "/" + PDF_BINARY_NAME, PDF_ASSET_PATH + "/jcr:content/renditions/original");
     }
 
     @Test
@@ -94,7 +96,7 @@ class DownloadImplTest {
     @Test
     void testFullyConfiguredDownload_assetWithoutSizeProperty() {
         context.load().json(TEST_BASE + TEST_CONTENT_DAM_WITHOUT_SIZE_PROP_JSON, "/content/dam/core/documents_without_size");
-        context.load().binaryFile("/download/" + PDF_BINARY_NAME, PDF_ASSET_WITHOUT_SIZE_PROP_PATH + "/jcr:content/renditions/original");
+        context.load().binaryFile(TEST_BASE+ "/" + PDF_BINARY_NAME, PDF_ASSET_WITHOUT_SIZE_PROP_PATH + "/jcr:content/renditions/original");
 
         Download download = getDownloadUnderTest(DOWNLOAD_4);
         assertEquals(TITLE, download.getTitle());
@@ -139,9 +141,9 @@ class DownloadImplTest {
                 Download.PN_DISPLAY_FILENAME, true,
                 Download.PN_DISPLAY_FORMAT, true,
                 Download.PN_DISPLAY_SIZE, true);
-        assertTrue("Display of filename is not enabled", download.displayFilename());
-        assertTrue("Display of file size is not enabled", download.displaySize());
-        assertTrue("Display of file format is not enabled", download.displayFormat());
+        assertTrue(download.displayFilename(), "Display of filename is not enabled");
+        assertTrue(download.displaySize(), "Display of file size is not enabled");
+        assertTrue(download.displayFormat(), "Display of file format is not enabled");
         Utils.testJSONExport(download, Utils.getTestExporterJSONPath(TEST_BASE, DOWNLOAD_FULLY_CONFIGURED));
     }
 
@@ -149,7 +151,7 @@ class DownloadImplTest {
     void testDownloadWithTitleType() {
         Download download = getDownloadUnderTest(DOWNLOAD_1,
                 Download.PN_TITLE_TYPE, "h5");
-        assertEquals("Expected title type is not correct", "h5", download.getTitleType());
+        assertEquals("h5", download.getTitleType(), "Expected title type is not correct");
         Utils.testJSONExport(download, Utils.getTestExporterJSONPath(TEST_BASE, DOWNLOAD_WITH_TITLE_TYPE));
     }
 
@@ -159,7 +161,7 @@ class DownloadImplTest {
         Style mockStyle = new MockStyle(mockResource, new MockValueMap(mockResource));
 
         Download download = getDownloadUnderTest(DOWNLOAD_1, mockStyle);
-        assertNull("Expected title type is not correct", download.getTitleType());
+        assertNull(download.getTitleType(), "Expected title type is not correct");
         Utils.testJSONExport(download, Utils.getTestExporterJSONPath(TEST_BASE, DOWNLOAD_FULLY_CONFIGURED));
     }
 
@@ -167,14 +169,14 @@ class DownloadImplTest {
     void testDownloadWithCustomActionText() {
         Download download = getDownloadUnderTest(DOWNLOAD_1,
                 Download.PN_ACTION_TEXT, STYLE_ACTION_TEST);
-        assertEquals("Expected action text is not correct", COMPONENT_ACTION_TEXT, download.getActionText());
+        assertEquals(COMPONENT_ACTION_TEXT, download.getActionText(), "Expected action text is not correct");
         Utils.testJSONExport(download, Utils.getTestExporterJSONPath(TEST_BASE, DOWNLOAD_FULLY_CONFIGURED));
     }
 
     @Test
     void testDownloadWithoutActionText() {
         Download downloadWithoutActionText = getDownloadUnderTest(DOWNLOAD_2);
-        assertNull("Expected action text is not correct", downloadWithoutActionText.getActionText());
+        assertNull(downloadWithoutActionText.getActionText(), "Expected action text is not correct");
         Utils.testJSONExport(downloadWithoutActionText, Utils.getTestExporterJSONPath(TEST_BASE, DOWNLOAD_WITH_DAM_PROPERTIES));
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/EmbedImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/EmbedImplTest.java
@@ -31,8 +31,8 @@ import com.day.cq.wcm.api.designer.Style;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(AemContextExtension.class)

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImplTest.java
@@ -41,7 +41,7 @@ import com.day.cq.wcm.msm.api.LiveRelationshipManager;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,8 +51,10 @@ class ExperienceFragmentImplTest {
 
     private static final String TEST_BASE = "/experiencefragment";
     private static final String CONTEXT_PATH = "/core";
-    private static final String SITE_ROOT = "/content/mysite";
-    private static final String PRODUCT_PAGE_TEMPLATE = "/conf/coretest/settings/wcm/templates/product-page";
+    private static final String CONTENT_ROOT = "/content";
+    private static final String SITE_ROOT = CONTENT_ROOT + "/mysite";
+    private static final String CONF_ROOT = "/conf/coretest/settings";
+    private static final String PRODUCT_PAGE_TEMPLATE = CONF_ROOT + "/wcm/templates/product-page";
     private static final String NO_LOC_PAGE = SITE_ROOT + "/page";
     private static final String EN_PAGE = SITE_ROOT + "/en/page";
     private static final String US_EN_PAGE = SITE_ROOT + "/us/en/page";
@@ -68,87 +70,83 @@ class ExperienceFragmentImplTest {
 
     @BeforeEach
     void setUp() throws WCMException {
-        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, "/content");
-        context.load().json(TEST_BASE + "/test-conf.json", "/conf/coretest/settings");
-       
-        context.addModelsForPackage("com.adobe.cq.wcm.core.components.internal.models.dummy");
-        context.addModelsForClasses("com.adobe.cq.wcm.core.components.internal.models.v1");
-        
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, CONTENT_ROOT);
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONF_JSON, CONF_ROOT);
         context.registerService(LanguageManager.class, new MockLanguageManager());
         LiveRelationshipManager relationshipManager = mock(LiveRelationshipManager.class);
         when(relationshipManager.isSource(any(Resource.class))).then(
-                invocation -> {
-                    Object[] arguments = invocation.getArguments();
-                    Resource resource = (Resource) arguments[0];
-                    return BLUEPRINT_PAGE.equals(resource.getPath());
-                }
+            invocation -> {
+                Object[] arguments = invocation.getArguments();
+                Resource resource = (Resource) arguments[0];
+                return BLUEPRINT_PAGE.equals(resource.getPath());
+            }
         );
         when(relationshipManager.getLiveRelationships(any(Resource.class), isNull(), isNull())).then(
-                invocation -> {
-                    Object[] arguments = invocation.getArguments();
-                    Resource resource = (Resource) arguments[0];
-                    if (BLUEPRINT_PAGE.equals(resource.getPath())) {
-                        LiveRelationship liveRelationship = mock(LiveRelationship.class);
-                        LiveCopy liveCopy = mock(LiveCopy.class);
-                        when(liveCopy.getBlueprintPath()).thenReturn(BLUEPRINT_ROOT);
-                        when(liveRelationship.getLiveCopy()).thenReturn(liveCopy);
-                        final ArrayList<LiveRelationship> relationships = new ArrayList<>();
-                        relationships.add(liveRelationship);
-                        final Iterator iterator = relationships.iterator();
-                        return new RangeIterator() {
+            invocation -> {
+                Object[] arguments = invocation.getArguments();
+                Resource resource = (Resource) arguments[0];
+                if (BLUEPRINT_PAGE.equals(resource.getPath())) {
+                    LiveRelationship liveRelationship = mock(LiveRelationship.class);
+                    LiveCopy liveCopy = mock(LiveCopy.class);
+                    when(liveCopy.getBlueprintPath()).thenReturn(BLUEPRINT_ROOT);
+                    when(liveRelationship.getLiveCopy()).thenReturn(liveCopy);
+                    final ArrayList<LiveRelationship> relationships = new ArrayList<>();
+                    relationships.add(liveRelationship);
+                    final Iterator<LiveRelationship> iterator = relationships.iterator();
+                    return new RangeIterator() {
 
-                            int index = 0;
+                        int index = 0;
 
-                            @Override
-                            public void skip(long skipNum) {
+                        @Override
+                        public void skip(long skipNum) {
 
-                            }
+                        }
 
-                            @Override
-                            public long getSize() {
-                                return relationships.size();
-                            }
+                        @Override
+                        public long getSize() {
+                            return relationships.size();
+                        }
 
-                            @Override
-                            public long getPosition() {
-                                return index;
-                            }
+                        @Override
+                        public long getPosition() {
+                            return index;
+                        }
 
-                            @Override
-                            public boolean hasNext() {
-                                return iterator.hasNext();
-                            }
+                        @Override
+                        public boolean hasNext() {
+                            return iterator.hasNext();
+                        }
 
-                            @Override
-                            public Object next() {
-                                index++;
-                                return iterator.next();
-                            }
-                        };
-                    }
-                    return null;
+                        @Override
+                        public Object next() {
+                            index++;
+                            return iterator.next();
+                        }
+                    };
                 }
+                return null;
+            }
         );
         when(relationshipManager.hasLiveRelationship(any(Resource.class))).then(
-                invocation -> {
-                    Object[] arguments = invocation.getArguments();
-                    Resource resource = (Resource) arguments[0];
-                    return LIVECOPY_PAGE.equals(resource.getPath());
-                }
+            invocation -> {
+                Object[] arguments = invocation.getArguments();
+                Resource resource = (Resource) arguments[0];
+                return LIVECOPY_PAGE.equals(resource.getPath());
+            }
         );
         when(relationshipManager.getLiveRelationship(any(Resource.class), anyBoolean())).then(
-                invocation -> {
-                    Object[] arguments = invocation.getArguments();
-                    Resource resource = (Resource) arguments[0];
-                    if (LIVECOPY_PAGE.equals(resource.getPath())) {
-                        LiveRelationship liveRelationship = mock(LiveRelationship.class);
-                        LiveCopy liveCopy = mock(LiveCopy.class);
-                        when(liveCopy.getPath()).thenReturn(LIVECOPY_ROOT);
-                        when(liveRelationship.getLiveCopy()).thenReturn(liveCopy);
-                        return liveRelationship;
-                    }
-                    return null;
+            invocation -> {
+                Object[] arguments = invocation.getArguments();
+                Resource resource = (Resource) arguments[0];
+                if (LIVECOPY_PAGE.equals(resource.getPath())) {
+                    LiveRelationship liveRelationship = mock(LiveRelationship.class);
+                    LiveCopy liveCopy = mock(LiveCopy.class);
+                    when(liveCopy.getPath()).thenReturn(LIVECOPY_ROOT);
+                    when(liveRelationship.getLiveCopy()).thenReturn(liveCopy);
+                    return liveRelationship;
                 }
+                return null;
+            }
         );
         context.registerService(LiveRelationshipManager.class, relationshipManager);
     }
@@ -165,7 +163,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInPageWithoutLocalization() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(NO_LOC_PAGE
-                + "/jcr:content/root/xf-component-1");
+            + "/jcr:content/root/xf-component-1");
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf1"));
     }
@@ -178,7 +176,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInTemplateWithoutLocalization() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-1a", NO_LOC_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-1a", NO_LOC_PAGE);
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf1"));
     }
@@ -191,7 +189,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testUndefinedXFInPageWithoutLocalization() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(NO_LOC_PAGE
-                + "/jcr:content/root/xf-component-2");
+            + "/jcr:content/root/xf-component-2");
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf2"));
     }
 
@@ -203,7 +201,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testUndefinedXFInTemplateWithoutLocalization() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-2a", NO_LOC_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-2a", NO_LOC_PAGE);
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf2"));
     }
 
@@ -215,7 +213,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testEmptyXFInPageWithoutLocalization() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(NO_LOC_PAGE
-                + "/jcr:content/root/xf-component-3");
+            + "/jcr:content/root/xf-component-3");
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf3"));
     }
 
@@ -227,7 +225,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testEmptyXFInTemplateWithoutLocalization() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-3a", NO_LOC_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-3a", NO_LOC_PAGE);
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf3"));
     }
 
@@ -243,7 +241,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInPageWithLocalizationWithSameLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(EN_PAGE
-                + "/jcr:content/root/xf-component-10");
+            + "/jcr:content/root/xf-component-10");
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf10"));
     }
@@ -256,7 +254,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInTemplateWithLocalizationWithSameLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-10a", EN_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-10a", EN_PAGE);
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf10"));
     }
@@ -269,7 +267,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInPageWithLocalizationWithDifferentLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(EN_PAGE
-                + "/jcr:content/root/xf-component-11");
+            + "/jcr:content/root/xf-component-11");
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf11"));
     }
@@ -282,7 +280,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInTemplateWithLocalizationWithDifferentLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-11a", EN_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-11a", EN_PAGE);
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf11a"));
     }
@@ -295,7 +293,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testUndefinedXFInPageWithLocalization() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(EN_PAGE
-                + "/jcr:content/root/xf-component-12");
+            + "/jcr:content/root/xf-component-12");
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf12"));
     }
 
@@ -307,7 +305,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testUndefinedXFInTemplateWithLocalization() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-12a", EN_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-12a", EN_PAGE);
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf12"));
     }
 
@@ -319,7 +317,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testEmptyXFInPageWithLocalization() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(EN_PAGE
-                + "/jcr:content/root/xf-component-13");
+            + "/jcr:content/root/xf-component-13");
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf13"));
     }
 
@@ -331,8 +329,8 @@ class ExperienceFragmentImplTest {
     @Test
     void testEmptyXFInTemplateWithLocalization() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-13a", EN_PAGE);
-        Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf13a"));
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-13a", EN_PAGE);
+        Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf13"));
     }
 
 
@@ -347,7 +345,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInPageWithLocalizationWithSameCountryLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(US_EN_PAGE
-                + "/jcr:content/root/xf-component-20");
+            + "/jcr:content/root/xf-component-20");
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf20"));
     }
@@ -360,7 +358,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInTemplateWithLocalizationWithSameCountryLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-20a", US_EN_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-20a", US_EN_PAGE);
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf20"));
     }
@@ -373,7 +371,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInPageWithLocalizationWithDifferentCountryLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(US_EN_PAGE
-                + "/jcr:content/root/xf-component-21");
+            + "/jcr:content/root/xf-component-21");
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf21"));
     }
@@ -386,7 +384,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInTemplateWithLocalizationWithDifferentCountryLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-21a", US_EN_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-21a", US_EN_PAGE);
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf21a"));
     }
@@ -399,7 +397,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testUndefinedXFInPageWithLocalizationWithDifferentCountryLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(US_EN_PAGE
-                + "/jcr:content/root/xf-component-22");
+            + "/jcr:content/root/xf-component-22");
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf22"));
     }
 
@@ -411,7 +409,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testUndefinedXFInTemplateWithLocalizationWithDifferentCountryLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-22a", US_EN_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-22a", US_EN_PAGE);
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf22"));
     }
 
@@ -427,7 +425,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInPageWithLocalizationWithSameCountrySiteLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(CH_MYSITE_FR_PAGE
-                + "/jcr:content/root/xf-component-30");
+            + "/jcr:content/root/xf-component-30");
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf30"));
     }
@@ -440,7 +438,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInTemplateWithLocalizationWithSameCountrySiteLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-30a", CH_MYSITE_FR_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-30a", CH_MYSITE_FR_PAGE);
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf30"));
     }
@@ -453,7 +451,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInPageWithLocalizationWithDifferentCountrySiteLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(CH_MYSITE_FR_PAGE
-                + "/jcr:content/root/xf-component-31");
+            + "/jcr:content/root/xf-component-31");
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf31"));
     }
@@ -466,7 +464,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInTemplateWithLocalizationWithDifferentCountrySiteLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-31a", CH_MYSITE_FR_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-31a", CH_MYSITE_FR_PAGE);
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf31a"));
     }
@@ -479,7 +477,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testUndefinedXFInPageWithLocalizationWithDifferentCountrySiteLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(CH_MYSITE_FR_PAGE
-                + "/jcr:content/root/xf-component-32");
+            + "/jcr:content/root/xf-component-32");
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf32"));
     }
 
@@ -491,7 +489,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testUndefinedXFInTemplateWithLocalizationWithDifferentCountrySiteLanguage() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-32a", CH_MYSITE_FR_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-32a", CH_MYSITE_FR_PAGE);
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf32"));
     }
 
@@ -507,7 +505,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInPageWithLocalizationWithSameCountry_Language() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(CH_FR_PAGE
-                + "/jcr:content/root/xf-component-40");
+            + "/jcr:content/root/xf-component-40");
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf40"));
     }
@@ -546,7 +544,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInTemplateWithLocalizationWithDifferentCountry_Language() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-41a", CH_FR_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-41a", CH_FR_PAGE);
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf41a"));
     }
@@ -559,7 +557,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testUndefinedXFInPageWithLocalizationWithDifferentCountry_Language() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(CH_FR_PAGE
-                + "/jcr:content/root/xf-component-42");
+            + "/jcr:content/root/xf-component-42");
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf42"));
     }
 
@@ -587,7 +585,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInPageWithLocalizationWithSameBlueprint() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(BLUEPRINT_PAGE
-                + "/jcr:content/root/xf-component-50");
+            + "/jcr:content/root/xf-component-50");
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf50"));
     }
@@ -600,7 +598,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInTemplateWithLocalizationWithSameBlueprint() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-50a", BLUEPRINT_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-50a", BLUEPRINT_PAGE);
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf50"));
     }
@@ -613,7 +611,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInPageWithLocalizationWithDifferentBlueprint() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(BLUEPRINT_PAGE
-                + "/jcr:content/root/xf-component-51");
+            + "/jcr:content/root/xf-component-51");
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf51"));
     }
@@ -626,7 +624,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInTemplateWithLocalizationWithDifferentBlueprint() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-51a", BLUEPRINT_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-51a", BLUEPRINT_PAGE);
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf51a"));
     }
@@ -639,7 +637,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInPageWithLocalizationWithSameLivecopy() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(LIVECOPY_PAGE
-                + "/jcr:content/root/xf-component-60");
+            + "/jcr:content/root/xf-component-60");
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf60"));
     }
@@ -652,7 +650,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInTemplateLocalizationWithSameLivecopy() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
-                PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-60a", LIVECOPY_PAGE);
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-60a", LIVECOPY_PAGE);
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf60"));
     }
@@ -665,7 +663,7 @@ class ExperienceFragmentImplTest {
     @Test
     void testValidXFInPageWithLocalizationWithDifferentLivecopy() {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(LIVECOPY_PAGE
-                + "/jcr:content/root/xf-component-61");
+            + "/jcr:content/root/xf-component-61");
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf61"));
     }
@@ -681,34 +679,6 @@ class ExperienceFragmentImplTest {
             PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-61a", LIVECOPY_PAGE);
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf61a"));
-    }
-    
-    
-    /**
-     * Site with language localization
-     * XF component is defined in the page
-     * XF component points to the same language branch as the page
-     * Underlying XF has actual components present which will be exported.
-     */
-    @Test
-    void testValidXFInPageWithContent() {
-        ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(EN_PAGE
-                + "/jcr:content/root/xf-component-70");
-        assertEquals("header", experienceFragment.getName());
-        Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf70"));
-    }
-    
-    /*
-     * Site with language localization
-     * XF component is defined in the page
-     * XF component points to the same language branch as the page
-     */
-    @Test
-    void testValidXFInPageWithNoContent() {
-        ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(EN_PAGE
-                + "/jcr:content/root/xf-component-71");
-        assertEquals("header_empty", experienceFragment.getName());
-        Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf71"));
     }
 
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImplTest.java
@@ -29,16 +29,18 @@ import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.models.Image;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(AemContextExtension.class)
 public class ImageImplTest extends AbstractImageTest {
 
-    private static String TEST_ROOT = "/content";
+    private static final String TEST_ROOT = "/content";
     protected static String PAGE = TEST_ROOT + "/test";
-    private static String IMAGE_TITLE_ALT = "Adobe Logo";
+    private static final String IMAGE_TITLE_ALT = "Adobe Logo";
     protected static String IMAGE_FILE_REFERENCE = "/content/dam/core/images/Adobe_Systems_logo_and_wordmark.png";
-    private static String IMAGE_LINK = "https://www.adobe.com";
+    private static final String IMAGE_LINK = "https://www.adobe.com";
     protected static String ASSET_NAME = "adobe-systems-logo-and-wordmark";
 
     protected String testBase = TEST_BASE;
@@ -82,8 +84,8 @@ public class ImageImplTest extends AbstractImageTest {
         Image image = getImageUnderTest(IMAGE3_PATH);
         assertEquals(IMAGE_TITLE_ALT, image.getAlt());
         assertEquals(IMAGE_TITLE_ALT, image.getTitle());
-        assertNull("Did not expect a file reference.", image.getFileReference());
-        assertFalse("Image should not display a caption popup.", image.displayPopupTitle());
+        assertNull(image.getFileReference(), "Did not expect a file reference.");
+        assertFalse(image.displayPopupTitle(), "Image should not display a caption popup.");
         assertEquals(IMAGE_LINK, image.getLink());
         assertEquals(CONTEXT_PATH + escapedResourcePath + "." + selector + ".82.600.png/1490005239000/" + ASSET_NAME + ".png", image.getSrc());
         String expectedJson = "{\"smartImages\":[\"/core/content/test/_jcr_content/root/image3." + selector +  "." + jpegQuality +
@@ -97,10 +99,10 @@ public class ImageImplTest extends AbstractImageTest {
     void testSimpleDecorativeImage() {
         String escapedResourcePath = IMAGE4_PATH.replace("jcr:content", "_jcr_content");
         Image image = getImageUnderTest(IMAGE4_PATH);
-        assertNull("Did not expect a value for the alt attribute, since the image is marked as decorative.", image.getAlt());
-        assertNull("Did not expect a title for this image.", image.getTitle());
-        assertFalse("Image should not display a caption popup.", image.displayPopupTitle());
-        assertNull("Did not expect a link for this image, since it's marked as decorative.", image.getLink());
+        assertNull(image.getAlt(), "Did not expect a value for the alt attribute, since the image is marked as decorative.");
+        assertNull(image.getTitle(), "Did not expect a title for this image.");
+        assertFalse(image.displayPopupTitle(), "Image should not display a caption popup.");
+        assertNull(image.getLink(), "Did not expect a link for this image, since it's marked as decorative.");
         assertEquals(CONTEXT_PATH + escapedResourcePath + "." + selector + ".png/1494867377756/adobe-systems-logo-and-wordmark.png", image.getSrc());
         compareJSON(
                 "{\"" + Image.JSON_SMART_IMAGES + "\":[], \"" + Image.JSON_SMART_SIZES + "\":[], \"" + Image.JSON_LAZY_ENABLED +
@@ -182,7 +184,7 @@ public class ImageImplTest extends AbstractImageTest {
                 "allowedRenditionWidths", new int[]{600}, "disableLazyLoading", true);
         String escapedResourcePath = IMAGE27_PATH.replace("jcr:content", "_jcr_content");
         Image image = getImageUnderTest(IMAGE27_PATH);
-        assertNull("Did not expect a file reference.", image.getFileReference());
+        assertNull(image.getFileReference(), "Did not expect a file reference.");
         assertEquals(CONTEXT_PATH + escapedResourcePath + "." + selector + ".82.600.png/1490005239000.png", image.getSrc());
         String expectedJson = "{\"smartImages\":[\"/core/content/test/_jcr_content/root/image27." + selector +  "." + jpegQuality +
         ".600.png/1490005239000.png\"],\"smartSizes\":[600],\"lazyEnabled\":false}";

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationImplTest.java
@@ -31,7 +31,7 @@ import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(AemContextExtension.class)
 class LanguageNavigationImplTest {
@@ -112,7 +112,7 @@ class LanguageNavigationImplTest {
     void testLanguageNavigationItemsNoRoot() {
         LanguageNavigation languageNavigation = getLanguageNavigationUnderTest(
                 NAVIGATION_ROOT + "/LOCALE-1/LOCALE-5/about/jcr:content/root/languagenavigation-component-4");
-        assertEquals("Didn't expect any language navigation items.", 0, languageNavigation.getItems().size());
+        assertEquals(0, languageNavigation.getItems().size(), "Didn't expect any language navigation items.");
         Utils.testJSONExport(languageNavigation, Utils.getTestExporterJSONPath(TEST_BASE, "languagenavigation4"));
 
     }
@@ -168,26 +168,19 @@ class LanguageNavigationImplTest {
     }
 
     private void verifyLanguageNavigationItems(Object[][] expectedPages, List<NavigationItem> items) {
-        assertEquals("The language navigation items contain a different number of pages than expected.", expectedPages.length,
-                items.size());
+        assertEquals(expectedPages.length, items.size(),
+            "The language navigation items contain a different number of pages than expected.");
         int index = 0;
         while (items.size() > index) {
             LanguageNavigationItem item = (LanguageNavigationItem) items.get(index);
-            assertEquals("The language navigation items don't seem to have the correct order.", expectedPages[index][0], item.getPath());
-            assertEquals("The language navigation item's title is not what was expected: " + item.getPath(), expectedPages[index][1],
-                    item.getTitle());
-            assertEquals("The language navigation item's active state is not what was expected: " + item.getPath(), expectedPages[index][2],
-                    item.isActive());
-            assertEquals("The language navigation item's level is not what was expected: " + item.getPath(), expectedPages[index][3],
-                    item.getLevel());
-            assertEquals("The language navigation item's country is not what was expected: " + item.getPath(), expectedPages[index][4],
-                    item.getCountry());
-            assertEquals("The language navigation item's language is not what was expected: " + item.getPath(), expectedPages[index][5],
-                    item.getLanguage());
-            assertEquals("The language navigation item's locale is not what was expected: " + item.getPath(), expectedPages[index][5],
-                    item.getLocale().toString().replace('_', '-'));
-            assertEquals("The language navigation item's URL is not what was expected: " + item.getPath(),
-                    CONTEXT_PATH + expectedPages[index][6], item.getURL());
+            assertEquals(expectedPages[index][0], item.getPath(), "The language navigation items don't seem to have the correct order.");
+            assertEquals(expectedPages[index][1], item.getTitle(), "The language navigation item's title is not what was expected: " + item.getPath());
+            assertEquals(expectedPages[index][2], item.isActive(), "The language navigation item's active state is not what was expected: " + item.getPath());
+            assertEquals(expectedPages[index][3], item.getLevel(), "The language navigation item's level is not what was expected: " + item.getPath());
+            assertEquals(expectedPages[index][4], item.getCountry(), "The language navigation item's country is not what was expected: " + item.getPath());
+            assertEquals(expectedPages[index][5], item.getLanguage(), "The language navigation item's language is not what was expected: " + item.getPath());
+            assertEquals(expectedPages[index][5], item.getLocale().toString().replace('_', '-'), "The language navigation item's locale is not what was expected: " + item.getPath());
+            assertEquals(CONTEXT_PATH + expectedPages[index][6], item.getURL(), "The language navigation item's URL is not what was expected: " + item.getPath());
             index++;
         }
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
@@ -22,55 +22,56 @@ import javax.jcr.Session;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.scripting.SlingBindings;
-import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
 
-import com.adobe.cq.sightly.WCMBindings;
 import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.List;
 import com.day.cq.search.SimpleSearch;
 import com.day.cq.search.result.SearchResult;
 import com.day.cq.wcm.api.Page;
-import com.day.cq.wcm.api.designer.Style;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(AemContextExtension.class)
 public class ListImplTest {
 
     private static final String TEST_BASE = "/list";
+    private static final String CONTENT_ROOT = "/content";
     private static final String CURRENT_PAGE = "/content/list";
-    private static final String LIST_1 = "/content/list/listTypes/staticListType";
-    private static final String LIST_2 = "/content/list/listTypes/staticListType";
-    private static final String LIST_3 = "/content/list/listTypes/childrenListType";
-    private static final String LIST_4 = "/content/list/listTypes/childrenListTypeWithDepth";
-    private static final String LIST_5 = "/content/list/listTypes/tagsListType";
-    private static final String LIST_6 = "/content/list/listTypes/searchListType";
-    private static final String LIST_7 = "/content/list/listTypes/staticOrderByTitleListType";
-    private static final String LIST_8 = "/content/list/listTypes/staticOrderByTitleDescListType";
-    private static final String LIST_9 = "/content/list/listTypes/staticOrderByModificationDateListType";
-    private static final String LIST_10 = "/content/list/listTypes/staticOrderByModificationDateDescListType";
-    private static final String LIST_11 = "/content/list/listTypes/staticMaxItemsListType";
-    private static final String LIST_12 = "/content/list/listTypes/staticOrderByModificationDateListTypeWithNoModificationDate";
-    private static final String LIST_13 = "/content/list/listTypes/staticOrderByModificationDateListTypeWithNoModificationDateForOneItem";
-    private static final String LIST_14 = "/content/list/listTypes/staticOrderByTitleListTypeWithNoTitle";
-    private static final String LIST_15 = "/content/list/listTypes/staticOrderByTitleListTypeWithNoTitleForOneItem";
-    private static final String LIST_16 = "/content/list/listTypes/staticOrderByTitleListTypeWithAccent";
 
-    @ClassRule
-    public static final AemContext CONTEXT = CoreComponentTestContext.createContext(TEST_BASE, "/content/list");
+    private static final String TEST_PAGE_CONTENT_ROOT = CURRENT_PAGE + "/jcr:content/root";
+    private static final String LIST_1 = TEST_PAGE_CONTENT_ROOT + "/staticListType";
+    private static final String LIST_2 = TEST_PAGE_CONTENT_ROOT + "/staticListType";
+    private static final String LIST_3 = TEST_PAGE_CONTENT_ROOT + "/childrenListType";
+    private static final String LIST_4 = TEST_PAGE_CONTENT_ROOT + "/childrenListTypeWithDepth";
+    private static final String LIST_5 = TEST_PAGE_CONTENT_ROOT + "/tagsListType";
+    private static final String LIST_6 = TEST_PAGE_CONTENT_ROOT + "/searchListType";
+    private static final String LIST_7 = TEST_PAGE_CONTENT_ROOT + "/staticOrderByTitleListType";
+    private static final String LIST_8 = TEST_PAGE_CONTENT_ROOT + "/staticOrderByTitleDescListType";
+    private static final String LIST_9 = TEST_PAGE_CONTENT_ROOT + "/staticOrderByModificationDateListType";
+    private static final String LIST_10 = TEST_PAGE_CONTENT_ROOT + "/staticOrderByModificationDateDescListType";
+    private static final String LIST_11 = TEST_PAGE_CONTENT_ROOT + "/staticMaxItemsListType";
+    private static final String LIST_12 = TEST_PAGE_CONTENT_ROOT + "/staticOrderByModificationDateListTypeWithNoModificationDate";
+    private static final String LIST_13 = TEST_PAGE_CONTENT_ROOT + "/staticOrderByModificationDateListTypeWithNoModificationDateForOneItem";
+    private static final String LIST_14 = TEST_PAGE_CONTENT_ROOT + "/staticOrderByTitleListTypeWithNoTitle";
+    private static final String LIST_15 = TEST_PAGE_CONTENT_ROOT + "/staticOrderByTitleListTypeWithNoTitleForOneItem";
+    private static final String LIST_16 = TEST_PAGE_CONTENT_ROOT + "/staticOrderByTitleListTypeWithAccent";
 
-    @BeforeClass
-    public static void setUp() {
-        CONTEXT.load().json("/list/test-tags.json", "/content/cq:tags/list");
+    public final AemContext context = CoreComponentTestContext.newAemContext();
+
+    @BeforeEach
+    public void setUp() {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, CONTENT_ROOT);
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_TAGS_JSON, CONTENT_ROOT + "/cq:tags/list");
     }
 
     @Test
@@ -127,14 +128,14 @@ public class ListImplTest {
     public void testSearchListType() throws Exception {
         Session mockSession = mock(Session.class);
         SimpleSearch mockSimpleSearch = mock(SimpleSearch.class);
-        CONTEXT.registerAdapter(ResourceResolver.class, Session.class, mockSession);
-        CONTEXT.registerAdapter(Resource.class, SimpleSearch.class, mockSimpleSearch);
+        context.registerAdapter(ResourceResolver.class, Session.class, mockSession);
+        context.registerAdapter(Resource.class, SimpleSearch.class, mockSimpleSearch);
         SearchResult searchResult = mock(SearchResult.class);
 
         when(mockSimpleSearch.getResult()).thenReturn(searchResult);
         when(searchResult.getResources()).thenReturn(
             Collections.singletonList(Objects.requireNonNull(
-                CONTEXT.resourceResolver().getResource("/content/list/pages/page_1/jcr:content")))
+                context.resourceResolver().getResource("/content/list/pages/page_1/jcr:content")))
                 .iterator());
 
         List list = getListUnderTest(LIST_6);
@@ -208,25 +209,13 @@ public class ListImplTest {
     }
 
     private List getListUnderTest(String resourcePath) {
-        Utils.enableDataLayerForOldAemContext(CONTEXT, true);
-        Resource resource = CONTEXT.resourceResolver().getResource(resourcePath);
+        Utils.enableDataLayer(context, true);
+        Resource resource = context.resourceResolver().getResource(resourcePath);
         if (resource == null) {
             throw new IllegalStateException("Did you forget to defines test resource " + resourcePath + "?");
         }
-        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(CONTEXT.resourceResolver(), CONTEXT.bundleContext());
-        request.setResource(resource);
-        SlingBindings bindings = new SlingBindings();
-        bindings.put(SlingBindings.RESOURCE, resource);
-        bindings.put(SlingBindings.REQUEST, request);
-        bindings.put(WCMBindings.PROPERTIES, resource.getValueMap());
-        Style style = mock(Style.class);
-        when(style.get(any(), any(Object.class))).thenAnswer(
-                invocation -> invocation.getArguments()[1]
-        );
-        bindings.put(WCMBindings.CURRENT_STYLE, style);
-        bindings.put(WCMBindings.CURRENT_PAGE, CONTEXT.pageManager().getPage(CURRENT_PAGE));
-        request.setAttribute(SlingBindings.class.getName(), bindings);
-        return request.adaptTo(List.class);
+        context.currentResource(resource);
+        return context.request().adaptTo(List.class);
     }
 
     private void checkListConsistencyByTitle(List list, String[] expectedPageTitles) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImplTest.java
@@ -40,7 +40,7 @@ import com.day.cq.wcm.msm.api.LiveRelationshipManager;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
@@ -97,7 +97,7 @@ class NavigationImplTest {
                         when(liveRelationship.getTargetPath()).thenReturn("/content/navigation-livecopy");
                         final ArrayList<LiveRelationship> relationships = new ArrayList<>();
                         relationships.add(liveRelationship);
-                        final Iterator iterator = relationships.iterator();
+                        final Iterator<LiveRelationship> iterator = relationships.iterator();
                         return new RangeIterator() {
 
                             int index = 0;
@@ -159,7 +159,7 @@ class NavigationImplTest {
     @Test
     void testNavigationNoRoot() {
         Navigation navigation = getNavigationUnderTest(NAV_COMPONENT_2);
-        assertEquals("Didn't expect any navigation items.", 0, navigation.getItems().size());
+        assertEquals(0, navigation.getItems().size(), "Didn't expect any navigation items.");
         Utils.testJSONExport(navigation, Utils.getTestExporterJSONPath(TEST_BASE, "navigation4"));
     }
 
@@ -477,16 +477,13 @@ class NavigationImplTest {
     }
 
     private void verifyNavigationItems(Object[][] expectedPages, List<NavigationItem> items) {
-        assertEquals("The navigation tree contains a different number of pages than expected.", expectedPages.length, items.size());
+        assertEquals(expectedPages.length, items.size(), "The navigation tree contains a different number of pages than expected.");
         int index = 0;
         for (NavigationItem item : items) {
-            assertEquals("The navigation tree doesn't seem to have the correct order.", expectedPages[index][0], item.getPath());
-            assertEquals("The navigation item's level is not what was expected: " + item.getPath(),
-                    expectedPages[index][1], item.getLevel());
-            assertEquals("The navigation item's active state is not what was expected: " + item.getPath(),
-                    expectedPages[index][2], item.isActive());
-            assertEquals("The navigation item's URL is not what was expected: " + item.getPath(),
-                    CONTEXT_PATH + expectedPages[index][3], item.getURL());
+            assertEquals(expectedPages[index][0], item.getPath(), "The navigation tree doesn't seem to have the correct order.");
+            assertEquals(expectedPages[index][1], item.getLevel(), "The navigation item's level is not what was expected: " + item.getPath());
+            assertEquals(expectedPages[index][2], item.isActive(), "The navigation item's active state is not what was expected: " + item.getPath());
+            assertEquals(CONTEXT_PATH + expectedPages[index][3], item.getURL(), "The navigation item's URL is not what was expected: " + item.getPath());
             index++;
         }
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImplTest.java
@@ -38,9 +38,9 @@ import com.google.common.collect.Sets;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static junit.framework.TestCase.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 public class PageImplTest {
@@ -54,7 +54,7 @@ public class PageImplTest {
 
     private static final String DESING_CACHE_KEY = "io.wcm.testing.mock.aem.context.MockAemSlingBindings_design_/content/page/templated" +
             "-page";
-    private static String TEST_BASE = "/page";
+    private static final String TEST_BASE = "/page";
     private static final String FN_FAVICON_ICO = "favicon.ico";
     private static final String FN_FAVICON_PNG = "favicon_32.png";
     private static final String FN_TOUCH_ICON_60 = "touch-icon_60.png";
@@ -117,7 +117,7 @@ public class PageImplTest {
     @SuppressWarnings("deprecation")
     void testFavicons() {
         Page page = getPageUnderTest(PAGE, DESIGN_PATH_KEY, DESIGN_PATH);
-        Map favicons = page.getFavicons();
+        Map<String, String> favicons = page.getFavicons();
         assertEquals(DESIGN_PATH + "/" + FN_FAVICON_ICO, favicons.get(PN_FAVICON_ICO));
         assertEquals(DESIGN_PATH + "/" + FN_FAVICON_PNG, favicons.get(PN_FAVICON_PNG));
         assertEquals(DESIGN_PATH + "/" + FN_TOUCH_ICON_60, favicons.get(PN_TOUCH_ICON_60));

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PdfViewerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PdfViewerImplTest.java
@@ -25,10 +25,10 @@ import com.adobe.cq.wcm.core.components.models.PdfViewer;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 class PdfViewerImplTest {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ProgressBarImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ProgressBarImplTest.java
@@ -26,7 +26,7 @@ import com.adobe.cq.wcm.core.components.models.ProgressBar;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(AemContextExtension.class)
 public class ProgressBarImplTest {
@@ -52,32 +52,32 @@ public class ProgressBarImplTest {
     @Test
     public void testCompleted() {
         ProgressBar progressBar = getComponentUnderTest(PROGRESSBAR_1);
-        assertEquals(75, progressBar.getCompleted(), 0);
-        assertEquals(25, progressBar.getRemaining(), 0);
+        assertEquals(75, progressBar.getCompleted());
+        assertEquals(25, progressBar.getRemaining());
         Utils.testJSONExport(progressBar, Utils.getTestExporterJSONPath(TEST_BASE, PROGRESSBAR_1));
     }
 
     @Test
     public void testDefault() {
         ProgressBar progressBar = getComponentUnderTest(PROGRESSBAR_2);
-        assertEquals(0, progressBar.getCompleted(), 0);
-        assertEquals(100, progressBar.getRemaining(), 0);
+        assertEquals(0, progressBar.getCompleted());
+        assertEquals(100, progressBar.getRemaining());
     }
 
     @Test
     public void testTooSmall() {
         // completed < 0
         ProgressBar progressBar = getComponentUnderTest(PROGRESSBAR_3);
-        assertEquals(0, progressBar.getCompleted(), 0);
-        assertEquals(100, progressBar.getRemaining(), 0);
+        assertEquals(0, progressBar.getCompleted());
+        assertEquals(100, progressBar.getRemaining());
     }
 
     @Test
     public void testTooLarge() {
         // completed > 100
         ProgressBar progressBar = getComponentUnderTest(PROGRESSBAR_4);
-        assertEquals(100, progressBar.getCompleted(), 0);
-        assertEquals(0, progressBar.getRemaining(), 0);
+        assertEquals(100, progressBar.getCompleted());
+        assertEquals(0, progressBar.getRemaining());
     }
 
     protected ProgressBar getComponentUnderTest(String resourcePath) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/SearchImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/SearchImplTest.java
@@ -24,7 +24,7 @@ import com.adobe.cq.wcm.core.components.models.Search;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(AemContextExtension.class)
 class SearchImplTest {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/SeparatorImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/SeparatorImplTest.java
@@ -25,7 +25,7 @@ import com.adobe.cq.wcm.core.components.models.Separator;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(AemContextExtension.class)
 class SeparatorImplTest {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/SocialMediaHelperImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/SocialMediaHelperImplTest.java
@@ -40,8 +40,8 @@ import com.day.cq.wcm.api.Page;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 class SocialMediaHelperImplTest {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImplTest.java
@@ -17,7 +17,6 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.List;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +28,7 @@ import com.adobe.cq.wcm.core.components.models.Tabs;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(AemContextExtension.class)
 class TabsImplTest {
@@ -56,7 +55,7 @@ class TabsImplTest {
     @Test
     void testEmptyTabs() {
         Tabs tabs = getTabsUnderTest(TABS_EMPTY);
-        Assert.assertEquals(0, tabs.getItems().size());
+        assertEquals(0, tabs.getItems().size());
         Utils.testJSONExport(tabs, Utils.getTestExporterJSONPath(TEST_BASE, "tabs0"));
     }
 
@@ -98,13 +97,11 @@ class TabsImplTest {
     }
 
     private void verifyTabItems(Object[][] expectedItems, List<ListItem> items) {
-        assertEquals("The tabs contains a different number of items than expected.", expectedItems.length, items.size());
+        assertEquals(expectedItems.length, items.size(), "The tabs contains a different number of items than expected.");
         int index = 0;
         for (ListItem item : items) {
-            assertEquals("The tabs item's name is not what was expected.",
-                expectedItems[index][0], item.getName());
-            assertEquals("The tabs item's title is not what was expected: " + item.getTitle(),
-                expectedItems[index][1], item.getTitle());
+            assertEquals(expectedItems[index][0], item.getName(), "The tabs item's name is not what was expected.");
+            assertEquals(expectedItems[index][1], item.getTitle(), "The tabs item's title is not what was expected: " + item.getTitle());
             index++;
         }
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
@@ -41,13 +41,16 @@ import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.org.lidalia.slf4jtest.LoggingEvent.debug;
 import static uk.org.lidalia.slf4jtest.LoggingEvent.error;
-
 
 @ExtendWith(AemContextExtension.class)
 class TeaserImplTest {
@@ -180,11 +183,11 @@ class TeaserImplTest {
     @Test
     void testTeaserWithActions() {
         Teaser teaser = getTeaserUnderTest(TEASER_7);
-        assertTrue("Expected teaser with actions", teaser.isActionsEnabled());
-        assertEquals("Expected to find two actions", 2, teaser.getActions().size());
+        assertTrue(teaser.isActionsEnabled(), "Expected teaser with actions");
+        assertEquals(2, teaser.getActions().size(), "Expected to find two actions");
         ListItem action = teaser.getActions().get(0);
-        assertEquals("Action link does not match", "http://www.adobe.com", action.getPath());
-        assertEquals("Action text does not match", "Adobe", action.getTitle());
+        assertEquals("http://www.adobe.com", action.getPath(), "Action link does not match");
+        assertEquals("Adobe", action.getTitle(), "Action text does not match");
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(TEST_BASE, "teaser9"));
     }
 
@@ -198,8 +201,8 @@ class TeaserImplTest {
     @Test
     void testTeaserWithTitleAndDescriptionFromActions() {
         Teaser teaser = getTeaserUnderTest(TEASER_8);
-        assertTrue("Expected teaser with actions", teaser.isActionsEnabled());
-        assertEquals("Expected to find two Actions", 2, teaser.getActions().size());
+        assertTrue(teaser.isActionsEnabled(), "Expected teaser with actions");
+        assertEquals(2, teaser.getActions().size(), "Expected to find two Actions");
         assertEquals("Teasers Test", teaser.getTitle());
         assertEquals("Teasers description", teaser.getDescription());
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(TEST_BASE, "teaser11"));
@@ -209,14 +212,14 @@ class TeaserImplTest {
     void testTeaserWithTitleType() {
         Teaser teaser = getTeaserUnderTest(TEASER_1,
             Teaser.PN_TITLE_TYPE, "h5");
-        assertEquals("Expected title type is not correct", "h5", teaser.getTitleType());
+        assertEquals("h5", teaser.getTitleType(), "Expected title type is not correct");
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(TEST_BASE, "teaser2"));
     }
 
     @Test
     void testTeaserWithDefaultTitleType() {
         Teaser teaser = getTeaserUnderTest(TEASER_1);
-        assertNull("Expected the default title type is not correct", teaser.getTitleType());
+        assertNull(teaser.getTitleType(), "Expected the default title type is not correct");
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(TEST_BASE, "teaser1"));
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TextImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TextImplTest.java
@@ -26,7 +26,10 @@ import com.adobe.cq.wcm.core.components.models.Text;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 class TextImplTest {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/AbstractContentFragmentTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/AbstractContentFragmentTest.java
@@ -20,19 +20,13 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.Nullable;
-import javax.jcr.Session;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.scripting.SlingBindings;
-import org.apache.sling.testing.mock.jcr.MockJcr;
-import org.apache.sling.testing.mock.sling.servlet.MockHttpSession;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 
@@ -42,7 +36,6 @@ import com.adobe.cq.sightly.WCMBindings;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.day.cq.search.QueryBuilder;
 import io.wcm.testing.mock.aem.junit5.AemContext;
-import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 import static org.mockito.Mockito.mock;
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
@@ -18,6 +18,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
@@ -31,10 +32,13 @@ import com.adobe.cq.wcm.core.components.models.contentfragment.ContentFragment;
 import com.adobe.cq.wcm.core.components.models.contentfragment.DAMContentFragment;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(AemContextExtension.class)
 class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragment> {
@@ -60,7 +64,7 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     @Test
     void textOnlyInvalidPath() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY_INVALID_PATH);
-        assertNotNull("Model shouldn't be null when the path is not a content fragment", fragment);
+        assertNotNull(fragment, "Model shouldn't be null when the path is not a content fragment");
     }
 
     @Test
@@ -102,13 +106,13 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     @Test
     void structuredNoPath() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_NO_PATH);
-        assertNotNull("Model shouldn't be null when no path is set", fragment);
+        assertNotNull(fragment, "Model shouldn't be null when no path is set");
     }
 
     @Test
     void structuredNonExistingPath() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_NON_EXISTING_PATH);
-        assertNotNull("Model shouldn't be null when the path does not exist", fragment);
+        assertNotNull(fragment, "Model shouldn't be null when the path does not exist");
         assertNull(fragment.getTitle());
         assertNull(fragment.getDescription());
         assertNull(fragment.getType());
@@ -121,7 +125,7 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     @Test
     void structuredOnlyInvalidPath() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_INVALID_PATH);
-        assertNotNull("Model shouldn't be null when the path is not a content fragment", fragment);
+        assertNotNull(fragment, "Model shouldn't be null when the path is not a content fragment");
     }
 
     @Test
@@ -245,7 +249,7 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     void getParagraphsOfMultiDisplayModeIsNull() {
         // Structure CF has displayMode=multi which should not return paragraphs
         ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED);
-        assertThat(fragment.getParagraphs(), is(nullValue()));
+        assertNull(fragment.getParagraphs());
     }
 
     @Test
@@ -254,7 +258,7 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
 
         ContentFragment contentFragment = getModelInstanceUnderTest(CF_STRUCTURED_SINGLE_ELEMENT_MAIN);
 
-        assertThat(contentFragment.getParagraphs(), is(new String[]{MAIN_CONTENT}));
+        assertArrayEquals(new String[]{MAIN_CONTENT}, contentFragment.getParagraphs());
     }
 
     /**
@@ -275,25 +279,25 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     private void assertContentFragment(ContentFragment fragment, String variationName, String expectedTitle,
                                        String expectedDescription, String expectedType, String expectedName,
                                        String[] expectedAssociatedContent, MockElement... expectedElements) {
-        assertEquals("Content fragment has wrong title", expectedTitle, fragment.getTitle());
-        assertEquals("Content fragment has wrong description", expectedDescription, fragment.getDescription());
-        assertEquals("Content fragment has wrong type", expectedType, fragment.getType());
-        assertEquals("Content fragment has wrong name", expectedName, fragment.getName());
-        List<Resource> associatedContent = fragment.getAssociatedContent();
-        assertEquals("Content fragment has wrong number of associated content", expectedAssociatedContent.length, associatedContent.size());
+        assertEquals(expectedTitle, fragment.getTitle(), "Content fragment has wrong title");
+        assertEquals(expectedDescription, fragment.getDescription(), "Content fragment has wrong description");
+        assertEquals(expectedType, fragment.getType(), "Content fragment has wrong type");
+        assertEquals(expectedName, fragment.getName(), "Content fragment has wrong name");
+        List<Resource> associatedContent = Objects.requireNonNull(fragment.getAssociatedContent());
+        assertEquals(expectedAssociatedContent.length, associatedContent.size(), "Content fragment has wrong number of associated content");
         for (int i = 0; i < expectedAssociatedContent.length; i++) {
             Resource resource = associatedContent.get(i);
-            assertEquals("Element has wrong associated content", expectedAssociatedContent[i], resource.getPath());
+            assertEquals(expectedAssociatedContent[i], resource.getPath(), "Element has wrong associated content");
         }
         Map<String, DAMContentFragment.DAMContentElement> elementsMap = fragment.getExportedElements();
         assertNotNull(elementsMap);
         List<DAMContentFragment.DAMContentElement> elements = new ArrayList<>(elementsMap.values());
-        assertEquals("Content fragment has wrong number of elements", expectedElements.length, elements.size());
+        assertEquals(expectedElements.length, elements.size(), "Content fragment has wrong number of elements");
         for (int i = 0; i < expectedElements.length; i++) {
             DAMContentFragment.DAMContentElement element = elements.get(i);
             MockElement expected = expectedElements[i];
-            assertEquals("Element has wrong name", expected.name, element.getName());
-            assertEquals("Element has wrong title", expected.title, element.getTitle());
+            assertEquals(expected.name, element.getName(), "Element has wrong name");
+            assertEquals(expected.title, element.getTitle(), "Element has wrong title");
             String contentType = expected.contentType;
             boolean isMultiLine = expected.isMultiLine;
             String htmlValue = expected.htmlValue;
@@ -306,14 +310,14 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
             }
             Object elementValue = element.getValue();
             if (elementValue != null && elementValue.getClass().isArray()) {
-                assertArrayEquals("Element's values didn't match", expectedValues, (String[]) elementValue);
+                assertArrayEquals(expectedValues, (String[]) elementValue, "Element's values didn't match");
             } else {
-                assertEquals("Element is not single valued", expectedValues.length, 1);
-                assertEquals("Element's value didn't match", expectedValues[0], elementValue);
+                assertEquals(expectedValues.length, 1, "Element is not single valued");
+                assertEquals(expectedValues[0], elementValue, "Element's value didn't match");
             }
-            assertEquals("Element has wrong content type", contentType, element.getExportedType());
-            assertEquals("Element has wrong isMultiLine flag", isMultiLine, element.isMultiLine());
-            assertEquals("Element has wrong html", htmlValue, element.getHtml());
+            assertEquals(contentType, element.getExportedType(), "Element has wrong content type");
+            assertEquals(isMultiLine, element.isMultiLine(), "Element has wrong isMultiLine flag");
+            assertEquals(htmlValue, element.getHtml(), "Element has wrong html");
         }
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentListImplTest.java
@@ -37,9 +37,8 @@ import com.day.cq.search.result.SearchResult;
 import com.google.common.collect.ImmutableMap;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(AemContextExtension.class)
@@ -95,10 +94,9 @@ public class ContentFragmentListImplTest extends AbstractContentFragmentTest<Con
     @Test
     void testListWithNoModel() {
         ContentFragmentList contentFragmentList = getModelInstanceUnderTest(NO_MODEL);
-        assertThat(contentFragmentList, not(nullValue()));
+        assertNotNull(contentFragmentList);
         assertEquals(contentFragmentList.getListItems().size(), 0);
-        assertThat(contentFragmentList.getExportedType(),
-                is(ContentFragmentListImpl.RESOURCE_TYPE));
+        assertEquals(ContentFragmentListImpl.RESOURCE_TYPE, contentFragmentList.getExportedType());
         Utils.testJSONExport(contentFragmentList, Utils.getTestExporterJSONPath(TEST_BASE, NO_MODEL));
     }
 
@@ -131,8 +129,7 @@ public class ContentFragmentListImplTest extends AbstractContentFragmentTest<Con
             when(queryBuilderMock.createQuery(Mockito.any(PredicateGroup.class), Mockito.any(Session.class))).thenReturn(query);
 
             ContentFragmentList contentFragmentList = getModelInstanceUnderTest(listName);
-            assertThat(contentFragmentList.getExportedType(),
-                    is(ContentFragmentListImpl.RESOURCE_TYPE));
+            assertEquals(ContentFragmentListImpl.RESOURCE_TYPE, contentFragmentList.getExportedType());
             assertEquals(contentFragmentList.getListItems().size(), 1);
             Utils.testJSONExport(contentFragmentList, Utils.getTestExporterJSONPath(TEST_BASE, listName));
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/datalayer/AssetDataImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/datalayer/AssetDataImplTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import com.day.cq.dam.api.Asset;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,12 +32,11 @@ public class AssetDataImplTest {
     @Test
     void testGetLastModifiedDate() {
         Asset asset = mock(Asset.class);
-        when(asset.getLastModified()).thenReturn(0l);
+        when(asset.getLastModified()).thenReturn(0L);
         ValueMap valueMap = mock(ValueMap.class);
         when(asset.adaptTo(ValueMap.class)).thenReturn(valueMap);
         Calendar now = Calendar.getInstance();
         when(valueMap.get(JcrConstants.JCR_CREATED, Calendar.class)).thenReturn(now);
         assertEquals(now.getTime(), new AssetDataImpl(asset).getLastModifiedDate());
-
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImplTest.java
@@ -15,7 +15,6 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1.form;
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -27,12 +26,13 @@ import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.servlethelpers.MockRequestDispatcherFactory;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.adobe.cq.export.json.SlingModelFilter;
 import com.adobe.cq.sightly.WCMBindings;
@@ -44,12 +44,11 @@ import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.foundation.forms.FormStructureHelper;
 import com.day.cq.wcm.foundation.forms.FormStructureHelperFactory;
 import com.day.cq.wcm.msm.api.MSMNameConstants;
-import io.wcm.testing.mock.aem.junit.AemContext;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith({AemContextExtension.class, MockitoExtension.class})
 public class ContainerImplTest {
 
     private static final String TEST_BASE = "/form/container";
@@ -59,8 +58,7 @@ public class ContainerImplTest {
     private static final String FORM2_PATH = CONTAINING_PAGE + "/jcr:content/root/responsivegrid/container_350773202";
     private static final String FORM3_PATH = CONTAINING_PAGE + "/jcr:content/root/responsivegrid/container-v2";
 
-    @ClassRule
-    public static final AemContext CONTEXT = CoreComponentTestContext.createContext(TEST_BASE, CONTAINING_PAGE);
+    public final AemContext context = CoreComponentTestContext.newAemContext();
 
     @Mock
     private FormStructureHelper formStructureHelper;
@@ -68,15 +66,11 @@ public class ContainerImplTest {
     @Mock
     private MockRequestDispatcherFactory requestDispatcherFactory;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        CONTEXT.registerService(FormStructureHelperFactory.class, new FormStructureHelperFactory() {
-            @Override
-            public FormStructureHelper getFormStructureHelper(Resource resource) {
-                return formStructureHelper;
-            }
-        });
-        CONTEXT.registerService(SlingModelFilter.class, new SlingModelFilter() {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, CONTAINING_PAGE);
+        context.registerService(FormStructureHelperFactory.class, resource -> formStructureHelper);
+        context.registerService(SlingModelFilter.class, new SlingModelFilter() {
 
             private final Set<String> IGNORED_NODE_NAMES = new HashSet<String>() {{
                 add(NameConstants.NN_RESPONSIVE_CONFIG);
@@ -101,7 +95,7 @@ public class ContainerImplTest {
     }
 
     @Test
-    public void testFormWithCustomAttributesAndFields() throws IOException {
+    public void testFormWithCustomAttributesAndFields() {
         Container container = getContainerUnderTest(FORM1_PATH);
         assertEquals("my-id", container.getId());
         assertEquals("my-id", container.getName());
@@ -114,7 +108,7 @@ public class ContainerImplTest {
     }
 
     @Test
-    public void testFormWithoutCustomAttributesAndField() throws IOException {
+    public void testFormWithoutCustomAttributesAndField() {
         Container container = getContainerUnderTest(FORM2_PATH);
         assertEquals("multipart/form-data", container.getEnctype());
         assertEquals("POST", container.getMethod());
@@ -125,18 +119,18 @@ public class ContainerImplTest {
     }
 
     @Test
-    public void testV2JSONExport() throws IOException {
+    public void testV2JSONExport() {
         Container container = getContainerUnderTest(FORM3_PATH);
         Utils.testJSONExport(container, Utils.getTestExporterJSONPath(TEST_BASE, FORM3_PATH));
     }
 
     private Container getContainerUnderTest(String resourcePath) {
-        Resource resource = CONTEXT.resourceResolver().getResource(resourcePath);
+        Resource resource = context.resourceResolver().getResource(resourcePath);
         if (resource == null) {
             throw new IllegalStateException("Does the test resource " + resourcePath + " exist?");
         }
         SlingBindings bindings = new SlingBindings();
-        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(CONTEXT.resourceResolver(), CONTEXT.bundleContext());
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver(), context.bundleContext());
         MockSlingHttpServletResponse response = new MockSlingHttpServletResponse();
         request.setContextPath(CONTEXT_PATH);
         request.setResource(resource);
@@ -144,7 +138,7 @@ public class ContainerImplTest {
         bindings.put(WCMBindings.PROPERTIES, resource.getValueMap());
         bindings.put(SlingBindings.REQUEST, request);
         bindings.put(SlingBindings.RESPONSE, response);
-        Page page = CONTEXT.currentPage(CONTAINING_PAGE);
+        Page page = context.currentPage(CONTAINING_PAGE);
         bindings.put(WCMBindings.CURRENT_PAGE, page);
         request.setRequestDispatcherFactory(requestDispatcherFactory);
         request.setAttribute(SlingBindings.class.getName(), bindings);

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/HiddenImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/HiddenImplTest.java
@@ -28,8 +28,8 @@ import com.day.cq.wcm.foundation.forms.FormStructureHelperFactory;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(AemContextExtension.class)
 class HiddenImplTest {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/OptionsImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/OptionsImplTest.java
@@ -16,10 +16,8 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1.form;
 
 import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import java.io.IOException;
 import java.util.List;
 
 import org.apache.sling.api.request.RequestDispatcherOptions;
@@ -28,9 +26,6 @@ import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.servlethelpers.MockRequestDispatcherFactory;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
 
 import com.adobe.cq.sightly.WCMBindings;
 import com.adobe.cq.wcm.core.components.Utils;
@@ -40,12 +35,17 @@ import com.adobe.cq.wcm.core.components.models.form.Options;
 import com.adobe.cq.wcm.core.components.models.form.Options.Type;
 import com.adobe.granite.ui.components.ds.DataSource;
 import com.adobe.granite.ui.components.ds.SimpleDataSource;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+@ExtendWith(AemContextExtension.class)
 public class OptionsImplTest {
 
     private static final String TEST_BASE = "/form/options";
@@ -60,11 +60,11 @@ public class OptionsImplTest {
     private static final String OPTIONS_8 = CONTENT_ROOT + "/multi-drop-down";
     private static final String OPTIONS_9 = CONTENT_ROOT + "/optionsDefault-v2";
 
-    @ClassRule
-    public static final AemContext CONTEXT = CoreComponentTestContext.createContext(TEST_BASE, CONTENT_ROOT);
+    public final AemContext context = CoreComponentTestContext.newAemContext();
 
-    @BeforeClass
-    public static void setUp() {
+    @BeforeEach
+    public void setUp() {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, CONTENT_ROOT);
         FormsHelperStubber.createStub();
     }
 
@@ -73,17 +73,17 @@ public class OptionsImplTest {
         Options options = getOptionsUnderTest(OPTIONS_1);
         assertEquals(Type.CHECKBOX, options.getType());
 
-        String id = "form-options" + "-" + String.valueOf(Math.abs(OPTIONS_1.hashCode() - 1));
+        String id = "form-options" + "-" + Math.abs(OPTIONS_1.hashCode() - 1);
         assertEquals(id, options.getId());
 
-        assertEquals(null, options.getName());
-        assertEquals(null, options.getValue());
-        assertEquals(null, options.getTitle());
-        assertEquals(null, options.getHelpMessage());
+        assertNull(options.getName());
+        assertNull(options.getValue());
+        assertNull(options.getTitle());
+        assertNull(options.getHelpMessage());
 
         List<OptionItem> optionItems = options.getItems();
         assertNotNull(optionItems);
-        assertTrue(optionItems.size() == 0);
+        assertEquals(optionItems.size(), 0);
 
         Utils.testJSONExport(options, Utils.getTestExporterJSONPath(TEST_BASE, OPTIONS_1));
     }
@@ -94,7 +94,7 @@ public class OptionsImplTest {
         Options options = getOptionsUnderTest(OPTIONS_2);
         assertEquals(Type.CHECKBOX, options.getType());
 
-        String id = "form-options" + "-" + String.valueOf(Math.abs(OPTIONS_2.hashCode() - 1));
+        String id = "form-options" + "-" + Math.abs(OPTIONS_2.hashCode() - 1);
         assertEquals(id, options.getId());
 
         assertEquals("local-name", options.getName());
@@ -103,7 +103,7 @@ public class OptionsImplTest {
 
         List<OptionItem> optionItems = options.getItems();
         assertNotNull(optionItems);
-        assertTrue(optionItems.size() == 2);
+        assertEquals(optionItems.size(), 2);
 
         evaluateOptionItem(optionItems.get(0), "local-item1-name", "local-item1-value", false, false);
         evaluateOptionItem(optionItems.get(1), "local-item2-name", "local-item2-value", true, true);
@@ -116,7 +116,7 @@ public class OptionsImplTest {
         Options options = getOptionsUnderTest(OPTIONS_3);
         List<OptionItem> optionItems = options.getItems();
         assertNotNull(optionItems);
-        assertTrue(optionItems.size() == 2);
+        assertEquals(optionItems.size(), 2);
 
         evaluateOptionItem(optionItems.get(0), "datasource-item1-name", "datasource-item1-value", true, false);
         evaluateOptionItem(optionItems.get(1), "datasource-item2-name", "datasource-item2-value", false, true);
@@ -128,7 +128,7 @@ public class OptionsImplTest {
         Options options = getOptionsUnderTest(OPTIONS_4);
         List<OptionItem> optionItems = options.getItems();
         assertNotNull(optionItems);
-        assertTrue(optionItems.size() == 2);
+        assertEquals(optionItems.size(), 2);
 
         evaluateOptionItem(optionItems.get(0), "list-item1-name", "list-item1-value", true, false);
         evaluateOptionItem(optionItems.get(1), "list-item2-name", "list-item2-value", false, true);
@@ -136,7 +136,7 @@ public class OptionsImplTest {
     }
 
     @Test
-    public void testCheckboxOptionsType() throws Exception {
+    public void testCheckboxOptionsType() {
         Options options = getOptionsUnderTest(OPTIONS_5);
         List<OptionItem> optionItems = options.getItems();
         assertEquals("name1", options.getName());
@@ -145,34 +145,31 @@ public class OptionsImplTest {
         assertEquals(Type.CHECKBOX, options.getType());
 
         assertNotNull(optionItems);
-        assertTrue(optionItems.size() == 3);
+        assertEquals(optionItems.size(), 3);
 
         // test the first option item
-        OptionItem item = optionItems.get(0);
-        evaluateOptionItem(item, "t1", "v1", true, true);
-        item = optionItems.get(1);
-        evaluateOptionItem(item, "t2", "v2", true, false);
-        item = optionItems.get(2);
-        evaluateOptionItem(item, "t3", "v3", false, false);
+        evaluateOptionItem(optionItems.get(0), "t1", "v1", true, true);
+        evaluateOptionItem(optionItems.get(1), "t2", "v2", true, false);
+        evaluateOptionItem(optionItems.get(2), "t3", "v3", false, false);
         Utils.testJSONExport(options, Utils.getTestExporterJSONPath(TEST_BASE, OPTIONS_5));
     }
 
     @Test
-    public void testRadioOptionsType() throws Exception {
+    public void testRadioOptionsType() {
         Options options = getOptionsUnderTest(OPTIONS_6);
         assertEquals(Type.RADIO, options.getType());
         Utils.testJSONExport(options, Utils.getTestExporterJSONPath(TEST_BASE, OPTIONS_6));
     }
 
     @Test
-    public void testDropDownOptionsType() throws Exception {
+    public void testDropDownOptionsType() {
         Options options = getOptionsUnderTest(OPTIONS_7);
         assertEquals(Type.DROP_DOWN, options.getType());
         Utils.testJSONExport(options, Utils.getTestExporterJSONPath(TEST_BASE, OPTIONS_7));
     }
 
     @Test
-    public void testMultiDropDownOptionsType() throws Exception {
+    public void testMultiDropDownOptionsType() {
         Options options = getOptionsUnderTest(OPTIONS_8);
         assertEquals(Type.MULTI_DROP_DOWN, options.getType());
         Utils.testJSONExport(options, Utils.getTestExporterJSONPath(TEST_BASE, OPTIONS_8));
@@ -185,17 +182,17 @@ public class OptionsImplTest {
     }
 
     private Options getOptionsUnderTest(String resourcePath) {
-        Resource resource = CONTEXT.resourceResolver().getResource(resourcePath);
+        Resource resource = context.resourceResolver().getResource(resourcePath);
         if (resource == null) {
             throw new IllegalStateException("Did you forget to define test resource " + resourcePath + "?");
         }
-        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(CONTEXT.resourceResolver(), CONTEXT.bundleContext());
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver(), context.bundleContext());
         MockSlingHttpServletResponse response = new MockSlingHttpServletResponse();
         request.setResource(resource);
         SlingBindings bindings = new SlingBindings();
         bindings.put(SlingBindings.RESOURCE, resource);
         bindings.put(SlingBindings.REQUEST, request);
-        bindings.put(SlingBindings.RESOLVER, CONTEXT.resourceResolver());
+        bindings.put(SlingBindings.RESOLVER, context.resourceResolver());
         bindings.put(SlingBindings.RESPONSE, response);
         bindings.put(WCMBindings.PROPERTIES, resource.getValueMap());
         request.setAttribute(SlingBindings.class.getName(), bindings);
@@ -223,22 +220,22 @@ public class OptionsImplTest {
     private class MockRequestDispatcher implements RequestDispatcher {
 
 
-        private RequestDispatcherOptions options;
+        private final RequestDispatcherOptions options;
 
         MockRequestDispatcher(RequestDispatcherOptions options) {
             this.options = options;
         }
 
         @Override
-        public void forward(ServletRequest request, ServletResponse response) throws ServletException, IOException {
+        public void forward(ServletRequest request, ServletResponse response) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void include(ServletRequest request, ServletResponse response) throws ServletException, IOException {
+        public void include(ServletRequest request, ServletResponse response) {
             String forcedResourceType = options.getForceResourceType();
             assertEquals(CONTENT_ROOT + "/dataDatasource/datasource", forcedResourceType);
-            Resource dataSourceResource = CONTEXT.resourceResolver().getResource(CONTENT_ROOT + "/dataDatasource/datasource/items");
+            Resource dataSourceResource = context.resourceResolver().getResource(CONTENT_ROOT + "/dataDatasource/datasource/items");
             SimpleDataSource dataSource = new SimpleDataSource(dataSourceResource.listChildren());
             request.setAttribute(DataSource.class.getName(), dataSource);
         }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/TextImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/TextImplTest.java
@@ -15,22 +15,23 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1.form;
 
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.scripting.SlingBindings;
-import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-
-import com.adobe.cq.sightly.WCMBindings;
 import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.form.Text;
 import com.day.cq.wcm.foundation.forms.FormStructureHelperFactory;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.assertEquals;
+import java.util.Objects;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(AemContextExtension.class)
 public class TextImplTest {
 
     private static final String TEST_BASE = "/form/text";
@@ -40,12 +41,12 @@ public class TextImplTest {
     private static final String TEXTINPUT3_PATH = CONTAINING_PAGE + "/jcr:content/root/responsivegrid/container/text-v2";
 
 
-    @ClassRule
-    public static final AemContext CONTEXT = CoreComponentTestContext.createContext(TEST_BASE, CONTAINING_PAGE);
+    public final AemContext context = CoreComponentTestContext.newAemContext();
 
-    @BeforeClass
-    public static void setUp() {
-        CONTEXT.registerService(FormStructureHelperFactory.class, resource -> null);
+    @BeforeEach
+    public void setUp() {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, CONTAINING_PAGE);
+        context.registerService(FormStructureHelperFactory.class, resource -> null);
         FormsHelperStubber.createStub();
     }
 
@@ -54,15 +55,15 @@ public class TextImplTest {
         Text text = getTextUnderTest(TEXTINPUT1_PATH);
         assertEquals("text", text.getName());
         assertEquals("Text input field", text.getTitle());
-        assertEquals(false, text.isRequired());
+        assertFalse(text.isRequired());
         assertEquals("", text.getRequiredMessage());
-        assertEquals(false, text.isReadOnly());
+        assertFalse(text.isReadOnly());
         assertEquals("text", text.getType());
         assertEquals("", text.getConstraintMessage());
         assertEquals("", text.getValue());
         assertEquals(2, text.getRows());
         assertEquals("", text.getHelpMessage());
-        assertEquals(false, text.hideTitle());
+        assertFalse(text.hideTitle());
     }
 
     @Test
@@ -70,15 +71,15 @@ public class TextImplTest {
         Text text = getTextUnderTest(TEXTINPUT2_PATH);
         assertEquals("Custom Name", text.getName());
         assertEquals("Custom title", text.getTitle());
-        assertEquals(true, text.isRequired());
+        assertTrue(text.isRequired());
         assertEquals("please fill the field", text.getRequiredMessage());
-        assertEquals(true, text.isReadOnly());
+        assertTrue(text.isReadOnly());
         assertEquals("email", text.getType());
         assertEquals("The value should be a valid email address", text.getConstraintMessage());
         assertEquals("Prefilled Sample Input", text.getValue());
         assertEquals(3, text.getRows());
         assertEquals("Custom help/placeholder message", text.getHelpMessage());
-        assertEquals(true, text.hideTitle());
+        assertTrue(text.hideTitle());
         Utils.testJSONExport(text, Utils.getTestExporterJSONPath(TEST_BASE, TEXTINPUT2_PATH));
     }
 
@@ -89,13 +90,7 @@ public class TextImplTest {
     }
 
     private Text getTextUnderTest(String resourcePath) {
-        Resource resource = CONTEXT.resourceResolver().getResource(resourcePath);
-        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(CONTEXT.resourceResolver(), CONTEXT.bundleContext());
-        request.setResource(resource);
-        SlingBindings bindings = new SlingBindings();
-        bindings.put(SlingBindings.RESOURCE, resource);
-        bindings.put(WCMBindings.PROPERTIES, resource.getValueMap());
-        request.setAttribute(SlingBindings.class.getName(), bindings);
-        return request.adaptTo(Text.class);
+        context.currentResource(Objects.requireNonNull(context.resourceResolver().getResource(resourcePath)));
+        return context.request().adaptTo(Text.class);
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImplTest.java
@@ -17,7 +17,6 @@ package com.adobe.cq.wcm.core.components.internal.models.v2;
 
 import java.util.List;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,12 +29,16 @@ import com.adobe.cq.wcm.core.components.models.ImageArea;
 import com.google.common.collect.ImmutableMap;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 class ImageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.ImageImplTest {
 
-    private static String TEST_BASE = "/image/v2";
+    private static final String TEST_BASE = "/image/v2";
     private static final String IMAGE20_PATH = PAGE + "/jcr:content/root/image20";
     private static final String IMAGE21_PATH = PAGE + "/jcr:content/root/image21";
     private static final String IMAGE22_PATH = PAGE + "/jcr:content/root/image22";
@@ -73,7 +76,7 @@ class ImageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.
         context.contentPolicyMapping(ImageImpl.RESOURCE_TYPE,
                 "allowedRenditionWidths", new int[]{600});
         Image image = getImageUnderTest(AbstractImageTest.IMAGE3_PATH);
-        Assert.assertArrayEquals(new int[] {600}, image.getWidths());
+        assertArrayEquals(new int[] {600}, image.getWidths());
         assertFalse(image.isLazyEnabled());
         Utils.testJSONExport(image, Utils.getTestExporterJSONPath(TEST_BASE, AbstractImageTest.IMAGE3_PATH));
     }
@@ -85,7 +88,7 @@ class ImageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.
         context.request().setParameterMap(ImmutableMap.of("contentPolicyDelegatePath", IMAGE0_PATH));
         Image image = getImageUnderTest(AbstractImageTest.IMAGE3_PATH);
 
-        Assert.assertArrayEquals(new int[] {600}, image.getWidths());
+        assertArrayEquals(new int[] {600}, image.getWidths());
         assertFalse(image.isLazyEnabled());
         Utils.testJSONExport(image, Utils.getTestExporterJSONPath(TEST_BASE, AbstractImageTest.IMAGE3_PATH + "-with-policy-delegate"));
     }
@@ -95,7 +98,7 @@ class ImageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.
         context.contentPolicyMapping(ImageImpl.RESOURCE_TYPE,
                 "allowedRenditionWidths", new int[]{600, 700, 800, 2000, 2500});
         Image image = getImageUnderTest(AbstractImageTest.IMAGE0_PATH);
-        Assert.assertArrayEquals(new int[] { 600, 700, 800, 2000, 2500 }, image.getWidths());
+        assertArrayEquals(new int[] { 600, 700, 800, 2000, 2500 }, image.getWidths());
         assertFalse(image.isLazyEnabled());
         Utils.testJSONExport(image, Utils.getTestExporterJSONPath(TEST_BASE, AbstractImageTest.IMAGE0_PATH));
     }
@@ -106,7 +109,7 @@ class ImageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.
                 "uuidDisabled", true);
         Image image = getImageUnderTest(AbstractImageTest.IMAGE4_PATH);
 
-        Assert.assertArrayEquals(new int[] {}, image.getWidths());
+        assertArrayEquals(new int[] {}, image.getWidths());
         assertFalse(image.isLazyEnabled());
         Utils.testJSONExport(image, Utils.getTestExporterJSONPath(TEST_BASE, AbstractImageTest.IMAGE4_PATH));
     }
@@ -133,10 +136,10 @@ class ImageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.
                 "uuidDisabled", true);
         String escapedResourcePath = AbstractImageTest.IMAGE4_PATH.replace("jcr:content", "_jcr_content");
         com.adobe.cq.wcm.core.components.models.Image image = getImageUnderTest(AbstractImageTest.IMAGE4_PATH);
-        assertNull("Did not expect a value for the alt attribute, since the image is marked as decorative.", image.getAlt());
+        assertNull(image.getAlt(), "Did not expect a value for the alt attribute, since the image is marked as decorative.");
         assertEquals("Adobe Systems Logo and Wordmark", image.getTitle());
-        assertTrue("Image should display a caption popup.", image.displayPopupTitle());
-        assertNull("Did not expect a link for this image, since it's marked as decorative.", image.getLink());
+        assertTrue(image.displayPopupTitle(), "Image should display a caption popup.");
+        assertNull(image.getLink(), "Did not expect a link for this image, since it's marked as decorative.");
         assertEquals(CONTEXT_PATH + escapedResourcePath + "." + selector + ".png/1494867377756/" + ASSET_NAME + ".png", image.getSrc());
         compareJSON(
                 "{\"" + com.adobe.cq.wcm.core.components.models.Image.JSON_SMART_IMAGES + "\":[], \"" + com.adobe.cq.wcm.core.components.models.Image.JSON_SMART_SIZES + "\":[], \"" + com.adobe.cq.wcm.core.components.models.Image.JSON_LAZY_ENABLED +
@@ -182,12 +185,12 @@ class ImageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.
         int index = 0;
         while (areas.size() > index) {
             ImageArea area = areas.get(index);
-            assertEquals("The image area's shape is not as expected.", expectedAreas[index][0], area.getShape());
-            assertEquals("The image area's coordinates are not as expected.", expectedAreas[index][1], area.getCoordinates());
-            assertEquals("The image area's relative coordinates are not as expected.", expectedAreas[index][2], area.getRelativeCoordinates());
-            assertEquals("The image area's href is not as expected.", expectedAreas[index][3], area.getHref());
-            assertEquals("The image area's target is not as expected.", expectedAreas[index][4], area.getTarget());
-            assertEquals("The image area's alt text is not as expected.", expectedAreas[index][5], area.getAlt());
+            assertEquals(expectedAreas[index][0], area.getShape(), "The image area's shape is not as expected.");
+            assertEquals(expectedAreas[index][1], area.getCoordinates(), "The image area's coordinates are not as expected.");
+            assertEquals(expectedAreas[index][2], area.getRelativeCoordinates(), "The image area's relative coordinates are not as expected.");
+            assertEquals(expectedAreas[index][3], area.getHref(), "The image area's href is not as expected.");
+            assertEquals(expectedAreas[index][4], area.getTarget(), "The image area's target is not as expected.");
+            assertEquals(expectedAreas[index][5], area.getAlt(), "The image area's alt text is not as expected.");
             index++;
         }
         Utils.testJSONExport(image, Utils.getTestExporterJSONPath(TEST_BASE, AbstractImageTest.IMAGE24_PATH));
@@ -228,7 +231,7 @@ class ImageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.
                 "allowedRenditionWidths", new int[]{600});
         String escapedResourcePath = IMAGE27_PATH.replace("jcr:content", "_jcr_content");
         Image image = getImageUnderTest(IMAGE27_PATH);
-        assertNull("Did not expect a file reference.", image.getFileReference());
+        assertNull(image.getFileReference(), "Did not expect a file reference.");
         assertEquals(CONTEXT_PATH + escapedResourcePath + "." + selector + ".82.600.png/1490005239000.png", image.getSrc());
         String expectedJson = "{\"smartImages\":[\"/core/content/test/_jcr_content/root/image27." + selector +  "." + jpegQuality +
             ".600.png/1490005239000.png\"],\"smartSizes\":[600],\"lazyEnabled\":false}";

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImplTest.java
@@ -1,23 +1,27 @@
-/*******************************************************************************
- * Copyright 2017 Adobe
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2017 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v2;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,8 +39,13 @@ import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 import static com.adobe.cq.wcm.core.components.Utils.getTestExporterJSONPath;
 import static com.adobe.cq.wcm.core.components.Utils.testJSONExport;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(AemContextExtension.class)
@@ -46,7 +55,7 @@ class PageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.P
     private static final String REDIRECT_PAGE = CONTENT_ROOT + "/redirect-page";
     private static final String PN_CLIENT_LIBS = "clientlibs";
 
-    private static MockProductInfoProvider mockProductInfoProvider = new MockProductInfoProvider();
+    private static final MockProductInfoProvider mockProductInfoProvider = new MockProductInfoProvider();
 
     @BeforeEach
     protected void setUp() {
@@ -88,12 +97,11 @@ class PageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.P
     @Test
     void testFavicons() {
         Page page = getPageUnderTest(PAGE);
-            assertThrows(UnsupportedOperationException.class, () -> { page.getFavicons();
-        });
+            assertThrows(UnsupportedOperationException.class, page::getFavicons);
     }
 
     @Test
-    void testGetFaviconClientLibPath() throws Exception {
+    void testGetFaviconClientLibPath() {
         Page page = getPageUnderTest(PAGE, Page.PN_APP_RESOURCES_CLIENTLIB,
                 "coretest.product-page.appResources");
         String faviconClientLibPath = page.getAppResourcesPath();
@@ -101,7 +109,7 @@ class PageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.P
     }
 
     @Test
-    void testRedirectTarget() throws Exception {
+    void testRedirectTarget() {
         Page page = getPageUnderTest(REDIRECT_PAGE);
         NavigationItem redirectTarget = page.getRedirectTarget();
         assertNotNull(redirectTarget);
@@ -110,28 +118,25 @@ class PageImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.P
     }
 
     @Test
-    void testGetCssClasses() throws Exception {
+    void testGetCssClasses() {
         Page page = getPageUnderTest(PAGE, CSS_CLASS_NAMES_KEY, new String[]{"class1", "class2"});
         String cssClasses = page.getCssClassNames();
-        assertEquals("The CSS classes of the page are not expected: " + PAGE, "class1 class2", cssClasses);
+        assertEquals("class1 class2", cssClasses, "The CSS classes of the page are not expected: " + PAGE);
     }
 
     @Test
     void testHasCloudconfigSupport() {
         Page page = new PageImpl();
-        assertFalse("Expected no cloudconfig support if product info provider missing", page.hasCloudconfigSupport());
+        assertFalse(page.hasCloudconfigSupport(), "Expected no cloudconfig support if product info provider missing");
 
         mockProductInfoProvider.setVersion(new Version("6.3.1"));
         page = getPageUnderTest(PAGE);
-        assertFalse("Expected no cloudconfig support if product version < 6.4.0", page.hasCloudconfigSupport());
+        assertFalse(page.hasCloudconfigSupport(), "Expected no cloudconfig support if product version < 6.4.0");
 
         // reset cached value
         Utils.setInternalState(page, "hasCloudconfigSupport", (Boolean)null);
         mockProductInfoProvider.setVersion(new Version("6.4.0"));
-        assertTrue("Expected cloudconfig support if product version >= 6.4.0", page.hasCloudconfigSupport());
+        assertTrue(page.hasCloudconfigSupport(), "Expected cloudconfig support if product version >= 6.4.0");
     }
 
-//    private Page getPageUnderTest(String pagePath) {
-//        return super.getPageUnderTest(Page.class, pagePath);
-//    }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/embed/OEmbedClientImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/embed/OEmbedClientImplTest.java
@@ -38,9 +38,9 @@ import com.adobe.cq.wcm.core.components.services.embed.OEmbedClient;
 import com.adobe.cq.wcm.core.components.services.embed.OEmbedResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/embed/OEmbedJSONResponseImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/embed/OEmbedJSONResponseImplTest.java
@@ -20,7 +20,9 @@ import java.io.InputStream;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.adobe.cq.wcm.core.components.services.embed.OEmbedResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/embed/OEmbedUrlProcessorTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/embed/OEmbedUrlProcessorTest.java
@@ -21,9 +21,9 @@ import org.mockito.Mockito;
 import com.adobe.cq.wcm.core.components.services.embed.OEmbedClient;
 import com.adobe.cq.wcm.core.components.services.embed.UrlProcessor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class OEmbedUrlProcessorTest {
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/embed/OEmbedXMLResponseImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/embed/OEmbedXMLResponseImplTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import com.adobe.cq.wcm.core.components.services.embed.OEmbedResponse;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class OEmbedXMLResponseImplTest {
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/embed/PinterestUrlProcessorTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/embed/PinterestUrlProcessorTest.java
@@ -19,7 +19,9 @@ import org.junit.jupiter.api.Test;
 
 import com.adobe.cq.wcm.core.components.services.embed.UrlProcessor;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class PinterestUrlProcessorTest {
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactoryTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactoryTest.java
@@ -18,9 +18,9 @@ package com.adobe.cq.wcm.core.components.internal.servlets;
 import java.lang.annotation.Annotation;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AdaptiveImageServletMappingConfigurationFactoryTest {
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletTest.java
@@ -15,7 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.servlets;
 
-import java.awt.*;
+import java.awt.Dimension;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -32,7 +32,9 @@ import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.testing.mock.sling.servlet.MockRequestPathInfo;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
+import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,14 +51,18 @@ import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.org.lidalia.slf4jtest.LoggingEvent.warn;
 
 @ExtendWith(AemContextExtension.class)
 class AdaptiveImageServletTest extends AbstractImageTest {
 
-    private static String TEST_BASE = "/image";
+    private static final String TEST_BASE = "/image";
 
     private AdaptiveImageServlet servlet;
     private static final int ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH = 1280;
@@ -97,8 +103,8 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         BufferedImage image = ImageIO.read(byteArrayInputStream);
         Dimension expectedDimension = new Dimension(800, 800);
         Dimension actualDimension = new Dimension(image.getWidth(), image.getHeight());
-        assertEquals("Expected image rendered at requested size.", expectedDimension, actualDimension);
-        assertEquals("Expected a PNG image.", "image/png", response.getContentType());
+        Assertions.assertEquals(expectedDimension, actualDimension, "Expected image rendered at requested size.");
+        Assertions.assertEquals("image/png", response.getContentType(), "Expected a PNG image.");
     }
 
     @Test
@@ -109,9 +115,8 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         MockSlingHttpServletResponse response = requestResponsePair.getRight();
         context.contentPolicyMapping(ImageImpl.RESOURCE_TYPE, "allowedRenditionWidths", new String[] {"600","700","800"});
         servlet.doGet(request, response);
-        assertEquals("Expected a 404 response when the design does not allow the requested width to be rendered.", HttpServletResponse
-                .SC_NOT_FOUND, response.getStatus());
-        assertArrayEquals("Expected an empty response output.", new byte[0], response.getOutput());
+        Assertions.assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus(), "Expected a 404 response when the design does not allow the requested width to be rendered.");
+        Assertions.assertArrayEquals(new byte[0], response.getOutput(), "Expected an empty response output.");
     }
 
     @Test
@@ -121,9 +126,8 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         MockSlingHttpServletRequest request = requestResponsePair.getLeft();
         MockSlingHttpServletResponse response = requestResponsePair.getRight();
         servlet.doGet(request, response);
-        assertEquals("Expected a 404 response when the request contains width information but no content policy has been defined.",
-                HttpServletResponse.SC_NOT_FOUND, response.getStatus());
-        assertArrayEquals("Expected an empty response output.", new byte[0], response.getOutput());
+        Assertions.assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus(), "Expected a 404 response when the request contains width information but no content policy has been defined.");
+        Assertions.assertArrayEquals(new byte[0], response.getOutput(), "Expected an empty response output.");
     }
 
     @Test
@@ -138,7 +142,7 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         BufferedImage image = ImageIO.read(byteArrayInputStream);
         Dimension expectedDimension = new Dimension(ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH, ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH);
         Dimension actualDimension = new Dimension(image.getWidth(), image.getHeight());
-        assertEquals("Expected image rendered with the default resize configuration width.", expectedDimension, actualDimension);
+        Assertions.assertEquals(expectedDimension, actualDimension, "Expected image rendered with the default resize configuration width.");
     }
 
 
@@ -155,7 +159,7 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         Dimension expectedDimension =
                 new Dimension(ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH, ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH);
         Dimension actualDimension = new Dimension(image.getWidth(), image.getHeight());
-        assertEquals("Expected image rendered with the default resize configuration width.", expectedDimension, actualDimension);
+        Assertions.assertEquals(expectedDimension, actualDimension, "Expected image rendered with the default resize configuration width.");
     }
 
     @Test
@@ -165,9 +169,8 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         MockSlingHttpServletRequest request = requestResponsePair.getLeft();
         MockSlingHttpServletResponse response = requestResponsePair.getRight();
         servlet.doGet(request, response);
-        assertEquals("Expected a 404 response when the request has more selectors than expected.",
-                HttpServletResponse.SC_NOT_FOUND, response.getStatus());
-        assertArrayEquals("Expected an empty response output.", new byte[0], response.getOutput());
+        Assertions.assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus(), "Expected a 404 response when the request has more selectors than expected.");
+        Assertions.assertArrayEquals(new byte[0], response.getOutput(), "Expected an empty response output.");
     }
 
     @Test
@@ -177,9 +180,8 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         MockSlingHttpServletRequest request = requestResponsePair.getLeft();
         MockSlingHttpServletResponse response = requestResponsePair.getRight();
         servlet.doGet(request, response);
-        assertEquals("Expected a 404 response when the request has an invalid width selector.",
-                HttpServletResponse.SC_NOT_FOUND, response.getStatus());
-        assertArrayEquals("Expected an empty response output.", new byte[0], response.getOutput());
+        Assertions.assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus(), "Expected a 404 response when the request has an invalid width selector.");
+        Assertions.assertArrayEquals(new byte[0], response.getOutput(), "Expected an empty response output.");
     }
 
     @Test
@@ -194,9 +196,9 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         BufferedImage image = ImageIO.read(byteArrayInputStream);
         Dimension expectedDimension = new Dimension(700, 700);
         Dimension actualDimension = new Dimension(image.getWidth(), image.getHeight());
-        assertEquals("Expected image rendered at requested size.", expectedDimension, actualDimension);
-        assertEquals("Expected a PNG image.", "image/png", response.getContentType());
-        assertThat(testLogger.getLoggingEvents(), hasItem(warn("One of the configured widths ({}) from the {} content policy is not a " +
+        Assertions.assertEquals(expectedDimension, actualDimension, "Expected image rendered at requested size.");
+        Assertions.assertEquals("image/png", response.getContentType(), "Expected a PNG image.");
+        MatcherAssert.assertThat(testLogger.getLoggingEvents(), hasItem(warn("One of the configured widths ({}) from the {} content policy is not a " +
                 "valid Integer.", "invalid", "/conf/$aem-mock$/settings/wcm/policies/core/wcm/components/image/v1/image/$mock-policy")));
     }
 
@@ -207,9 +209,8 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         MockSlingHttpServletRequest request = requestResponsePair.getLeft();
         MockSlingHttpServletResponse response = requestResponsePair.getRight();
         servlet.doGet(request, response);
-        assertEquals("Expected a 404 response when the image does not have a valid file reference.",
-                HttpServletResponse.SC_NOT_FOUND, response.getStatus());
-        assertArrayEquals("Expected an empty response output.", new byte[0], response.getOutput());
+        Assertions.assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus(), "Expected a 404 response when the image does not have a valid file reference.");
+        Assertions.assertArrayEquals(new byte[0], response.getOutput(), "Expected an empty response output.");
     }
 
     @Test
@@ -222,7 +223,7 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         ByteArrayInputStream stream = new ByteArrayInputStream(response.getOutput());
         InputStream directStream =
                 this.getClass().getClassLoader().getResourceAsStream("image/Adobe_Systems_logo_and_wordmark.gif");
-        assertTrue(IOUtils.contentEquals(stream, directStream));
+        Assertions.assertTrue(IOUtils.contentEquals(stream, directStream));
     }
 
     @Test
@@ -235,7 +236,7 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         ByteArrayInputStream stream = new ByteArrayInputStream(response.getOutput());
         InputStream directStream =
                 this.getClass().getClassLoader().getResourceAsStream("image/Adobe_Systems_logo_and_wordmark.svg");
-        assertTrue(IOUtils.contentEquals(stream, directStream));
+        Assertions.assertTrue(IOUtils.contentEquals(stream, directStream));
     }
 
     @Test
@@ -247,7 +248,7 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         // 1 millisecond less than the jcr:lastModified value from test-conf.json
         request.addDateHeader("If-Modified-Since", 1489998822137L);
         servlet.doGet(request, response);
-        assertEquals(HttpServletResponse.SC_NOT_MODIFIED, response.getStatus());
+        Assertions.assertEquals(HttpServletResponse.SC_NOT_MODIFIED, response.getStatus());
     }
 
     @Test
@@ -260,7 +261,7 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         ByteArrayInputStream stream = new ByteArrayInputStream(response.getOutput());
         InputStream directStream =
                 this.getClass().getClassLoader().getResourceAsStream("image/Adobe_Systems_logo_and_wordmark.gif");
-        assertTrue(IOUtils.contentEquals(stream, directStream));
+        Assertions.assertTrue(IOUtils.contentEquals(stream, directStream));
     }
 
     @Test
@@ -273,7 +274,7 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         ByteArrayInputStream stream = new ByteArrayInputStream(response.getOutput());
         InputStream directStream =
                 this.getClass().getClassLoader().getResourceAsStream("image/Adobe_Systems_logo_and_wordmark.svg");
-        assertTrue(IOUtils.contentEquals(stream, directStream));
+        Assertions.assertTrue(IOUtils.contentEquals(stream, directStream));
     }
 
     @Test
@@ -285,7 +286,7 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         // 1 millisecond less than the jcr:lastModified value from test-conf.json
         request.addDateHeader("If-Modified-Since", 1490005239001L);
         servlet.doGet(request, response);
-        assertEquals(HttpServletResponse.SC_NOT_MODIFIED, response.getStatus());
+        Assertions.assertEquals(HttpServletResponse.SC_NOT_MODIFIED, response.getStatus());
     }
 
     @Test
@@ -298,8 +299,8 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         servlet.doGet(request, response);
         InputStream directStream = this.getClass().getClassLoader().getResourceAsStream("image/Adobe_Systems_logo_and_wordmark.png");
         ByteArrayInputStream stream = new ByteArrayInputStream(response.getOutput());
-        assertTrue("Expected to get the original asset back, since the requested width is equal to the image's width.",
-                IOUtils.contentEquals(directStream, stream));
+        Assertions.assertTrue(IOUtils.contentEquals(directStream, stream),
+            "Expected to get the original asset back, since the requested width is equal to the image's width.");
     }
 
     @Test
@@ -312,8 +313,8 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         servlet.doGet(request, response);
         InputStream directStream = this.getClass().getClassLoader().getResourceAsStream("image/Adobe_Systems_logo_and_wordmark.png");
         ByteArrayInputStream stream = new ByteArrayInputStream(response.getOutput());
-        assertTrue("Expected to get the original asset back, since the requested width would result in upscaling the image.",
-                IOUtils.contentEquals(directStream, stream));
+        Assertions.assertTrue(IOUtils.contentEquals(directStream, stream),
+            "Expected to get the original asset back, since the requested width would result in upscaling the image.");
     }
 
     @Test
@@ -326,8 +327,8 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         servlet.doGet(request, response);
         ByteArrayInputStream stream = new ByteArrayInputStream(response.getOutput());
         BufferedImage image = ImageIO.read(stream);
-        assertEquals(600, image.getWidth());
-        assertEquals(600, image.getHeight());
+        Assertions.assertEquals(600, image.getWidth());
+        Assertions.assertEquals(600, image.getHeight());
     }
 
     @Test
@@ -340,7 +341,7 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         requestPathInfo.setSuffix("/1494867377756.png");
         MockSlingHttpServletResponse response = requestResponsePair.getRight();
         servlet.doGet(request, response);
-        assertEquals("Expected a 200 response code.", 200, response.getStatus());
+        Assertions.assertEquals(200, response.getStatus(), "Expected a 200 response code.");
     }
 
     @Test
@@ -353,7 +354,7 @@ class AdaptiveImageServletTest extends AbstractImageTest {
 
         requestPathInfo.setSuffix(TEMPLATE_IMAGE_PATH.replace(TEMPLATE_PATH, "") + "/1490005239000.png");
         servlet.doGet(request, response);
-        assertEquals("Expected a 200 response code.", 200, response.getStatus());
+        Assertions.assertEquals(200, response.getStatus(), "Expected a 200 response code.");
     }
 
     @Test
@@ -404,14 +405,14 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         MockSlingHttpServletResponse response = requestResponsePair.getRight();
         context.contentPolicyMapping(ImageImpl.RESOURCE_TYPE, "allowedRenditionWidths", new String[] {"800"});
         servlet.doGet(request, response);
-        assertEquals("Expected a 200 response code.", 200, response.getStatus());
-        assertEquals("Mon, 20 Mar 2017 10:20:39 GMT", response.getHeader(HttpConstants.HEADER_LAST_MODIFIED));
+        Assertions.assertEquals(200, response.getStatus(), "Expected a 200 response code.");
+        Assertions.assertEquals("Mon, 20 Mar 2017 10:20:39 GMT", response.getHeader(HttpConstants.HEADER_LAST_MODIFIED));
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(response.getOutput());
         BufferedImage image = ImageIO.read(byteArrayInputStream);
         Dimension expectedDimension = new Dimension(800, 800);
         Dimension actualDimension = new Dimension(image.getWidth(), image.getHeight());
-        assertEquals("Expected image rendered at requested size.", expectedDimension, actualDimension);
-        assertEquals("Expected a PNG image.", "image/png", response.getContentType());
+        Assertions.assertEquals(expectedDimension, actualDimension, "Expected image rendered at requested size.");
+        Assertions.assertEquals("image/png", response.getContentType(), "Expected a PNG image.");
     }
 
     @Test
@@ -423,9 +424,9 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         requestPathInfo.setSuffix("/42.png");
         MockSlingHttpServletResponse response = requestResponsePair.getRight();
         servlet.doGet(request, response);
-        assertEquals("Expected a 302 response code.", 302, response.getStatus());
-        assertEquals("Expected redirect location with correct last modified suffix",
-                CONTEXT_PATH + "/content/test/jcr%3acontent/root/image19.coreimg.800.png/1490005239000.png", response.getHeader("Location"));
+        Assertions.assertEquals(302, response.getStatus(), "Expected a 302 response code.");
+        Assertions.assertEquals(CONTEXT_PATH + "/content/test/jcr%3acontent/root/image19.coreimg.800.png/1490005239000.png", response.getHeader("Location"),
+            "Expected redirect location with correct last modified suffix");
     }
 
     @Test
@@ -437,9 +438,9 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         MockRequestPathInfo requestPathInfo = (MockRequestPathInfo) request.getRequestPathInfo();
         requestPathInfo.setSuffix("");
         servlet.doGet(request, response);
-        assertEquals("Expected a 302 response code.", 302, response.getStatus());
-        assertEquals("Expected redirect location with correct last modified suffix",
-                CONTEXT_PATH + "/content/test/jcr%3acontent/root/image19.coreimg.800.png/1490005239000.png", response.getHeader("Location"));
+        Assertions.assertEquals(302, response.getStatus(), "Expected a 302 response code.");
+        Assertions.assertEquals(CONTEXT_PATH + "/content/test/jcr%3acontent/root/image19.coreimg.800.png/1490005239000.png", response.getHeader("Location"),
+            "Expected redirect location with correct last modified suffix");
     }
 
     @Test
@@ -453,8 +454,8 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         BufferedImage image = ImageIO.read(byteArrayInputStream);
         Dimension expectedDimension = new Dimension(ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH, ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH);
         Dimension actualDimension = new Dimension(image.getWidth(), image.getHeight());
-        assertEquals("Expected image rendered at requested size.", expectedDimension, actualDimension);
-        assertEquals("Expected a PNG image.", "image/png", response.getContentType());
+        Assertions.assertEquals(expectedDimension, actualDimension, "Expected image rendered at requested size.");
+        Assertions.assertEquals("image/png", response.getContentType(), "Expected a PNG image.");
     }
 
     @Test
@@ -463,7 +464,7 @@ class AdaptiveImageServletTest extends AbstractImageTest {
                 prepareRequestResponsePair(IMAGE3_PATH, 1490005239000L, "img.600", "png", "jpeg");
         MockSlingHttpServletResponse response = requestResponsePair.getRight();
         servlet.doGet(requestResponsePair.getLeft(), response);
-        assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+        Assertions.assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
     }
 
     @Test
@@ -475,15 +476,15 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         rpi.setSuffix("/random");
         MockSlingHttpServletResponse response = requestResponsePair.getRight();
         servlet.doGet(request, response);
-        assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+        Assertions.assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
 
         rpi.setSuffix("/1");
         servlet.doGet(request, response);
-        assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+        Assertions.assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
 
         rpi.setSuffix("/1.");
         servlet.doGet(request, response);
-        assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+        Assertions.assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
     }
 
     @Test
@@ -496,10 +497,11 @@ class AdaptiveImageServletTest extends AbstractImageTest {
 
         requestPathInfo.setSuffix(TEMPLATE_IMAGE_PATH.replace(TEMPLATE_PATH, "") + ".png");
         servlet.doGet(request, response);
-        assertEquals("Expected a 302 response code.", 302, response.getStatus());
-        assertEquals("Expected redirect location with correct last modified suffix",
-                CONTEXT_PATH + "/content/test.coreimg.png/structure/jcr%3acontent/root/image_template/1490005239000.png",
-                response.getHeader("Location"));
+        Assertions.assertEquals(302, response.getStatus(), "Expected a 302 response code.");
+        Assertions.assertEquals(
+            CONTEXT_PATH + "/content/test.coreimg.png/structure/jcr%3acontent/root/image_template/1490005239000.png",
+            response.getHeader("Location"),
+            "Expected redirect location with correct last modified suffix");
     }
 
     @Test
@@ -512,10 +514,11 @@ class AdaptiveImageServletTest extends AbstractImageTest {
 
         requestPathInfo.setSuffix(TEMPLATE_IMAGE_PATH.replace(TEMPLATE_PATH, "") + "/1490005238000.png");
         servlet.doGet(request, response);
-        assertEquals("Expected a 302 response code.", 302, response.getStatus());
-        assertEquals("Expected redirect location with correct last modified suffix",
-                CONTEXT_PATH + "/content/test.coreimg.png/structure/jcr%3acontent/root/image_template/1490005239000.png",
-                response.getHeader("Location"));
+        Assertions.assertEquals(302, response.getStatus(), "Expected a 302 response code.");
+        Assertions.assertEquals(
+            CONTEXT_PATH + "/content/test.coreimg.png/structure/jcr%3acontent/root/image_template/1490005239000.png",
+            response.getHeader("Location"),
+            "Expected redirect location with correct last modified suffix");
     }
 
     @Test
@@ -527,13 +530,13 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         MockRequestPathInfo requestPathInfo = (MockRequestPathInfo) request.getRequestPathInfo();
         requestPathInfo.setSuffix(TEMPLATE_IMAGE_PATH.replace(TEMPLATE_PATH, "") + "/1490005239000.png");
         servlet.doGet(request, response);
-        assertEquals("Expected a 200 response code.", 200, response.getStatus());
+        Assertions.assertEquals(200, response.getStatus(), "Expected a 200 response code.");
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(response.getOutput());
         BufferedImage image = ImageIO.read(byteArrayInputStream);
         Dimension expectedDimension = new Dimension(ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH, ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH);
         Dimension actualDimension = new Dimension(image.getWidth(), image.getHeight());
-        assertEquals("Expected image rendered at requested size.", expectedDimension, actualDimension);
-        assertEquals("Expected a PNG image.", "image/png", response.getContentType());
+        Assertions.assertEquals(expectedDimension, actualDimension, "Expected image rendered at requested size.");
+        Assertions.assertEquals("image/png", response.getContentType(), "Expected a PNG image.");
 
     }
 
@@ -559,7 +562,7 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         MockSlingHttpServletRequest request = requestResponsePair.getLeft();
         MockSlingHttpServletResponse response = requestResponsePair.getRight();
         servlet.doGet(request, response);
-        assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+        Assertions.assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
     }
 
     private void testCropScaling(String imagePath, int requestedWidth, int expectedWidth, int expectedHeight) throws IOException {
@@ -570,10 +573,8 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         context.contentPolicyMapping(ImageImpl.RESOURCE_TYPE, "allowedRenditionWidths", new String[] {"1440"});
         servlet.doGet(request, response);
         BufferedImage image = ImageIO.read(new ByteArrayInputStream(response.getOutput()));
-        assertEquals("Expected the cropped rectangle to have a 1390px width, since the servlet should not perform cropping upscaling.",
-                expectedWidth, image.getWidth());
-        assertEquals("Expected the cropped rectangle to have a 515px height, since the servlet should not perform cropping upscaling.",
-                expectedHeight, image.getHeight());
+        Assertions.assertEquals(expectedWidth, image.getWidth(), "Expected the cropped rectangle to have a 1390px width, since the servlet should not perform cropping upscaling.");
+        Assertions.assertEquals(expectedHeight, image.getHeight(), "Expected the cropped rectangle to have a 515px height, since the servlet should not perform cropping upscaling.");
     }
 
     private void testHorizontalAndVerticalFlip(Pair<MockSlingHttpServletRequest, MockSlingHttpServletResponse> requestResponsePair) throws
@@ -582,14 +583,13 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         MockSlingHttpServletResponse response = requestResponsePair.getRight();
         context.contentPolicyMapping(ImageImpl.RESOURCE_TYPE, "allowedRenditionWidths", new String[] {"2000"});
         servlet.doGet(request, response);
-        assertEquals("Expected a 200 response.",
-                HttpServletResponse.SC_OK, response.getStatus());
+        Assertions.assertEquals(HttpServletResponse.SC_OK, response.getStatus(), "Expected a 200 response.");
         Layer layer = new Layer(this.getClass().getClassLoader().getResourceAsStream("image/Adobe_Systems_logo_and_wordmark.png"));
         layer.flipHorizontally();
         layer.flipVertically();
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         layer.write(StandardImageHandler.PNG1_MIMETYPE, 1.0, outputStream);
-        assertArrayEquals(outputStream.toByteArray(), response.getOutput());
+        Assertions.assertArrayEquals(outputStream.toByteArray(), response.getOutput());
     }
 
     private Pair<MockSlingHttpServletRequest, MockSlingHttpServletResponse> prepareRequestResponsePair(String resourcePath,
@@ -632,8 +632,8 @@ class AdaptiveImageServletTest extends AbstractImageTest {
 
     private static class RequestResponsePair extends Pair<MockSlingHttpServletRequest, MockSlingHttpServletResponse> {
 
-        private MockSlingHttpServletRequest request;
-        private MockSlingHttpServletResponse response;
+        private final MockSlingHttpServletRequest request;
+        private final MockSlingHttpServletResponse response;
 
         private RequestResponsePair(MockSlingHttpServletRequest request,
                                    MockSlingHttpServletResponse response) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AllowedHeadingElementsDataSourceServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AllowedHeadingElementsDataSourceServletTest.java
@@ -25,7 +25,10 @@ import com.adobe.granite.ui.components.ds.DataSource;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 class AllowedHeadingElementsDataSourceServletTest {
@@ -40,7 +43,7 @@ class AllowedHeadingElementsDataSourceServletTest {
 
     @BeforeEach
     void setUp() {
-        context.load().json(TEST_BASE + "/test-content.json", TEST_PAGE);
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, TEST_PAGE);
         dataSourceServlet = new AllowedHeadingElementsDataSourceServlet();
         context.request().setAttribute(Value.CONTENTPATH_ATTRIBUTE,TITLE_RESOURCE_JCR_TITLE_TYPE);
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AllowedHeadingElementsDataSourceServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AllowedHeadingElementsDataSourceServletTest.java
@@ -25,10 +25,10 @@ import com.adobe.granite.ui.components.ds.DataSource;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 class AllowedHeadingElementsDataSourceServletTest {
@@ -57,10 +57,10 @@ class AllowedHeadingElementsDataSourceServletTest {
         DataSource dataSource = (DataSource) context.request().getAttribute(DataSource.class.getName());
         assertNotNull(dataSource);
         dataSource.iterator().forEachRemaining(resource -> {
-            assertTrue("Expected class", TextValueDataResourceSource.class.isAssignableFrom(resource.getClass()));
+            assertTrue(TextValueDataResourceSource.class.isAssignableFrom(resource.getClass()), "Expected class");
             TextValueDataResourceSource textValueDataResourceSource = (TextValueDataResourceSource) resource;
-            assertTrue("Expected type in (h3, h4)", textValueDataResourceSource.getText().matches("h[3|4]"));
-            assertTrue("Expected value in (h3, h4)", textValueDataResourceSource.getValue().matches("h[3|4]"));
+            assertTrue(textValueDataResourceSource.getText().matches("h[3|4]"), "Expected type in (h3, h4)");
+            assertTrue(textValueDataResourceSource.getValue().matches("h[3|4]"), "Expected value in (h3, h4)");
             if (textValueDataResourceSource.getValue().equals("h3")) {
                 assertTrue(textValueDataResourceSource.getSelected());
             } else {
@@ -77,10 +77,10 @@ class AllowedHeadingElementsDataSourceServletTest {
         DataSource dataSource = (DataSource) context.request().getAttribute(DataSource.class.getName());
         assertNotNull(dataSource);
         dataSource.iterator().forEachRemaining(resource -> {
-            assertTrue("Expected class", TextValueDataResourceSource.class.isAssignableFrom(resource.getClass()));
+            assertTrue(TextValueDataResourceSource.class.isAssignableFrom(resource.getClass()), "Expected class");
             TextValueDataResourceSource textValueDataResourceSource = (TextValueDataResourceSource) resource;
-            assertNull("Expected null type", textValueDataResourceSource.getText());
-            assertTrue("Expected value in (foo, h10)", textValueDataResourceSource.getValue().matches("foo|h10"));
+            assertNull(textValueDataResourceSource.getText(), "Expected null type");
+            assertTrue(textValueDataResourceSource.getValue().matches("foo|h10"), "Expected value in (foo, h10)");
         });
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/ClientLibraryCategoriesDataSourceServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/ClientLibraryCategoriesDataSourceServletTest.java
@@ -17,57 +17,50 @@ package com.adobe.cq.wcm.core.components.internal.servlets;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
-
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.testing.Utils;
 import com.adobe.granite.ui.clientlibs.ClientLibrary;
 import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
-import com.adobe.granite.ui.clientlibs.LibraryType;
 import com.adobe.granite.ui.components.ds.DataSource;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(AemContextExtension.class)
 public class ClientLibraryCategoriesDataSourceServletTest {
 
-    @Rule
-    public AemContext context = CoreComponentTestContext.createContext("/commons/datasources/clientlibrarycategories/v1",
-        "/apps");
-
-    private static final String CLIENTLIB_A_PATH = "/apps/clientlibs/a-jsonly";
+    private static final String TEST_BASE = "/commons/datasources/clientlibrarycategories/v1";
+    private static final String TEST_APPS_ROOT = "/apps";
     private static final String[] CLIENTLIB_A_CATEGORIES = new String[] { "clientlib.a.jsonly" };
-    private static final Set<LibraryType> CLIENTLIB_A_TYPES = new HashSet<>(Arrays.asList(LibraryType.JS));
 
     private static final String CLIENTLIB_B_PATH = "/apps/clientlibs/b-cssonly";
     private static final String[] CLIENTLIB_B_CATEGORIES = new String[] { "clientlib.b.cssonly" };
-    private static final Set<LibraryType> CLIENTLIB_B_TYPES = new HashSet<>(Arrays.asList(LibraryType.CSS));
 
     private static final String CLIENTLIB_C_PATH = "/apps/clientlibs/c-jsandcss";
     private static final String[] CLIENTLIB_C_CATEGORIES = new String[] { "clientlib.c.jsandcss" };
-    private static final Set<LibraryType> CLIENTLIB_C_TYPES = new HashSet<>(Arrays.asList(LibraryType.JS, LibraryType.CSS));
+
+    public final AemContext context = CoreComponentTestContext.newAemContext();
 
     private ClientLibraryCategoriesDataSourceServlet dataSourceServlet;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, TEST_APPS_ROOT);
+
         dataSourceServlet = new ClientLibraryCategoriesDataSourceServlet();
 
         HtmlLibraryManager htmlLibraryManager = mock(HtmlLibraryManager.class);
 
-        Map<String, ClientLibrary> clientLibraries = new HashMap<String, ClientLibrary>();
+        Map<String, ClientLibrary> clientLibraries = new HashMap<>();
         when(htmlLibraryManager.getLibraries()).thenReturn(clientLibraries);
 
         // A. JavaScript only
@@ -97,12 +90,12 @@ public class ClientLibraryCategoriesDataSourceServletTest {
         DataSource dataSource = (DataSource) context.request().getAttribute(DataSource.class.getName());
         assertNotNull(dataSource);
         dataSource.iterator().forEachRemaining(resource -> {
-            assertTrue("Expected class", TextValueDataResourceSource.class.isAssignableFrom(resource.getClass()));
+            assertTrue(TextValueDataResourceSource.class.isAssignableFrom(resource.getClass()), "Expected class");
             TextValueDataResourceSource textValueDataResourceSource = (TextValueDataResourceSource) resource;
-            assertTrue("Expected type in (clientlib.a.jsonly, clientlib.b.cssonly, clientlib.c.jsandcss)",
-                Arrays.asList(CLIENTLIB_A_CATEGORIES[0], CLIENTLIB_B_CATEGORIES[0], CLIENTLIB_C_CATEGORIES[0]).contains(textValueDataResourceSource.getText()));
-            assertTrue("Expected value in (clientlib.a.jsonly, clientlib.b.cssonly, clientlib.c.jsandcss)",
-                Arrays.asList(CLIENTLIB_A_CATEGORIES[0], CLIENTLIB_B_CATEGORIES[0], CLIENTLIB_C_CATEGORIES[0]).contains(textValueDataResourceSource.getValue()));
+            assertTrue(Arrays.asList(CLIENTLIB_A_CATEGORIES[0], CLIENTLIB_B_CATEGORIES[0], CLIENTLIB_C_CATEGORIES[0]).contains(textValueDataResourceSource.getText()),
+                "Expected type in (clientlib.a.jsonly, clientlib.b.cssonly, clientlib.c.jsandcss)");
+            assertTrue(Arrays.asList(CLIENTLIB_A_CATEGORIES[0], CLIENTLIB_B_CATEGORIES[0], CLIENTLIB_C_CATEGORIES[0]).contains(textValueDataResourceSource.getValue()),
+                "Expected value in (clientlib.a.jsonly, clientlib.b.cssonly, clientlib.c.jsandcss)");
         });
     }
 
@@ -113,12 +106,12 @@ public class ClientLibraryCategoriesDataSourceServletTest {
         DataSource dataSource = (DataSource) context.request().getAttribute(DataSource.class.getName());
         assertNotNull(dataSource);
         dataSource.iterator().forEachRemaining(resource -> {
-            assertTrue("Expected class", TextValueDataResourceSource.class.isAssignableFrom(resource.getClass()));
+            assertTrue(TextValueDataResourceSource.class.isAssignableFrom(resource.getClass()), "Expected class");
             TextValueDataResourceSource textValueDataResourceSource = (TextValueDataResourceSource) resource;
-            assertTrue("Expected type in (clientlib.a.jsonly, clientlib.c.jsandcss)",
-                Arrays.asList(CLIENTLIB_A_CATEGORIES[0], CLIENTLIB_C_CATEGORIES[0]).contains(textValueDataResourceSource.getText()));
-            assertTrue("Expected value in (clientlib.a.jsonly, clientlib.c.jsandcss)",
-                Arrays.asList(CLIENTLIB_A_CATEGORIES[0], CLIENTLIB_C_CATEGORIES[0]).contains(textValueDataResourceSource.getValue()));
+            assertTrue(Arrays.asList(CLIENTLIB_A_CATEGORIES[0], CLIENTLIB_C_CATEGORIES[0]).contains(textValueDataResourceSource.getText()),
+                "Expected type in (clientlib.a.jsonly, clientlib.c.jsandcss)");
+            assertTrue(Arrays.asList(CLIENTLIB_A_CATEGORIES[0], CLIENTLIB_C_CATEGORIES[0]).contains(textValueDataResourceSource.getValue()),
+                "Expected value in (clientlib.a.jsonly, clientlib.c.jsandcss)");
         });
     }
 
@@ -129,12 +122,12 @@ public class ClientLibraryCategoriesDataSourceServletTest {
         DataSource dataSource = (DataSource) context.request().getAttribute(DataSource.class.getName());
         assertNotNull(dataSource);
         dataSource.iterator().forEachRemaining(resource -> {
-            assertTrue("Expected class", TextValueDataResourceSource.class.isAssignableFrom(resource.getClass()));
+            assertTrue(TextValueDataResourceSource.class.isAssignableFrom(resource.getClass()), "Expected class");
             TextValueDataResourceSource textValueDataResourceSource = (TextValueDataResourceSource) resource;
-            assertTrue("Expected type in (clientlib.b.cssonly, clientlib.c.jsandcss)",
-                Arrays.asList(CLIENTLIB_B_CATEGORIES[0], CLIENTLIB_C_CATEGORIES[0]).contains(textValueDataResourceSource.getText()));
-            assertTrue("Expected value in (clientlib.b.cssonly, clientlib.c.jsandcss)",
-                Arrays.asList(CLIENTLIB_B_CATEGORIES[0], CLIENTLIB_C_CATEGORIES[0]).contains(textValueDataResourceSource.getValue()));
+            assertTrue(Arrays.asList(CLIENTLIB_B_CATEGORIES[0], CLIENTLIB_C_CATEGORIES[0]).contains(textValueDataResourceSource.getText()),
+                "Expected type in (clientlib.b.cssonly, clientlib.c.jsandcss)");
+            assertTrue(Arrays.asList(CLIENTLIB_B_CATEGORIES[0], CLIENTLIB_C_CATEGORIES[0]).contains(textValueDataResourceSource.getValue()),
+                "Expected value in (clientlib.b.cssonly, clientlib.c.jsandcss)");
         });
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/CoreFormHandlingServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/CoreFormHandlingServletTest.java
@@ -18,37 +18,29 @@ package com.adobe.cq.wcm.core.components.internal.servlets;
 import java.lang.annotation.Annotation;
 import javax.servlet.FilterChain;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
-import org.apache.sling.servlethelpers.MockSlingHttpServletRequest;
-import org.apache.sling.servlethelpers.MockSlingHttpServletResponse;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.testing.Utils;
-import com.day.cq.wcm.foundation.forms.FormStructureHelperFactory;
 import com.day.cq.wcm.foundation.forms.FormsHandlingServletHelper;
-import com.day.cq.wcm.foundation.security.SaferSlingPostValidator;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith({AemContextExtension.class, MockitoExtension.class})
 public class CoreFormHandlingServletTest {
 
-    @Mock
-    FormStructureHelperFactory formStructureHelperFactory;
-
-    @Mock
-    SaferSlingPostValidator saferSlingPostValidator;
+    private static final String[] NAME_WHITELIST = {"param-text", "param-button"};
+    private static final boolean ALLOW_EXPRESSIONS = false;
+    private static final String SELECTOR = "form";
+    private static final String EXTENSION = "html";
 
     @Mock
     FormsHandlingServletHelper formsHandlingServletHelper;
@@ -56,21 +48,11 @@ public class CoreFormHandlingServletTest {
     @InjectMocks
     CoreFormHandlingServlet servlet;
 
-    @ClassRule
-    public static final AemContext context = CoreComponentTestContext.createContext();
+    public static AemContext context = CoreComponentTestContext.newAemContext();
 
-    private static final String[] NAME_WHITELIST = {"param-text", "param-button"};
-
-    private static final boolean ALLOW_EXPRESSIONS = false;
-
-    private static final String SELECTOR = "form";
-
-    private static final String EXTENSION = "html";
-
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         servlet = new CoreFormHandlingServlet();
-        MockitoAnnotations.initMocks(this);
         servlet.activate(new CoreFormHandlingServlet.Configuration() {
 
             @Override
@@ -93,18 +75,14 @@ public class CoreFormHandlingServletTest {
 
     @Test
     public void testDoPost() throws Exception {
-        SlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver());
-        SlingHttpServletResponse response = new MockSlingHttpServletResponse();
-        servlet.doPost(request, response);
-        verify(formsHandlingServletHelper).doPost(request, response);
+        servlet.doPost(context.request(), context.response());
+        verify(formsHandlingServletHelper).doPost(context.request(), context.response());
     }
 
     @Test
     public void testDoFilter() throws Exception {
-        SlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver());
-        SlingHttpServletResponse response = new MockSlingHttpServletResponse();
         FilterChain filterChain = mock(FilterChain.class);
-        servlet.doFilter(request, response, filterChain);
-        verify(formsHandlingServletHelper).handleFilter(request, response, filterChain, EXTENSION, SELECTOR);
+        servlet.doFilter(context.request(), context.response(), filterChain);
+        verify(formsHandlingServletHelper).handleFilter(context.request(), context.response(), filterChain, EXTENSION, SELECTOR);
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/DownloadServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/DownloadServletTest.java
@@ -25,8 +25,8 @@ import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 class DownloadServletTest {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/FormActionTypeDataSourceServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/FormActionTypeDataSourceServletTest.java
@@ -13,40 +13,39 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-
 package com.adobe.cq.wcm.core.components.internal.servlets;
 
 import java.util.ArrayList;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ValueMap;
-import org.jetbrains.annotations.Nullable;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.granite.ui.components.ds.DataSource;
 import com.day.cq.wcm.foundation.forms.FormsManager;
 import com.google.common.base.Function;
-import io.wcm.testing.mock.aem.junit.AemContext;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static com.adobe.cq.wcm.core.components.internal.servlets.TextValueDataResourceSource.PN_TEXT;
 import static com.adobe.cq.wcm.core.components.internal.servlets.TextValueDataResourceSource.PN_VALUE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith({AemContextExtension.class, MockitoExtension.class})
 public class FormActionTypeDataSourceServletTest {
 
-    @Rule
-    public AemContext context = CoreComponentTestContext.createContext("/form/container/datasource/actiontypedatasource",
-            "/apps");
+    private static final String TEST_BASE = "/form/container/datasource/actiontypedatasource";
+    private static final String APPS_ROOT = "/apps";
+
+    public final AemContext context = CoreComponentTestContext.newAemContext();
 
     @Mock
     private FormsManager formsManagerMock;
@@ -55,10 +54,10 @@ public class FormActionTypeDataSourceServletTest {
     private FormsManager.ComponentDescription description;
 
 
-    private FormActionTypeDataSourceServlet dataSourceServlet;
+    @BeforeEach
+    public void setUp() {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, APPS_ROOT);
 
-    @Before
-    public void setUp() throws Exception {
         registerFormsManagerAdapter();
         ArrayList<FormsManager.ComponentDescription> componentDescriptions = new ArrayList<>();
         componentDescriptions.add(description);
@@ -70,24 +69,18 @@ public class FormActionTypeDataSourceServletTest {
     @Test
     public void testDataSource() throws Exception {
         context.currentResource("/apps/actiontypedatasource");
-        dataSourceServlet = new FormActionTypeDataSourceServlet();
+        FormActionTypeDataSourceServlet dataSourceServlet = new FormActionTypeDataSourceServlet();
         dataSourceServlet.doGet(context.request(), context.response());
         DataSource dataSource = (com.adobe.granite.ui.components.ds.DataSource) context.request().getAttribute(
                 DataSource.class.getName());
         assertNotNull(dataSource);
         Resource resource = dataSource.iterator().next();
-        ValueMap valueMap = resource.adaptTo(ValueMap.class);
-        assertEquals("Form Action", valueMap.get(PN_TEXT, String.class));
-        assertEquals("form/action", valueMap.get(PN_VALUE, String.class));
+        assertEquals("Form Action", resource.getValueMap().get(PN_TEXT, String.class));
+        assertEquals("form/action", resource.getValueMap().get(PN_VALUE, String.class));
     }
 
     private void registerFormsManagerAdapter() {
-        context.registerAdapter(ResourceResolver.class, FormsManager.class, new Function<ResourceResolver, FormsManager>() {
-            @Nullable
-            @Override
-            public FormsManager apply(@Nullable ResourceResolver input) {
-                return formsManagerMock;
-            }
-        });
+        context.registerAdapter(ResourceResolver.class, FormsManager.class,
+            (Function<ResourceResolver, FormsManager>) input -> formsManagerMock);
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/FormActionTypeSettingsDataSourceServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/FormActionTypeSettingsDataSourceServletTest.java
@@ -13,37 +13,36 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-
 package com.adobe.cq.wcm.core.components.internal.servlets;
 
 import java.util.ArrayList;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.jetbrains.annotations.Nullable;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.granite.ui.components.ds.DataSource;
 import com.day.cq.wcm.foundation.forms.FormsManager;
 import com.google.common.base.Function;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith({AemContextExtension.class, MockitoExtension.class})
 public class FormActionTypeSettingsDataSourceServletTest {
 
-    @Rule
-    public AemContext context = CoreComponentTestContext.createContext("/form/container/datasource/actiontypesettingsdatasource",
-            "/apps");
+    private static final String TEST_BASE = "/form/container/datasource/actiontypesettingsdatasource";
+    private static final String APPS_ROOT = "/apps";
+
+    public final AemContext context = CoreComponentTestContext.newAemContext();
 
     @Mock
     private FormsManager formsManagerMock;
@@ -51,11 +50,10 @@ public class FormActionTypeSettingsDataSourceServletTest {
     @Mock
     private FormsManager.ComponentDescription description;
 
+    @BeforeEach
+    public void setUp() {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, APPS_ROOT);
 
-    private FormActionTypeSettingsDataSourceServlet dataSourceServlet;
-
-    @Before
-    public void setUp() throws Exception {
         registerFormsManagerAdapter();
         ArrayList<FormsManager.ComponentDescription> componentDescriptions = new ArrayList<>();
         componentDescriptions.add(description);
@@ -66,22 +64,16 @@ public class FormActionTypeSettingsDataSourceServletTest {
     @Test
     public void testDataSource() throws Exception {
         context.currentResource("/apps/actiontypesettingsdatasource");
-        dataSourceServlet = new FormActionTypeSettingsDataSourceServlet();
+        FormActionTypeSettingsDataSourceServlet dataSourceServlet = new FormActionTypeSettingsDataSourceServlet();
         dataSourceServlet.doGet(context.request(), context.response());
-        DataSource dataSource = (DataSource) context.request().getAttribute(
-                DataSource.class.getName());
+        DataSource dataSource = (DataSource) context.request().getAttribute(DataSource.class.getName());
         assertNotNull(dataSource);
         Resource resource = dataSource.iterator().next();
         assertEquals(resource.getPath(), context.currentResource("/apps/form/action/cq:dialog").getPath());
     }
 
     private void registerFormsManagerAdapter() {
-        context.registerAdapter(ResourceResolver.class, FormsManager.class, new Function<ResourceResolver, FormsManager>() {
-            @Nullable
-            @Override
-            public FormsManager apply(@Nullable ResourceResolver input) {
-                return formsManagerMock;
-            }
-        });
+        context.registerAdapter(ResourceResolver.class, FormsManager.class,
+            (Function<ResourceResolver, FormsManager>) input -> formsManagerMock);
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/ImageDelegateRenderConditionTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/ImageDelegateRenderConditionTest.java
@@ -15,53 +15,46 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.servlets;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.testing.mock.sling.servlet.MockRequestPathInfo;
-import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.internal.models.v1.AbstractImageDelegatingModel;
 import com.adobe.granite.ui.components.ExpressionCustomizer;
 import com.adobe.granite.ui.components.rendercondition.RenderCondition;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(AemContextExtension.class)
 public class ImageDelegateRenderConditionTest {
 
-    @ClassRule
-    public static final AemContext CONTEXT = CoreComponentTestContext.createContext("/image-delegate-render-condition",
-            "/apps/core/wcm/components");
-
+    private static final String TEST_BASE = "/image-delegate-render-condition";
+    private static final String APPS_ROOT = "/apps/core/wcm/components";
+    private static final String CONF_ROOT = "/conf";
     private static final String SUFFIX = "/conf/coretest/settings/wcm/policies/core/wcm/components/teaser/policy_1505736393478";
 
-    @BeforeClass
-    public static void setUp() {
-        CONTEXT.load().json("/image-delegate-render-condition/test-conf.json", "/conf");
+    public final AemContext context = CoreComponentTestContext.newAemContext();
+
+    @BeforeEach
+    public void setUp() {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, APPS_ROOT);
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONF_JSON, CONF_ROOT);
     }
 
     @Test
     public void testDoGet() throws Exception {
         ImageDelegateRenderCondition imageDelegateRenderCondition = new ImageDelegateRenderCondition();
-        SlingHttpServletRequest request = prepareRequest();
-        imageDelegateRenderCondition.doGet(request, CONTEXT.response());
-        RenderCondition renderCondition = (RenderCondition) request.getAttribute(RenderCondition.class.getName());
+        context.requestPathInfo().setSuffix(SUFFIX);
+        imageDelegateRenderCondition.doGet(context.request(), context.response());
+        RenderCondition renderCondition = (RenderCondition) context.request().getAttribute(RenderCondition.class.getName());
         assertNotNull(renderCondition);
         assertTrue(renderCondition.check());
-        ExpressionCustomizer expressionCustomizer = (ExpressionCustomizer) request.getAttribute(ExpressionCustomizer.class.getName());
+        ExpressionCustomizer expressionCustomizer = (ExpressionCustomizer) context.request().getAttribute(ExpressionCustomizer.class.getName());
         assertNotNull(expressionCustomizer);
         assertTrue(expressionCustomizer.hasVariable(AbstractImageDelegatingModel.IMAGE_DELEGATE));
-    }
-
-    public SlingHttpServletRequest prepareRequest() {
-        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(CONTEXT.resourceResolver(), CONTEXT.bundleContext());
-        MockRequestPathInfo requestPathInfo = (MockRequestPathInfo) request.getRequestPathInfo();
-        requestPathInfo.setSuffix(SUFFIX);
-        return request;
     }
 
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/SearchResultServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/SearchResultServletTest.java
@@ -16,7 +16,7 @@
 package com.adobe.cq.wcm.core.components.internal.servlets;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -25,12 +25,11 @@ import org.apache.sling.testing.mock.sling.servlet.MockRequestPathInfo;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
 import org.jetbrains.annotations.Nullable;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.ListItem;
@@ -47,16 +46,18 @@ import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith({AemContextExtension.class, MockitoExtension.class})
 public class SearchResultServletTest {
 
     private static final String TEST_BASE = "/search";
+    private static final String CONTENT_ROOT = "/content";
 
     private SearchResultServlet underTest;
 
@@ -75,20 +76,19 @@ public class SearchResultServletTest {
     @Mock
     private Hit mockHit;
 
-    @Rule
-    public AemContext context = CoreComponentTestContext.createContext(TEST_BASE, "/content");
+    public final AemContext context = CoreComponentTestContext.newAemContext();
 
     private static final String TEST_ROOT_EN = "/content/en/search/page";
     private static final String TEST_TEMPLATE_EN = "/content/en/search/page-template";
-    private static final String TEST_ROOT_DE = "/content/de";
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, CONTENT_ROOT);
         context.load().json(TEST_BASE + "/test-conf.json", "/conf/test/settings/wcm/templates");
         underTest = new SearchResultServlet();
         when(mockQueryBuilder.createQuery(any(), any())).thenReturn(mockQuery);
         when(mockQuery.getResult()).thenReturn(mockSearchResult);
-        when(mockSearchResult.getHits()).thenReturn(Arrays.asList(new Hit[] { mockHit }));
+        when(mockSearchResult.getHits()).thenReturn(Collections.singletonList(mockHit));
         Utils.setInternalState(underTest, "queryBuilder", mockQueryBuilder);
         Utils.setInternalState(underTest, "languageManager", new MockLanguageManager());
         Utils.setInternalState(underTest, "relationshipManager", mockLiveRelationshipManager);
@@ -96,7 +96,7 @@ public class SearchResultServletTest {
 
     @Test
     public void testSimpleSearch() throws Exception {
-        com.adobe.cq.wcm.core.components.Utils.enableDataLayerForOldAemContext(context, true);
+        com.adobe.cq.wcm.core.components.Utils.enableDataLayer(context, true);
         Resource resource = context.currentResource(TEST_ROOT_EN);
         when(mockHit.getResource()).thenReturn(resource);
         MockSlingHttpServletRequest request = context.request();
@@ -112,7 +112,7 @@ public class SearchResultServletTest {
 
     @Test
     public void testTemplateBasedSearch() throws Exception {
-        com.adobe.cq.wcm.core.components.Utils.enableDataLayerForOldAemContext(context, true);
+        com.adobe.cq.wcm.core.components.Utils.enableDataLayer(context, true);
         Resource resource = context.currentResource(TEST_TEMPLATE_EN);
         when(mockHit.getResource()).thenReturn(resource);
         MockSlingHttpServletRequest request = context.request();

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/WorkflowModelDataSourceServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/WorkflowModelDataSourceServletTest.java
@@ -17,69 +17,53 @@ package com.adobe.cq.wcm.core.components.internal.servlets;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ValueMap;
-import org.jetbrains.annotations.Nullable;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.granite.ui.components.ds.DataSource;
 import com.adobe.granite.workflow.WorkflowSession;
 import com.adobe.granite.workflow.model.WorkflowModel;
 import com.google.common.base.Function;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(AemContextExtension.class)
 public class WorkflowModelDataSourceServletTest {
 
-    @Rule
-    public AemContext context = CoreComponentTestContext.createContext("/form/container/datasource/workflowmodeldatasource",
-            "/apps/workflowdatasource");
+    private static final String TEST_BASE = "/form/container/datasource/workflowmodeldatasource";
+    private static final String APPS_ROOT = "/apps/workflowdatasource";
 
-    @Mock
-    private WorkflowSession workflowSessionMock;
+    private final AemContext context = CoreComponentTestContext.newAemContext();
 
-    @Mock
-    private WorkflowModel workflowModelMock;
-
-    private WorkflowModelDataSourceServlet dataSourceServlet;
-
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, APPS_ROOT);
+
+        WorkflowSession workflowSessionMock = mock(WorkflowSession.class);
+        WorkflowModel workflowModelMock = mock(WorkflowModel.class);
         when(workflowModelMock.getTitle()).thenReturn("Workflow Title");
         when(workflowModelMock.getId()).thenReturn("test/workflow");
         when(workflowSessionMock.getModels()).thenReturn(new WorkflowModel[]{workflowModelMock});
-        registerWorkflowSessionAdapter();
-    }
-
-    private void registerWorkflowSessionAdapter() {
-        context.registerAdapter(ResourceResolver.class, WorkflowSession.class, new Function<ResourceResolver, WorkflowSession>() {
-            @Nullable
-            @Override
-            public WorkflowSession apply(@Nullable ResourceResolver input) {
-                return workflowSessionMock;
-            }
-        });
+        context.registerAdapter(ResourceResolver.class, WorkflowSession.class,
+            (Function<ResourceResolver, WorkflowSession>) input -> workflowSessionMock);
     }
 
     @Test
     public void testDataSource() throws Exception {
         context.currentResource("/apps/workflowdatasource");
-        dataSourceServlet = new WorkflowModelDataSourceServlet();
+        WorkflowModelDataSourceServlet dataSourceServlet = new WorkflowModelDataSourceServlet();
         dataSourceServlet.doGet(context.request(), context.response());
         DataSource dataSource = (DataSource) context.request().getAttribute(DataSource.class.getName());
         assertNotNull(dataSource);
         Resource resource = dataSource.iterator().next();
-        ValueMap valueMap = resource.adaptTo(ValueMap.class);
-        assertEquals("Workflow Title", valueMap.get("text", String.class));
-        assertEquals("test/workflow", valueMap.get("value", String.class));
+        assertEquals("Workflow Title", resource.getValueMap().get("text", String.class));
+        assertEquals("test/workflow", resource.getValueMap().get("value", String.class));
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/AbstractContentFragmentDataSourceServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/AbstractContentFragmentDataSourceServletTest.java
@@ -42,10 +42,15 @@ import com.adobe.granite.ui.components.ds.DataSource;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @ExtendWith(AemContextExtension.class)
 abstract class AbstractContentFragmentDataSourceServletTest {
@@ -60,15 +65,14 @@ abstract class AbstractContentFragmentDataSourceServletTest {
     private static final RootResourceBundle RESOURCE_BUNDLE = new RootResourceBundle();
 
     @BeforeEach
-    @SuppressWarnings("unchecked")
     void setUp() {
         context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, "/content");
         // load the content fragments
-        context.load().json("/contentfragment/test-content-dam-contentfragments.json", CONTENT_FRAGMENTS_PATH);
+        context.load().json(TEST_BASE + "/test-content-dam-contentfragments.json", CONTENT_FRAGMENTS_PATH);
         // load the data sources
-        context.load().json("/contentfragment/test-content-datasources.json", DATASOURCES_PATH);
+        context.load().json(TEST_BASE + "/test-content-datasources.json", DATASOURCES_PATH);
         // load the content fragment models
-        context.load().json("/contentfragment/test-content-conf.json", "/conf/global/settings/dam/cfm/models");
+        context.load().json(TEST_BASE + "/test-content-conf.json", "/conf/global/settings/dam/cfm/models");
         // register an adapter that adapts resources to (mocks of) content fragments
         context.registerAdapter(Resource.class, com.adobe.cq.dam.cfm.ContentFragment.class, AbstractContentFragmentTest.ADAPTER);
 
@@ -82,8 +86,8 @@ abstract class AbstractContentFragmentDataSourceServletTest {
 
         // mock the expression resolver
         expressionResolver = mock(ExpressionResolver.class);
-        when(expressionResolver.resolve(any(String.class), any(Locale.class), any(Class.class),
-                any(SlingHttpServletRequest.class))).then(returnsFirstArg());
+        when(expressionResolver.resolve(any(String.class), any(Locale.class), any(), any(SlingHttpServletRequest.class)))
+            .then(returnsFirstArg());
     }
 
     ExpressionResolver expressionResolver;
@@ -115,19 +119,15 @@ abstract class AbstractContentFragmentDataSourceServletTest {
      * Asserts that the specified {@code dataSource} contains the expected items.
      */
     void assertDataSource(DataSource dataSource, String[] names, String[] titles) {
-        assertNotNull("Datasource was null", dataSource);
+        assertNotNull(dataSource, "Datasource was null");
         Iterator<Resource> iterator = dataSource.iterator();
         for (int i = 0; i < names.length; i++) {
-            if (!iterator.hasNext()) {
-                fail("Datasource returned " + i + " items, expected " + names.length);
-            }
+            assertTrue(iterator.hasNext(), "Datasource returned " + i + " items, expected " + names.length);
             ValueMap properties = iterator.next().getValueMap();
             assertEquals(names[i], properties.get("value", String.class));
             assertEquals(titles[i], properties.get("text", String.class));
         }
-        if (iterator.hasNext()) {
-            fail("Datasource returned too many items, expected " + names.length);
-        }
+        assertFalse(iterator.hasNext(), "Datasource returned too many items, expected " + names.length);
     }
 
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/AbstractDataSourceServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/AbstractDataSourceServletTest.java
@@ -19,13 +19,12 @@ import javax.annotation.Nonnull;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.adobe.granite.ui.components.ExpressionResolver;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AbstractDataSourceServletTest {
 
@@ -48,8 +47,8 @@ public class AbstractDataSourceServletTest {
         Resource resource = dataSource.createResource(resourceResolver, title, value);
 
         // THEN
-        assertThat(resource.getValueMap().get("text"), is(title));
-        assertThat(resource.getValueMap().get("value"), is(value));
-        assertThat(resource.getResourceType(), is(Resource.RESOURCE_TYPE_NON_EXISTING));
+        assertEquals(title, resource.getValueMap().get("text"));
+        assertEquals(value, resource.getValueMap().get("value"));
+        assertEquals(Resource.RESOURCE_TYPE_NON_EXISTING, resource.getResourceType());
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ElementNamesRenderConditionTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ElementNamesRenderConditionTest.java
@@ -38,8 +38,8 @@ import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 import static com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment.AbstractContentFragmentTest.ADAPTER;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -65,11 +65,11 @@ class ElementNamesRenderConditionTest {
     void setUp() {
         context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, "/content");
         // load the content fragments
-        context.load().json("/contentfragment/test-content-dam-contentfragments.json", CONTENT_FRAGMENTS_PATH);
+        context.load().json(TEST_BASE + "/test-content-dam-contentfragments.json", CONTENT_FRAGMENTS_PATH);
         // load the render conditions
-        context.load().json("/contentfragment/test-content-renderconditions.json", RENDERCONDITIONS_PATH);
+        context.load().json(TEST_BASE + "/test-content-renderconditions.json", RENDERCONDITIONS_PATH);
         // load the content fragment models
-        context.load().json("/contentfragment/test-content-conf.json", "/conf/global/settings/dam/cfm/models");
+        context.load().json(TEST_BASE + "/test-content-conf.json", "/conf/global/settings/dam/cfm/models");
         // register an adapter that adapts resources to (mocks of) content fragments
         context.registerAdapter(Resource.class, com.adobe.cq.dam.cfm.ContentFragment.class, ADAPTER);
         // mock services
@@ -86,17 +86,15 @@ class ElementNamesRenderConditionTest {
     }
 
     @Test
-    void testSingleTextDisplayMode()
-            throws ServletException, IOException {
+    void testSingleTextDisplayMode() throws ServletException, IOException {
         RenderCondition renderCondition = getRenderCondition(RC_SINGLE_TEXT);
-        assertTrue("Invalid value of render condition", renderCondition.check());
+        assertTrue(renderCondition.check(), "Invalid value of render condition");
     }
 
     @Test
-    void testMultipleElementsDisplayMode()
-            throws ServletException, IOException {
+    void testMultipleElementsDisplayMode() throws ServletException, IOException {
         RenderCondition renderCondition = getRenderCondition(RC_MULTI);
-        assertFalse("Invalid value of render condition", renderCondition.check());
+        assertFalse(renderCondition.check(), "Invalid value of render condition");
     }
 
     /**

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ModelElementsDataSourceServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ModelElementsDataSourceServletTest.java
@@ -18,18 +18,17 @@ package com.adobe.cq.wcm.core.components.internal.servlets.contentfragment;
 import java.io.InputStream;
 import java.util.List;
 
+import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.testing.mock.sling.ResourceResolverType;
-import org.apache.sling.testing.mock.sling.junit.SlingContext;
-import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 
 import com.adobe.granite.ui.components.ds.DataSource;
@@ -39,56 +38,48 @@ import com.google.common.collect.ImmutableMap;
 
 import static com.adobe.cq.wcm.core.components.internal.servlets.contentfragment.ModelElementsDataSourceServlet.PARAMETER_AND_PN_MODEL_PATH;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(AemContextExtension.class)
 public class ModelElementsDataSourceServletTest {
 
-    @Rule
-    public SlingContext slingContext = new SlingContext(ResourceResolverType.RESOURCERESOLVER_MOCK);
+    public final AemContext context = CoreComponentTestContext.newAemContext();
 
-    private ModelElementsDataSourceServlet modelElementsDataSourceServlet;
-
-    @Before
-    public void setUp() {
-        modelElementsDataSourceServlet = new ModelElementsDataSourceServlet();
-    }
+    private final ModelElementsDataSourceServlet modelElementsDataSourceServlet = new ModelElementsDataSourceServlet();
 
     @Test
     public void verifyDataSourceWhenNoParameterIsGiven() {
         // GIVEN
-        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(slingContext.bundleContext());
-        request.setResource(Mockito.mock(Resource.class));
+        context.request().setResource(Mockito.mock(Resource.class));
 
         // WHEN
-        modelElementsDataSourceServlet.doGet(request, slingContext.response());
+        modelElementsDataSourceServlet.doGet(context.request(), context.response());
 
         // THEN
-        assertThat(request.getAttribute(DataSource.class.getName()), instanceOf(EmptyDataSource.class));
+        assertThat(context.request().getAttribute(DataSource.class.getName()), instanceOf(EmptyDataSource.class));
     }
 
     @Test
     public void verifyDataSourceWhenOrderByIsGiven() {
         // GIVEN
         InputStream jsonResourceAsStream = getClass().getResourceAsStream("test-content.json");
-        slingContext.load().json(jsonResourceAsStream, "/conf/foobar/settings/dam/cfm/models/yetanothercfmodel");
-        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(slingContext.resourceResolver(),
-                slingContext.bundleContext());
+        context.load().json(jsonResourceAsStream, "/conf/foobar/settings/dam/cfm/models/yetanothercfmodel");
         Resource mockResource = Mockito.mock(Resource.class);
         when(mockResource.isResourceType(ModelElementsDataSourceServlet.RESOURCE_TYPE_ORDER_BY)).thenReturn(true);
-        request.setResource(mockResource);
-        request.setParameterMap(ImmutableMap.of(
+        context.request().setResource(mockResource);
+        context.request().setParameterMap(ImmutableMap.of(
                 PARAMETER_AND_PN_MODEL_PATH, "/conf/foobar/settings/dam/cfm/models/yetanothercfmodel"));
 
         // WHEN
-        modelElementsDataSourceServlet.doGet(request, slingContext.response());
+        modelElementsDataSourceServlet.doGet(context.request(), context.response());
 
         // THEN
-        SimpleDataSource simpleDataSource = (SimpleDataSource) request.getAttribute(DataSource.class.getName());
+        SimpleDataSource simpleDataSource = (SimpleDataSource) context.request().getAttribute(DataSource.class.getName());
         List<Resource> resourceList = IteratorUtils.toList(simpleDataSource.iterator());
         assertThat(resourceList, not(empty()));
         assertThat(resourceList, allOf(
@@ -102,18 +93,16 @@ public class ModelElementsDataSourceServletTest {
     public void verifyDataSourceWhenModelParameterIsGiven() {
         // GIVEN
         InputStream jsonResourceAsStream = getClass().getResourceAsStream("test-content.json");
-        slingContext.load().json(jsonResourceAsStream, "/conf/foobar/settings/dam/cfm/models/yetanothercfmodel");
-        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(slingContext.resourceResolver(),
-                slingContext.bundleContext());
-        request.setResource(Mockito.mock(Resource.class));
-        request.setParameterMap(ImmutableMap.of(
+        context.load().json(jsonResourceAsStream, "/conf/foobar/settings/dam/cfm/models/yetanothercfmodel");
+        context.currentResource(Mockito.mock(Resource.class));
+        context.request().setParameterMap(ImmutableMap.of(
                 PARAMETER_AND_PN_MODEL_PATH, "/conf/foobar/settings/dam/cfm/models/yetanothercfmodel"));
 
         // WHEN
-        modelElementsDataSourceServlet.doGet(request, slingContext.response());
+        modelElementsDataSourceServlet.doGet(context.request(), context.response());
 
         // THEN
-        SimpleDataSource simpleDataSource = (SimpleDataSource) request.getAttribute(DataSource.class.getName());
+        SimpleDataSource simpleDataSource = (SimpleDataSource) context.request().getAttribute(DataSource.class.getName());
         List<Resource> resourceList = IteratorUtils.toList(simpleDataSource.iterator());
         assertThat(resourceList, not(empty()));
         assertThat(resourceList, allOf(

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/AllowedEmbeddablesDataSourceServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/AllowedEmbeddablesDataSourceServletTest.java
@@ -16,18 +16,13 @@
 package com.adobe.cq.wcm.core.components.internal.servlets.embed;
 
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceUtil;
-import org.apache.sling.api.resource.ValueMap;
-import org.jetbrains.annotations.Nullable;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.internal.servlets.TextValueDataResourceSource;
@@ -35,50 +30,40 @@ import com.adobe.cq.wcm.core.components.testing.MockStyle;
 import com.adobe.granite.ui.components.Value;
 import com.adobe.granite.ui.components.ds.DataSource;
 import com.day.cq.wcm.api.designer.Designer;
-import com.day.cq.wcm.api.policies.ContentPolicy;
-import com.day.cq.wcm.api.policies.ContentPolicyManager;
 import com.google.common.base.Function;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(AemContextExtension.class)
 public class AllowedEmbeddablesDataSourceServletTest {
 
-    @Rule
-    public AemContext context = CoreComponentTestContext.createContext("/embed/v1/datasources/allowedembeddables",
-        "/apps");
+    private static final String TEST_BASE = "/embed/v1/datasources/allowedembeddables";
+    private static final String APPS_ROOT = "/apps";
 
-    private AllowedEmbeddablesDataSourceServlet dataSourceServlet;
+    public final AemContext context = CoreComponentTestContext.newAemContext();
 
-    @Mock
-    private ContentPolicyManager contentPolicyManager;
-
-    @Mock
-    private Designer designer;
-
-    @Mock
-    private ContentPolicy contentPolicy;
+    private final AllowedEmbeddablesDataSourceServlet dataSourceServlet = new AllowedEmbeddablesDataSourceServlet();
 
     private static final String CURRENT_PATH = "/apps/content/embed";
 
-    private ValueMap properties;
-
-    @Before
+    @BeforeEach
     public void setUp() {
-        dataSourceServlet = new AllowedEmbeddablesDataSourceServlet();
-        registerAdapter();
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, APPS_ROOT);
         context.currentResource(CURRENT_PATH);
     }
 
     @Test
     public void testAllowedEmbeddablesDataSourceServlet() {
-        Resource policyResource = context.resourceResolver().getResource("/apps/conf/policy_1558011912823");
-        properties = ResourceUtil.getValueMap(policyResource);
-        when(contentPolicyManager.getPolicy(any(Resource.class))).thenReturn(contentPolicy);
-        when(contentPolicy.getProperties()).thenReturn(properties);
+        context.contentPolicyMapping("my-app/components/embed",
+            Objects.requireNonNull(context.resourceResolver().getResource("/apps/conf/policy_1558011912823"))
+                .getValueMap());
+
         context.request().setAttribute(Value.CONTENTPATH_ATTRIBUTE, CURRENT_PATH);
         dataSourceServlet.doGet(context.request(), context.response());
         DataSource dataSource = (DataSource) context.request().getAttribute(DataSource.class.getName());
@@ -92,6 +77,9 @@ public class AllowedEmbeddablesDataSourceServletTest {
 
     @Test
     public void testAllowedEmbeddablesDesignDataSourceServlet() {
+        Designer designer = mock(Designer.class);
+        context.registerAdapter(ResourceResolver.class, Designer.class,
+            (Function<ResourceResolver, Designer>) input -> designer);
         Resource styleResource = context.resourceResolver().getResource("/apps/etc/designs/embed");
         MockStyle mockStyle = new MockStyle(styleResource, styleResource.getValueMap());
         when(designer.getStyle(any(Resource.class))).thenReturn(mockStyle);
@@ -135,22 +123,5 @@ public class AllowedEmbeddablesDataSourceServletTest {
             items++;
         }
         assertEquals(textValueDataResourceSources.length, items);
-    }
-
-    private void registerAdapter() {
-        context.registerAdapter(ResourceResolver.class, ContentPolicyManager.class,
-            new Function<ResourceResolver, ContentPolicyManager>() {
-                @Nullable
-                @Override
-                public ContentPolicyManager apply(@Nullable ResourceResolver input) {
-                    return contentPolicyManager;
-                }
-            });
-        context.registerAdapter(ResourceResolver.class, Designer.class,
-            new Function<ResourceResolver, Designer>() {
-                @Nullable
-                @Override
-                public Designer apply(@Nullable ResourceResolver input) { return designer; }
-            });
     }
 }

--- a/bundles/core/src/test/resources/list/exporter-childrenListType.json
+++ b/bundles/core/src/test/resources/list/exporter-childrenListType.json
@@ -1,5 +1,5 @@
 {
-    "id": "list-3a0d6ddd86",
+    "id": "list-f56abdba21",
     "dateFormatString": "yyyy-MM-dd",
     "items": [
         {
@@ -25,7 +25,7 @@
         }
     ],
     "dataLayer": {
-        "list-3a0d6ddd86": {
+        "list-f56abdba21": {
             "@type": "core/wcm/components/list"
         }
     },

--- a/bundles/core/src/test/resources/list/exporter-childrenListTypeWithDepth.json
+++ b/bundles/core/src/test/resources/list/exporter-childrenListTypeWithDepth.json
@@ -1,5 +1,5 @@
 {
-    "id": "list-84128a1e08",
+    "id": "list-24872edcd7",
     "dateFormatString": "yyyy-MM-dd",
     "items": [
         {
@@ -32,7 +32,7 @@
         }
     ],
     "dataLayer": {
-        "list-84128a1e08": {
+        "list-24872edcd7": {
             "@type": "core/wcm/components/list"
         }
     },

--- a/bundles/core/src/test/resources/list/exporter-searchListType.json
+++ b/bundles/core/src/test/resources/list/exporter-searchListType.json
@@ -1,5 +1,5 @@
 {
-    "id": "list-20f143d89d",
+    "id": "list-b2e295b751",
     "dateFormatString": "yyyy-MM-dd",
     "items": [
         {
@@ -11,7 +11,7 @@
         }
     ],
     "dataLayer": {
-        "list-20f143d89d": {
+        "list-b2e295b751": {
             "@type": "core/wcm/components/list"
         }
     },

--- a/bundles/core/src/test/resources/list/exporter-staticListType.json
+++ b/bundles/core/src/test/resources/list/exporter-staticListType.json
@@ -1,5 +1,5 @@
 {
-    "id": "list-e07bd4e270",
+    "id": "list-a0852f8ca1",
     "dateFormatString": "yyyy-MM-dd",
     "items": [
         {
@@ -18,7 +18,7 @@
         }
     ],
     "dataLayer": {
-        "list-e07bd4e270": {
+        "list-a0852f8ca1": {
             "@type": "core/wcm/components/list"
         }
     },

--- a/bundles/core/src/test/resources/list/exporter-staticMaxItemsListType.json
+++ b/bundles/core/src/test/resources/list/exporter-staticMaxItemsListType.json
@@ -1,5 +1,5 @@
 {
-    "id": "list-513f2340c1",
+    "id": "list-b44597ab83",
     "dateFormatString": "yyyy-MM-dd",
     "items": [
         {
@@ -11,7 +11,7 @@
         }
     ],
     "dataLayer": {
-        "list-513f2340c1": {
+        "list-b44597ab83": {
             "@type": "core/wcm/components/list"
         }
     },

--- a/bundles/core/src/test/resources/list/exporter-staticOrderByModificationDateDescListType.json
+++ b/bundles/core/src/test/resources/list/exporter-staticOrderByModificationDateDescListType.json
@@ -1,5 +1,5 @@
 {
-    "id": "list-39c9e886e9",
+    "id": "list-18e15834ab",
     "dateFormatString": "yyyy-MM-dd",
     "items": [
         {
@@ -18,7 +18,7 @@
         }
     ],
     "dataLayer": {
-        "list-39c9e886e9": {
+        "list-18e15834ab": {
             "@type": "core/wcm/components/list"
         }
     },

--- a/bundles/core/src/test/resources/list/exporter-staticOrderByModificationDateListType.json
+++ b/bundles/core/src/test/resources/list/exporter-staticOrderByModificationDateListType.json
@@ -1,5 +1,5 @@
 {
-    "id": "list-1e71cd25fd",
+    "id": "list-8fd5b645e5",
     "dateFormatString": "yyyy-MM-dd",
     "items": [
         {
@@ -18,7 +18,7 @@
         }
     ],
     "dataLayer": {
-        "list-1e71cd25fd": {
+        "list-8fd5b645e5": {
             "@type": "core/wcm/components/list"
         }
     },

--- a/bundles/core/src/test/resources/list/exporter-staticOrderByTitleDescListType.json
+++ b/bundles/core/src/test/resources/list/exporter-staticOrderByTitleDescListType.json
@@ -1,5 +1,5 @@
 {
-    "id": "list-10fef0cfcc",
+    "id": "list-e89abda5d8",
     "dateFormatString": "yyyy-MM-dd",
     "items": [
         {
@@ -18,7 +18,7 @@
         }
     ],
     "dataLayer": {
-        "list-10fef0cfcc": {
+        "list-e89abda5d8": {
             "@type": "core/wcm/components/list"
         }
     },

--- a/bundles/core/src/test/resources/list/exporter-staticOrderByTitleListType.json
+++ b/bundles/core/src/test/resources/list/exporter-staticOrderByTitleListType.json
@@ -1,5 +1,5 @@
 {
-    "id": "list-3684f2d161",
+    "id": "list-f322c3579b",
     "dateFormatString": "yyyy-MM-dd",
     "items": [
         {
@@ -18,7 +18,7 @@
         }
     ],
     "dataLayer": {
-        "list-3684f2d161": {
+        "list-f322c3579b": {
             "@type": "core/wcm/components/list"
         }
     },

--- a/bundles/core/src/test/resources/list/exporter-tagsListType.json
+++ b/bundles/core/src/test/resources/list/exporter-tagsListType.json
@@ -1,5 +1,5 @@
 {
-    "id": "list-6c84d3405b",
+    "id": "list-ea99384ea5",
     "dateFormatString": "yyyy-MM-dd",
     "items": [
         {
@@ -11,7 +11,7 @@
         }
     ],
     "dataLayer": {
-        "list-6c84d3405b": {
+        "list-ea99384ea5": {
             "@type": "core/wcm/components/list"
         }
     },

--- a/bundles/core/src/test/resources/list/test-content.json
+++ b/bundles/core/src/test/resources/list/test-content.json
@@ -1,277 +1,280 @@
 {
-    "jcr:primaryType": "cq:Page",
-    "listTypes"      : {
-        "jcr:primaryType"                          : "nt:unstructured",
-        "illegalListType"                          : {
-            "jcr:primaryType"   : "nt:unstructured",
-            "sling:resourceType": "core/wcm/components/list",
-            "listFrom"          : "nonExisting"
-        },
-        "staticListType"                           : {
-            "jcr:primaryType"     : "nt:unstructured",
-            "sling:resourceType"  : "core/wcm/components/list",
-            "listFrom"            : "static",
-            "showThumbnail"       : "true",
-            "linkItems"           : "true",
-            "showDescription"     : "true",
-            "showModificationDate": "true",
-            "pages"               : [
-                "/content/list/pages/page_1",
-                "/content/list/pages/page_2"
-            ]
-        },
-        "staticMaxItemsListType"                   : {
-            "jcr:primaryType"     : "nt:unstructured",
-            "sling:resourceType"  : "core/wcm/components/list",
-            "listFrom"            : "static",
-            "showThumbnail"       : "true",
-            "linkItems"           : "true",
-            "showDescription"     : "true",
-            "showModificationDate": "true",
-            "maxItems"            : "1",
-            "pages"               : [
-                "/content/list/pages/page_1",
-                "/content/list/pages/page_2"
-            ]
-        },
-        "staticOrderByTitleListType"               : {
-            "jcr:primaryType"     : "nt:unstructured",
-            "sling:resourceType"  : "core/wcm/components/list",
-            "listFrom"            : "static",
-            "showThumbnail"       : "true",
-            "linkItems"           : "true",
-            "showDescription"     : "true",
-            "showModificationDate": "true",
-            "orderBy"             : "title",
-            "pages"               : [
-                "/content/list/pages/page_2",
-                "/content/list/pages/page_1"
-            ]
-        },
-        "staticOrderByTitleListTypeWithNoTitle"               : {
-            "jcr:primaryType"     : "nt:unstructured",
-            "sling:resourceType"  : "core/wcm/components/list",
-            "listFrom"            : "static",
-            "showThumbnail"       : "true",
-            "linkItems"           : "true",
-            "showDescription"     : "true",
-            "showModificationDate": "true",
-            "orderBy"             : "title",
-            "pages"               : [
-                "/content/list/pages/page_3",
-                "/content/list/pages/page_4"
-            ]
-        },
-        "staticOrderByTitleListTypeWithNoTitleForOneItem"               : {
-            "jcr:primaryType"     : "nt:unstructured",
-            "sling:resourceType"  : "core/wcm/components/list",
-            "listFrom"            : "static",
-            "showThumbnail"       : "true",
-            "linkItems"           : "true",
-            "showDescription"     : "true",
-            "showModificationDate": "true",
-            "orderBy"             : "title",
-            "pages"               : [
-                "/content/list/pages/page_1",
-                "/content/list/pages/page_4",
-                "/content/list/pages/page_2"
-            ]
-        },
-        "staticOrderByTitleListTypeWithAccent": {
-            "jcr:primaryType"     : "nt:unstructured",
-            "sling:resourceType"  : "core/wcm/components/list",
-            "listFrom"            : "static",
-            "showThumbnail"       : "true",
-            "linkItems"           : "true",
-            "showDescription"     : "true",
-            "showModificationDate": "true",
-            "orderBy"             : "title",
-            "pages"               : [
-                "/content/list/pages/page_2",
-                "/content/list/pages/page_1",
-                "/content/list/pages/page_5"
-            ]
-        },
-        "staticOrderByModificationDateListType"    : {
-            "jcr:primaryType"     : "nt:unstructured",
-            "sling:resourceType"  : "core/wcm/components/list",
-            "listFrom"            : "static",
-            "showThumbnail"       : "true",
-            "linkItems"           : "true",
-            "showDescription"     : "true",
-            "showModificationDate": "true",
-            "orderBy"             : "modified",
-            "pages"               : [
-                "/content/list/pages/page_1",
-                "/content/list/pages/page_2"
-            ]
-        },
-        "staticOrderByModificationDateListTypeWithNoModificationDate": {
-            "jcr:primaryType"     : "nt:unstructured",
-            "sling:resourceType"  : "core/wcm/components/list",
-            "listFrom"            : "static",
-            "showThumbnail"       : "true",
-            "linkItems"           : "true",
-            "showDescription"     : "true",
-            "showModificationDate": "true",
-            "orderBy"             : "modified",
-            "pages"               : [
-                "/content/list/pages/page_1/page_1_1",
-                "/content/list/pages/page_1/page_1_2"
-            ]
-        },
-        "staticOrderByModificationDateListTypeWithNoModificationDateForOneItem": {
-            "jcr:primaryType"     : "nt:unstructured",
-            "sling:resourceType"  : "core/wcm/components/list",
-            "listFrom"            : "static",
-            "showThumbnail"       : "true",
-            "linkItems"           : "true",
-            "showDescription"     : "true",
-            "showModificationDate": "true",
-            "orderBy"             : "modified",
-            "pages"               : [
-                "/content/list/pages/page_1",
-                "/content/list/pages/page_1/page_1_2",
-                "/content/list/pages/page_2"
-            ]
-        },
-        "staticOrderByModificationDateDescListType": {
-            "jcr:primaryType"     : "nt:unstructured",
-            "sling:resourceType"  : "core/wcm/components/list",
-            "listFrom"            : "static",
-            "showThumbnail"       : "true",
-            "linkItems"           : "true",
-            "showDescription"     : "true",
-            "showModificationDate": "true",
-            "orderBy"             : "modified",
-            "sortOrder"           : "desc",
-            "pages"               : [
-                "/content/list/pages/page_1",
-                "/content/list/pages/page_2"
-            ]
-        },
-        "staticOrderByTitleDescListType"           : {
-            "jcr:primaryType"     : "nt:unstructured",
-            "sling:resourceType"  : "core/wcm/components/list",
-            "listFrom"            : "static",
-            "showThumbnail"       : "true",
-            "linkItems"           : "true",
-            "showDescription"     : "true",
-            "showModificationDate": "true",
-            "sortOrder"           : "desc",
-            "orderBy"             : "title",
-            "pages"               : [
-                "/content/list/pages/page_2",
-                "/content/list/pages/page_1"
-            ]
-        },
-        "childrenListType"                         : {
-            "jcr:primaryType"   : "nt:unstructured",
-            "sling:resourceType": "core/wcm/components/list",
-            "listFrom"          : "children",
-            "parentPage"        : "/content/list/pages/page_1"
-        },
-        "childrenListTypeWithDepth"                : {
-            "jcr:primaryType"   : "nt:unstructured",
-            "sling:resourceType": "core/wcm/components/list",
-            "listFrom"          : "children",
-            "parentPage"        : "/content/list/pages/page_1",
-            "childDepth"        : "2"
-        },
-        "tagsListType"                             : {
-            "jcr:primaryType"   : "nt:unstructured",
-            "sling:resourceType": "core/wcm/components/list",
-            "listFrom"          : "tags",
-            "tagsSearchRoot"    : "/content/list/pages/page_1",
-            "tags"              : [
-                "list:test_category/test_tag"
-            ]
-        },
-        "searchListType"                           : {
-            "jcr:primaryType"   : "nt:unstructured",
-            "sling:resourceType": "core/wcm/components/list",
-            "listFrom"          : "search",
-            "query"             : "Page 1.2"
-        }
-    },
-    "pages"          : {
-        "page_1": {
-            "jcr:primaryType": "cq:Page",
-            "jcr:content"    : {
-                "jcr:primaryType": "cq:PageContent",
-                "jcr:title"      : "Page 1",
-                "cq:lastModified": "2016-09-23T16:12:45.000-07:00"
-            },
-            "page_1_1"       : {
-                "jcr:primaryType": "cq:Page",
-                "jcr:content"    : {
-                    "jcr:primaryType": "cq:PageContent",
-                    "jcr:title"      : "Page 1.1"
-                }
-            },
-            "page_1_2"       : {
-                "jcr:primaryType": "cq:Page",
-                "jcr:content"    : {
-                    "jcr:primaryType": "cq:PageContent",
-                    "jcr:title"      : "Page 1.2"
+    "list": {
+        "jcr:primaryType": "cq:Page",
+        "jcr:content": {
+            "jcr:primaryType": "cq:PageContent",
+            "jcr:title": "List Page",
+            "root"              : {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "wcm/foundation/components/responsivegrid",
+                "illegalListType": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "nonExisting"
                 },
-                "page_1_2_1"     : {
+                "staticListType": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "static",
+                    "showThumbnail": "true",
+                    "linkItems": "true",
+                    "showDescription": "true",
+                    "showModificationDate": "true",
+                    "pages": [
+                        "/content/list/pages/page_1",
+                        "/content/list/pages/page_2"
+                    ]
+                },
+                "staticMaxItemsListType": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "static",
+                    "showThumbnail": "true",
+                    "linkItems": "true",
+                    "showDescription": "true",
+                    "showModificationDate": "true",
+                    "maxItems": "1",
+                    "pages": [
+                        "/content/list/pages/page_1",
+                        "/content/list/pages/page_2"
+                    ]
+                },
+                "staticOrderByTitleListType": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "static",
+                    "showThumbnail": "true",
+                    "linkItems": "true",
+                    "showDescription": "true",
+                    "showModificationDate": "true",
+                    "orderBy": "title",
+                    "pages": [
+                        "/content/list/pages/page_2",
+                        "/content/list/pages/page_1"
+                    ]
+                },
+                "staticOrderByTitleListTypeWithNoTitle": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "static",
+                    "showThumbnail": "true",
+                    "linkItems": "true",
+                    "showDescription": "true",
+                    "showModificationDate": "true",
+                    "orderBy": "title",
+                    "pages": [
+                        "/content/list/pages/page_3",
+                        "/content/list/pages/page_4"
+                    ]
+                },
+                "staticOrderByTitleListTypeWithNoTitleForOneItem": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "static",
+                    "showThumbnail": "true",
+                    "linkItems": "true",
+                    "showDescription": "true",
+                    "showModificationDate": "true",
+                    "orderBy": "title",
+                    "pages": [
+                        "/content/list/pages/page_1",
+                        "/content/list/pages/page_4",
+                        "/content/list/pages/page_2"
+                    ]
+                },
+                "staticOrderByTitleListTypeWithAccent": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "static",
+                    "showThumbnail": "true",
+                    "linkItems": "true",
+                    "showDescription": "true",
+                    "showModificationDate": "true",
+                    "orderBy": "title",
+                    "pages": [
+                        "/content/list/pages/page_2",
+                        "/content/list/pages/page_1",
+                        "/content/list/pages/page_5"
+                    ]
+                },
+                "staticOrderByModificationDateListType": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "static",
+                    "showThumbnail": "true",
+                    "linkItems": "true",
+                    "showDescription": "true",
+                    "showModificationDate": "true",
+                    "orderBy": "modified",
+                    "pages": [
+                        "/content/list/pages/page_1",
+                        "/content/list/pages/page_2"
+                    ]
+                },
+                "staticOrderByModificationDateListTypeWithNoModificationDate": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "static",
+                    "showThumbnail": "true",
+                    "linkItems": "true",
+                    "showDescription": "true",
+                    "showModificationDate": "true",
+                    "orderBy": "modified",
+                    "pages": [
+                        "/content/list/pages/page_1/page_1_1",
+                        "/content/list/pages/page_1/page_1_2"
+                    ]
+                },
+                "staticOrderByModificationDateListTypeWithNoModificationDateForOneItem": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "static",
+                    "showThumbnail": "true",
+                    "linkItems": "true",
+                    "showDescription": "true",
+                    "showModificationDate": "true",
+                    "orderBy": "modified",
+                    "pages": [
+                        "/content/list/pages/page_1",
+                        "/content/list/pages/page_1/page_1_2",
+                        "/content/list/pages/page_2"
+                    ]
+                },
+                "staticOrderByModificationDateDescListType": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "static",
+                    "showThumbnail": "true",
+                    "linkItems": "true",
+                    "showDescription": "true",
+                    "showModificationDate": "true",
+                    "orderBy": "modified",
+                    "sortOrder": "desc",
+                    "pages": [
+                        "/content/list/pages/page_1",
+                        "/content/list/pages/page_2"
+                    ]
+                },
+                "staticOrderByTitleDescListType": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "static",
+                    "showThumbnail": "true",
+                    "linkItems": "true",
+                    "showDescription": "true",
+                    "showModificationDate": "true",
+                    "sortOrder": "desc",
+                    "orderBy": "title",
+                    "pages": [
+                        "/content/list/pages/page_2",
+                        "/content/list/pages/page_1"
+                    ]
+                },
+                "childrenListType": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "children",
+                    "parentPage": "/content/list/pages/page_1"
+                },
+                "childrenListTypeWithDepth": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "children",
+                    "parentPage": "/content/list/pages/page_1",
+                    "childDepth": "2"
+                },
+                "tagsListType": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "tags",
+                    "tagsSearchRoot": "/content/list/pages/page_1",
+                    "tags": [
+                        "list:test_category/test_tag"
+                    ]
+                },
+                "searchListType": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "search",
+                    "query": "Page 1.2"
+                }
+            }
+        },
+        "pages": {
+            "page_1": {
+                "jcr:primaryType": "cq:Page",
+                "jcr:content": {
+                    "jcr:primaryType": "cq:PageContent",
+                    "jcr:title": "Page 1",
+                    "cq:lastModified": "2016-09-23T16:12:45.000-07:00"
+                },
+                "page_1_1": {
                     "jcr:primaryType": "cq:Page",
-                    "jcr:content"    : {
+                    "jcr:content": {
                         "jcr:primaryType": "cq:PageContent",
-                        "jcr:title"      : "Page 1.2.1"
+                        "jcr:title": "Page 1.1"
+                    }
+                },
+                "page_1_2": {
+                    "jcr:primaryType": "cq:Page",
+                    "jcr:content": {
+                        "jcr:primaryType": "cq:PageContent",
+                        "jcr:title": "Page 1.2"
                     },
-                    "page_1_2_1_1"   : {
+                    "page_1_2_1": {
                         "jcr:primaryType": "cq:Page",
-                        "jcr:content"    : {
+                        "jcr:content": {
                             "jcr:primaryType": "cq:PageContent",
-                            "jcr:title"      : "Page 1.2.1.1"
+                            "jcr:title": "Page 1.2.1"
+                        },
+                        "page_1_2_1_1": {
+                            "jcr:primaryType": "cq:Page",
+                            "jcr:content": {
+                                "jcr:primaryType": "cq:PageContent",
+                                "jcr:title": "Page 1.2.1.1"
+                            }
                         }
+                    }
+                },
+                "page_1_3": {
+                    "jcr:primaryType": "cq:Page",
+                    "jcr:content": {
+                        "jcr:primaryType": "cq:PageContent",
+                        "jcr:title": "Page 1.3",
+                        "cq:tags": [
+                            "list:test_category/test_tag"
+                        ]
                     }
                 }
             },
-            "page_1_3"       : {
+            "page_2": {
                 "jcr:primaryType": "cq:Page",
-                "jcr:content"    : {
+                "jcr:content": {
                     "jcr:primaryType": "cq:PageContent",
-                    "jcr:title"      : "Page 1.3",
-                    "cq:tags"        : [
-                        "list:test_category/test_tag"
-                    ]
+                    "jcr:title": "Page 2",
+                    "cq:lastModified": "2016-09-21T16:12:45.000-07:00"
+                }
+            },
+            "page_3": {
+                "jcr:primaryType": "cq:Page",
+                "jcr:content": {
+                    "jcr:primaryType": "cq:PageContent"
+                }
+            },
+            "page_4": {
+                "jcr:primaryType": "cq:Page",
+                "jcr:content": {
+                    "jcr:primaryType": "cq:PageContent"
+                }
+            },
+            "page_5": {
+                "jcr:primaryType": "cq:Page",
+                "jcr:content": {
+                    "jcr:primaryType": "cq:PageContent",
+                    "jcr:title": "Páge 1",
+                    "cq:lastModified": "2016-09-21T16:12:45.000-07:00"
                 }
             }
-        },
-        "page_2": {
-            "jcr:primaryType": "cq:Page",
-            "jcr:content"    : {
-                "jcr:primaryType": "cq:PageContent",
-                "jcr:title"      : "Page 2",
-                "cq:lastModified": "2016-09-21T16:12:45.000-07:00"
-            }
-        },
-        "page_3": {
-            "jcr:primaryType": "cq:Page",
-            "jcr:content"    : {
-                "jcr:primaryType": "cq:PageContent"
-            }
-        },
-        "page_4": {
-            "jcr:primaryType": "cq:Page",
-            "jcr:content"    : {
-                "jcr:primaryType": "cq:PageContent"
-            }
-        },
-        "page_5": {
-            "jcr:primaryType": "cq:Page",
-            "jcr:content"    : {
-                "jcr:primaryType": "cq:PageContent",
-                "jcr:title"      : "Páge 1",
-                "cq:lastModified": "2016-09-21T16:12:45.000-07:00"
-            }
         }
-    },
-    "jcr:content"    : {
-        "jcr:primaryType": "cq:PageContent",
-        "jcr:title"      : "List Page"
     }
 }

--- a/bundles/core/src/test/resources/list/v2/exporter-staticListType.json
+++ b/bundles/core/src/test/resources/list/v2/exporter-staticListType.json
@@ -1,15 +1,15 @@
 {
-    "id": "list-e07bd4e270",
+    "id": "list-a0852f8ca1",
     "dateFormatString": "yyyy-MM-dd",
     "items": [
         {
-            "id": "list-e07bd4e270-item-c1a450dfb3",
+            "id": "list-a0852f8ca1-item-c1a450dfb3",
             "path": "/content/list/pages/page_1",
             "url": "/context/content/list/pages/page_1.html",
             "lastModified": 1474672365000,
             "title": "Page 1",
             "dataLayer": {
-                "list-e07bd4e270-item-c1a450dfb3": {
+                "list-a0852f8ca1-item-c1a450dfb3": {
                     "xdm:linkURL": "/context/content/list/pages/page_1.html",
                     "@type": "cq:PageContent",
                     "dc:title": "Page 1"
@@ -18,13 +18,13 @@
             ":type": "cq:PageContent"
         },
         {
-            "id": "list-e07bd4e270-item-a11dd78c1e",
+            "id": "list-a0852f8ca1-item-a11dd78c1e",
             "path": "/content/list/pages/page_2",
             "url": "/context/content/list/pages/page_2.html",
             "lastModified": 1474499565000,
             "title": "Page 2",
             "dataLayer": {
-                "list-e07bd4e270-item-a11dd78c1e": {
+                "list-a0852f8ca1-item-a11dd78c1e": {
                     "xdm:linkURL": "/context/content/list/pages/page_2.html",
                     "@type": "cq:PageContent",
                     "dc:title": "Page 2"
@@ -34,7 +34,7 @@
         }
     ],
     "dataLayer": {
-        "list-e07bd4e270": {
+        "list-a0852f8ca1": {
             "@type": "core/wcm/components/list/v2/list"
         }
     },

--- a/bundles/core/src/test/resources/list/v2/test-content.json
+++ b/bundles/core/src/test/resources/list/v2/test-content.json
@@ -1,84 +1,87 @@
 {
-  "jcr:primaryType": "cq:Page",
-  "listTypes"      : {
-    "jcr:primaryType"                          : "nt:unstructured",
-    "illegalListType"                          : {
-      "jcr:primaryType"   : "nt:unstructured",
-      "sling:resourceType": "core/wcm/components/list",
-      "listFrom"          : "nonExisting"
-    },
-    "staticListType"                           : {
-      "jcr:primaryType"     : "nt:unstructured",
-      "sling:resourceType"  : "core/wcm/components/list/v2/list",
-      "listFrom"            : "static",
-      "showThumbnail"       : "true",
-      "linkItems"           : "true",
-      "showDescription"     : "true",
-      "showModificationDate": "true",
-      "pages"               : [
-        "/content/list/pages/page_1",
-        "/content/list/pages/page_2"
-      ]
-    }
-  },
-  "pages"          : {
-    "page_1": {
-      "jcr:primaryType": "cq:Page",
-      "jcr:content"    : {
-        "jcr:primaryType": "cq:PageContent",
-        "jcr:title"      : "Page 1",
-        "cq:lastModified": "2016-09-23T16:12:45.000-07:00"
-      },
-      "page_1_1"       : {
+    "list": {
         "jcr:primaryType": "cq:Page",
-        "jcr:content"    : {
-          "jcr:primaryType": "cq:PageContent",
-          "jcr:title"      : "Page 1.1"
-        }
-      },
-      "page_1_2"       : {
-        "jcr:primaryType": "cq:Page",
-        "jcr:content"    : {
-          "jcr:primaryType": "cq:PageContent",
-          "jcr:title"      : "Page 1.2"
-        },
-        "page_1_2_1"     : {
-          "jcr:primaryType": "cq:Page",
-          "jcr:content"    : {
+        "jcr:content": {
             "jcr:primaryType": "cq:PageContent",
-            "jcr:title"      : "Page 1.2.1"
-          },
-          "page_1_2_1_1"   : {
-            "jcr:primaryType": "cq:Page",
-            "jcr:content"    : {
-              "jcr:primaryType": "cq:PageContent",
-              "jcr:title"      : "Page 1.2.1.1"
+            "jcr:title": "List Page",
+            "root": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "wcm/foundation/components/responsivegrid",
+                "illegalListType": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "nonExisting"
+                },
+                "staticListType": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list/v2/list",
+                    "listFrom": "static",
+                    "showThumbnail": "true",
+                    "linkItems": "true",
+                    "showDescription": "true",
+                    "showModificationDate": "true",
+                    "pages": [
+                        "/content/list/pages/page_1",
+                        "/content/list/pages/page_2"
+                    ]
+                }
             }
-          }
+        },
+        "pages": {
+            "page_1": {
+                "jcr:primaryType": "cq:Page",
+                "jcr:content": {
+                    "jcr:primaryType": "cq:PageContent",
+                    "jcr:title": "Page 1",
+                    "cq:lastModified": "2016-09-23T16:12:45.000-07:00"
+                },
+                "page_1_1": {
+                    "jcr:primaryType": "cq:Page",
+                    "jcr:content": {
+                        "jcr:primaryType": "cq:PageContent",
+                        "jcr:title": "Page 1.1"
+                    }
+                },
+                "page_1_2": {
+                    "jcr:primaryType": "cq:Page",
+                    "jcr:content": {
+                        "jcr:primaryType": "cq:PageContent",
+                        "jcr:title": "Page 1.2"
+                    },
+                    "page_1_2_1": {
+                        "jcr:primaryType": "cq:Page",
+                        "jcr:content": {
+                            "jcr:primaryType": "cq:PageContent",
+                            "jcr:title": "Page 1.2.1"
+                        },
+                        "page_1_2_1_1": {
+                            "jcr:primaryType": "cq:Page",
+                            "jcr:content": {
+                                "jcr:primaryType": "cq:PageContent",
+                                "jcr:title": "Page 1.2.1.1"
+                            }
+                        }
+                    }
+                },
+                "page_1_3": {
+                    "jcr:primaryType": "cq:Page",
+                    "jcr:content": {
+                        "jcr:primaryType": "cq:PageContent",
+                        "jcr:title": "Page 1.3",
+                        "cq:tags": [
+                            "list:test_category/test_tag"
+                        ]
+                    }
+                }
+            },
+            "page_2": {
+                "jcr:primaryType": "cq:Page",
+                "jcr:content": {
+                    "jcr:primaryType": "cq:PageContent",
+                    "jcr:title": "Page 2",
+                    "cq:lastModified": "2016-09-21T16:12:45.000-07:00"
+                }
+            }
         }
-      },
-      "page_1_3"       : {
-        "jcr:primaryType": "cq:Page",
-        "jcr:content"    : {
-          "jcr:primaryType": "cq:PageContent",
-          "jcr:title"      : "Page 1.3",
-          "cq:tags"        : [
-            "list:test_category/test_tag"
-          ]
-        }
-      }
-    },
-    "page_2": {
-      "jcr:primaryType": "cq:Page",
-      "jcr:content"    : {
-        "jcr:primaryType": "cq:PageContent",
-        "jcr:title"      : "Page 2",
-        "cq:lastModified": "2016-09-21T16:12:45.000-07:00"
-      }
     }
-  },
-  "jcr:content"    : {
-    "jcr:primaryType": "cq:PageContent",
-    "jcr:title"      : "List Page"
-  }
 }

--- a/testing/junit/core/pom.xml
+++ b/testing/junit/core/pom.xml
@@ -198,11 +198,6 @@
             <version>1.1.22</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>provided</scope>

--- a/testing/junit/core/src/main/java/com/adobe/cq/wcm/core/components/testing/AbstractConstantTest.java
+++ b/testing/junit/core/src/main/java/com/adobe/cq/wcm/core/components/testing/AbstractConstantTest.java
@@ -15,10 +15,11 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.testing;
 
-import java.lang.reflect.*;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 public class AbstractConstantTest {
 
@@ -26,7 +27,9 @@ public class AbstractConstantTest {
         InvocationTargetException, InstantiationException {
         assertTrue("Class should be final", Modifier.isFinal(constantsClass.getModifiers()));
         Constructor[] declaredConstructors = constantsClass.getDeclaredConstructors();
-        assertEquals("Only one constructor should be present", 1, declaredConstructors.length);
+        if (declaredConstructors.length != 1) {
+            throw new AssertionError("Only one constructor should be present");
+        }
         assertTrue("Constructor should be private", Modifier.isPrivate(declaredConstructors[0].getModifiers()));
 
         Field fields[] = constantsClass.getDeclaredFields();
@@ -55,5 +58,11 @@ public class AbstractConstantTest {
         Constructor constructor = declaredConstructors[0];
         constructor.setAccessible(true);
         constructor.newInstance();
+    }
+
+    private static void assertTrue(String message, boolean condition) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
     }
 }

--- a/testing/junit/core/src/main/java/com/adobe/cq/wcm/core/components/testing/AbstractModelTest.java
+++ b/testing/junit/core/src/main/java/com/adobe/cq/wcm/core/components/testing/AbstractModelTest.java
@@ -29,9 +29,6 @@ import java.util.List;
 import org.reflections.Reflections;
 import org.reflections.scanners.SubTypesScanner;
 
-import static org.junit.Assert.fail;
-
-
 public class AbstractModelTest {
 
     @SuppressWarnings("squid:S1181")
@@ -113,14 +110,12 @@ public class AbstractModelTest {
         }
         if (errors.length() > 0) {
             errors.insert(0, "\n");
-            fail(errors.toString());
+            throw new AssertionError(errors.toString());
         }
     }
 
     private static List<Class> getClasses(String packageName) {
-        List<Class> classes = new ArrayList<>();
         Reflections reflections = new Reflections(packageName,  new SubTypesScanner(false));
-        reflections.getSubTypesOf(Object.class).forEach(clazz -> classes.add(clazz));
-        return classes;
+        return new ArrayList<>(reflections.getSubTypesOf(Object.class));
     }
 }

--- a/testing/junit/core/src/main/java/com/adobe/cq/wcm/core/components/testing/package-info.java
+++ b/testing/junit/core/src/main/java/com/adobe/cq/wcm/core/components/testing/package-info.java
@@ -14,7 +14,7 @@
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
-@Version("1.0.0")
+@Version("1.1.0")
 package com.adobe.cq.wcm.core.components.testing;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | None at this time, ticket can be created and PR updated if the changes in this PR are desireable.
| Patch: Bug Fix?          | No
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Modified + Pass (no newly added tests)
| Documentation Provided   | No
| Any Dependency Changes?  | Test dependencies only for `core.wcm.components.core`; dependencies modified for `core.wcm.components.junit.core`
| License                  | Apache License, Version 2.0

The purpose of this PR is to use a single unified testing framework (the latest).
Occasionally, developers reference previously existing tests as a blueprint for their tests - and in doing so, they may inadvertently regress to using Junit4 instead of Junit5.

By converting all tests to Junit5 (even old ones) and dropping the Junit4 dependencies, this can be avoided and all future tests will use Junit5.

This will also reduce the need to write helpers to deal with both Junit4 and Junit5 (e.g. `AemContext` has two versions).

- All unit tests using Junit4 are updated to use Junit5
- Junit4 specific test dependencies are removed from `com.wcm.components.core` project
- Junit4 dependencies are removed from the `core.wcm.components.junit.core` project. The tests now directly throw the assertion error instead of depending on a specific testing framework.
- Junit4 dependencies remain in parent dependency management because the `testing/it/http` project uses them