### PR TITLE
[ExperienceFragment] Fix incorrect exported items order

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtils.java
@@ -31,6 +31,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.factory.ModelFactory;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -202,7 +203,7 @@ public class ContentFragmentUtils {
      * Returns an optional grid type configured via {@link ContentPolicy content policy} property
      * ({@value #PN_CFM_GRID_TYPE}) or {@value #DEFAULT_GRID_TYPE} as default.
      *
-     * @param fragmentResource         the content fragment resource resource to be checked
+     * @param fragmentResource the content fragment resource resource to be checked
      * @return the configured grid type of a default
      */
     public static String getGridResourceType(Resource fragmentResource) {
@@ -235,13 +236,23 @@ public class ContentFragmentUtils {
     }
 
     /**
-     * Returns a map of all given resources mapping their name to their {@link ComponentExporter component exporter}
-     * model.
+     * Gets a map of all resources with the resource name as the key and the corresponding {@link ComponentExporter}
+     * model as the value.
+     *
+     * The returned map is ordered as provided by the resourceIterator.
+     * Any resource that cannot be adapted to a {@link ComponentExporter} model is omitted from the returned map.
+     *
+     * @param resourceIterator Iterator of resources for which to get the component exporters.
+     * @param modelFactory Model factory service.
+     * @param slingHttpServletRequest Current request.
+     * @return Ordered map of resource names to {@link ComponentExporter} models.
      */
-    public static Map<String, ComponentExporter> getComponentExporters(Iterator<Resource> resourceIterator,
-                                                                       ModelFactory modelFactory,
-                                                                       SlingHttpServletRequest slingHttpServletRequest) {
-        final Map<String, ComponentExporter> componentExporterMap = new LinkedHashMap<>();
+    @NotNull
+    public static LinkedHashMap<String, ComponentExporter> getComponentExporters(
+        @NotNull final Iterator<Resource> resourceIterator,
+        @NotNull final ModelFactory modelFactory,
+        @NotNull final SlingHttpServletRequest slingHttpServletRequest) {
+        final LinkedHashMap<String, ComponentExporter> componentExporterMap = new LinkedHashMap<>();
 
         while (resourceIterator.hasNext()) {
             Resource resource = resourceIterator.next();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -20,7 +20,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.jcr.RangeIterator;
@@ -169,13 +168,13 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
         return request.getResource().getResourceType();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Map<String, ? extends ComponentExporter> getExportedItems() {
         return children;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String[] getExportedItemsOrder() {
         return this.children.keySet().toArray(new String[0]);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -29,9 +29,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
@@ -63,11 +63,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static com.day.cq.wcm.api.NameConstants.NN_CONTENT;
 
-@Model(adaptables = SlingHttpServletRequest.class, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL,
-       adapters = {ExperienceFragment.class, ComponentExporter.class, ContainerExporter.class },
-       resourceType = {ExperienceFragmentImpl.RESOURCE_TYPE_V1 })
-@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME,
-          extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+@Model(adaptables = SlingHttpServletRequest.class,
+    adapters = {ExperienceFragment.class, ComponentExporter.class, ContainerExporter.class },
+    resourceType = {ExperienceFragmentImpl.RESOURCE_TYPE_V1 })
+@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class ExperienceFragmentImpl implements ExperienceFragment {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ExperienceFragmentImpl.class);
@@ -82,7 +81,7 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
     @Self
     private SlingHttpServletRequest request;
 
-    @ScriptVariable
+    @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
     @Nullable
     private Page currentPage;
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -20,6 +20,8 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -108,10 +110,6 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
     @OSGiService
     private LiveRelationshipManager relationshipManager;
 
-    @ValueMapValue(name = ComponentStyle.PN_CSS_CLASS)
-    @Default(values = "")
-    private String customCssClass;
-
     @Inject
     private ModelFactory modelFactory;
 
@@ -123,9 +121,9 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
     private String name;
 
     /**
-     * Class names of the responsive grid
+     * Class names of the responsive grid.
      */
-    private String classNames = CSS_BASE_CLASS;
+    private String classNames;
 
     /**
      * Child columns of the responsive grid
@@ -147,8 +145,6 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
             resolveLocalizedFragmentVariationPath();
             retrieveExperienceFragmentChildModels();
         }
-
-        appendCssClassNames();
     }
 
     @Override
@@ -190,7 +186,15 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
 
     @Override
     @JsonProperty("classNames")
+    @NotNull
     public String getCssClassNames() {
+        if (this.classNames == null) {
+            this.classNames = Stream.of(
+                CSS_BASE_CLASS,
+                this.getExportedItems().isEmpty() ? CSS_EMPTY_CLASS : "",
+                this.request.getResource().getValueMap().get(ComponentStyle.PN_CSS_CLASS, "")
+            ).filter(StringUtils::isNotBlank).collect(Collectors.joining(" "));
+        }
         return classNames;
     }
 
@@ -396,15 +400,6 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
                 children.putAll(resolvedChildren);
             }
         }
-    }
-
-    private void appendCssClassNames() {
-
-        if (children.isEmpty()) {
-            classNames += " empty";
-        }
-
-        classNames += StringUtils.isNotEmpty(customCssClass) ? " " + customCssClass : "";
     }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -133,9 +133,7 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
         final PageManager pageManager = resolver.adaptTo(PageManager.class);
 
         if (pageManager != null) {
-            /**
-             * CurrentPage is null when accessing the sling model exporter.
-             */
+            // currentPage is null when accessing the sling model exporter.
             if (currentPage == null) {
                 currentPage = pageManager.getContainingPage(resource);
             }
@@ -180,10 +178,6 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
         return this.children.keySet().toArray(new String[0]);
     }
 
-    /**
-     * @return The CSS class names to be applied to the current grid.
-     * @deprecated Use {@link #getCssClassNames()}
-     */
     @Override
     @JsonProperty("classNames")
     public String getCssClassNames() {
@@ -219,9 +213,6 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
             localizedFragmentVariationPath = null;
         }
     }
-
-
-
 
     /**
      * Returns the localization root of the resource defined at the given path.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -29,7 +29,6 @@ import javax.jcr.RangeIterator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Exporter;
@@ -37,7 +36,6 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
-import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.factory.ModelFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -87,9 +85,6 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
 
     @Inject
     protected Resource resource;
-
-    @SlingObject
-    private ResourceResolver resolver;
 
     @ScriptVariable
     @Nullable
@@ -247,7 +242,7 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
     private String getLocalizationRoot(String path) {
         String root = null;
         if (StringUtils.isNotEmpty(path)) {
-            Resource resource = resolver.getResource(path);
+            Resource resource = this.request.getResourceResolver().getResource(path);
             root = getLanguageRoot(resource);
             if (StringUtils.isEmpty(root)) {
                 root = getBlueprintPath(resource);
@@ -336,8 +331,8 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
     private String getXfLocalizationRoot(String xfPath, String currentPageRoot) {
         String xfRoot = null;
         if (StringUtils.isNotEmpty(xfPath) && StringUtils.isNotEmpty(currentPageRoot)
-                && this.resolver.getResource(xfPath) != null
-                && this.resolver.getResource(currentPageRoot) != null) {
+                && this.request.getResourceResolver().getResource(xfPath) != null
+                && this.request.getResourceResolver().getResource(currentPageRoot) != null) {
             String[] xfPathTokens = Text.explode(xfPath, PATH_DELIMITER_CHAR);
             String[] referenceRootTokens = Text.explode(currentPageRoot, PATH_DELIMITER_CHAR);
             int xfRootDepth = referenceRootTokens.length + 1;
@@ -358,7 +353,7 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
      * @return {@code true} if the resource exists, {@code false} otherwise
      */
     private boolean resourceExists(String path) {
-        return (StringUtils.isNotEmpty(path) && resolver.getResource(path) != null);
+        return (StringUtils.isNotEmpty(path) && this.request.getResourceResolver().getResource(path) != null);
     }
 
     /**
@@ -382,7 +377,7 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
      */
     private boolean isExperienceFragmentVariation(String path) {
         if (StringUtils.isNotEmpty(path)) {
-            Resource resource = resolver.getResource(path);
+            Resource resource = this.request.getResourceResolver().getResource(path);
             if (resource != null) {
                 ValueMap properties = resource.getValueMap();
                 String xfVariantType = properties.get(ExperienceFragmentsConstants.PN_XF_VARIANT_TYPE, String.class);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.PostConstruct;
-import javax.inject.Inject;
 import javax.jcr.RangeIterator;
 
 import org.apache.commons.lang3.StringUtils;
@@ -82,9 +81,6 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
 
     @Self
     private SlingHttpServletRequest request;
-
-    @Inject
-    protected Resource resource;
 
     @ScriptVariable
     @Nullable
@@ -180,8 +176,9 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
     }
 
     @NotNull
-    @Override public String getExportedType() {
-        return request.getResource().getResourceType();
+    @Override
+    public String getExportedType() {
+        return this.request.getResource().getResourceType();
     }
 
     @NotNull
@@ -367,7 +364,7 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
         }
 
         Template template = currentPage.getTemplate();
-        return template != null && StringUtils.startsWith(resource.getPath(), template.getPath());
+        return template != null && StringUtils.startsWith(this.request.getResource().getPath(), template.getPath());
     }
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -134,21 +134,18 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
 
     @PostConstruct
     protected void initModel() {
+        // currentPage is null when accessing the sling model exporter.
+        this.currentPage = Optional.ofNullable(this.currentPage)
+            .orElseGet(() -> Optional.ofNullable(this.request.getResourceResolver().adaptTo(PageManager.class))
+                .map(pm -> pm.getContainingPage(this.request.getResource()))
+                .orElse(null));
 
-        final PageManager pageManager = resolver.adaptTo(PageManager.class);
-
-        if (pageManager != null) {
-            // currentPage is null when accessing the sling model exporter.
-            if (currentPage == null) {
-                currentPage = pageManager.getContainingPage(resource);
-            }
-
-            if (currentPage != null) {
-                resolveLocalizedFragmentVariationPath();
-                retrieveExperienceFragmentChildModels();
-            } else {
-                LOGGER.error("Could not resolve currentPage!");
-            }
+        if (this.currentPage == null) {
+            LOGGER.error("Could not resolve currentPage!");
+        }
+        if (currentPage != null) {
+            resolveLocalizedFragmentVariationPath();
+            retrieveExperienceFragmentChildModels();
         }
 
         appendCssClassNames();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -16,8 +16,8 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -126,7 +126,7 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
     /**
      * Child columns of the responsive grid
      */
-    private final Map<String, ComponentExporter> children = new HashMap<>();
+    private final LinkedHashMap<String, ComponentExporter> children = new LinkedHashMap<>();
 
     @PostConstruct
     protected void initModel() {
@@ -178,8 +178,7 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
     @Nonnull
     @Override
     public String[] getExportedItemsOrder() {
-        return children.isEmpty() ?
-                new String[0] : children.keySet().toArray(new String[children.size()]);
+        return this.children.keySet().toArray(new String[0]);
     }
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -62,34 +62,73 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static com.day.cq.wcm.api.NameConstants.NN_CONTENT;
 
+/**
+ * Experience Fragment model implementation.
+ */
 @Model(adaptables = SlingHttpServletRequest.class,
     adapters = {ExperienceFragment.class, ComponentExporter.class, ContainerExporter.class },
     resourceType = {ExperienceFragmentImpl.RESOURCE_TYPE_V1 })
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class ExperienceFragmentImpl implements ExperienceFragment {
 
+    /**
+     * Logger.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(ExperienceFragmentImpl.class);
 
+    /**
+     * The experience fragment component resource type.
+     */
     public static final String RESOURCE_TYPE_V1 = "core/wcm/components/experiencefragment/v1/experiencefragment";
 
+    /**
+     * Sling path delimiter.
+     */
     private static final char PATH_DELIMITER_CHAR = '/';
+
+    /**
+     * Content root.
+     */
     private static final String CONTENT_ROOT = "/content";
+
+    /**
+     * Class name to be applied if the XF is empty or not configured.
+     */
     private static final String CSS_EMPTY_CLASS = "empty";
+
+    /**
+     * Class name to be applied to all experience fragments.
+     */
     private static final String CSS_BASE_CLASS = "aem-xf";
 
+    /**
+     * The current request.
+     */
     @Self
     private SlingHttpServletRequest request;
 
+    /**
+     * The current page.
+     */
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
     @Nullable
     private Page currentPage;
 
+    /**
+     * The language manager service.
+     */
     @OSGiService
     private LanguageManager languageManager;
 
+    /**
+     * The live relationship manager service.
+     */
     @OSGiService
     private LiveRelationshipManager relationshipManager;
 
+    /**
+     * The model factory service.
+     */
     @OSGiService
     private ModelFactory modelFactory;
 
@@ -113,8 +152,11 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
      */
     private LinkedHashMap<String, ComponentExporter> children;
 
+    /**
+     * Initialize the model.
+     */
     @PostConstruct
-    protected void initModel() {
+    private void initModel() {
         // currentPage is null when accessing the sling model exporter.
         this.currentPage = Optional.ofNullable(this.currentPage)
             .orElseGet(() -> Optional.ofNullable(this.request.getResourceResolver().adaptTo(PageManager.class))

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -101,7 +101,7 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
     @OSGiService
     private LiveRelationshipManager relationshipManager;
 
-    @Inject
+    @OSGiService
     private ModelFactory modelFactory;
 
     /**

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImplTest.java
@@ -36,7 +36,11 @@ import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -159,6 +163,26 @@ class ExperienceFragmentImplTest {
             + "/jcr:content/root/xf-component-1");
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf1"));
+    }
+
+    /**
+     * Tests that methods that cache results return the same object on subsequent calls.
+     */
+    @Test
+    void testCaching() {
+        ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(NO_LOC_PAGE
+            + "/jcr:content/root/xf-component-1");
+        assertNotNull(experienceFragment.getName());
+        assertSame(experienceFragment.getName(), experienceFragment.getName());
+
+        assertNotNull(experienceFragment.getCssClassNames());
+        assertSame(experienceFragment.getCssClassNames(), experienceFragment.getCssClassNames());
+
+        assertNotNull(experienceFragment.getExportedItems());
+        assertSame(experienceFragment.getExportedItems(), experienceFragment.getExportedItems());
+
+        assertNotNull(experienceFragment.getLocalizedFragmentVariationPath());
+        assertSame(experienceFragment.getLocalizedFragmentVariationPath(), experienceFragment.getLocalizedFragmentVariationPath());
     }
 
     /**

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImplTest.java
@@ -21,17 +21,13 @@ import java.util.Iterator;
 import javax.jcr.RangeIterator;
 
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.scripting.SlingBindings;
-import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.adobe.cq.sightly.WCMBindings;
 import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.ExperienceFragment;
-import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.WCMException;
 import com.day.cq.wcm.msm.api.LiveCopy;
 import com.day.cq.wcm.msm.api.LiveRelationship;
@@ -696,17 +692,9 @@ class ExperienceFragmentImplTest {
         if (resource == null) {
             throw new IllegalStateException("Does the test resource " + resourcePath + " exist?");
         }
-        final MockSlingHttpServletRequest request =
-            new MockSlingHttpServletRequest(context.resourceResolver(), context.bundleContext());
-        request.setContextPath(CONTEXT_PATH);
-        request.setResource(resource);
-        SlingBindings slingBindings = new SlingBindings();
-        Page currentPage = context.pageManager().getPage(currentPagePath);
-        slingBindings.put(SlingBindings.RESOURCE, resource);
-        slingBindings.put(WCMBindings.CURRENT_PAGE, currentPage);
-        slingBindings.put(WCMBindings.PAGE_MANAGER, context.pageManager());
-        slingBindings.put(WCMBindings.PROPERTIES, resource.getValueMap());
-        request.setAttribute(SlingBindings.class.getName(), slingBindings);
-        return request.adaptTo(ExperienceFragment.class);
+        context.currentPage(currentPagePath);
+        context.currentResource(resource);
+        context.request().setContextPath(CONTEXT_PATH);
+        return context.request().adaptTo(ExperienceFragment.class);
     }
 }

--- a/bundles/core/src/test/resources/experiencefragment/exporter-xf70.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-xf70.json
@@ -3,8 +3,8 @@
     "configured": true,
     ":type": "core/wcm/components/experiencefragment/v1/experiencefragment",
     ":itemsOrder": [
-        "image",
-        "text"
+        "text",
+        "image"
     ],
     ":items": {
         "image": {


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #1135 
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

- Fixes possibly incorrect exported items ordering by ensuring that the `children` models maintain the order that they are encountered in the repository.
- Corrects tests to match
- Replaces `Nonnull` annotations with `NotNull`
- Adds JavaDoc to previously undocumented members of `ExperienceFragmentImpl`, and correct several existing javadoc issues.
- Moves much of the model initializers to their respective getter methods to make it clearer how a getter return value is populated, remove the requirement that model initializer methods need to be called in specific orders for the getters to return reliable results, and to make sure that work is only done if required.
- Adds `Nullable` or `NotNull` annotations to private methods to reveal potential NPEs and correct.

