### PR TITLE
#1131 - Avoid installation of Core Components on a Cloud instance

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -79,6 +79,9 @@
                             <filter>true</filter>
                         </subPackage>
                     </subPackages>
+                    <properties>
+                        <cloudManagerTarget>none</cloudManagerTarget>
+                    </properties>
                     <packageType>container</packageType>
                 </configuration>
             </plugin>

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -58,6 +58,9 @@
                 <extensions>true</extensions>
                 <configuration>
                     <packageType>application</packageType>
+                    <properties>
+                        <cloudManagerTarget>none</cloudManagerTarget>
+                    </properties>
                     <dependencies>
                         <dependency>
                             <group>day/cq60/product</group>

--- a/extensions/amp/content/pom.xml
+++ b/extensions/amp/content/pom.xml
@@ -58,6 +58,9 @@
                 <extensions>true</extensions>
                 <configuration>
                     <packageType>application</packageType>
+                    <properties>
+                        <cloudManagerTarget>none</cloudManagerTarget>
+                    </properties>
                     <acHandling>merge</acHandling>
                     <dependencies>
                         <dependency>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1131`
| Patch: Bug Fix?          |
| Minor: New Feature?      | x
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | N/A
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Set `cloudManagerTarget` to `none` on packages already provided by AEM Cloud Service, to avoid reinstalling them.