### PR TITLE
Issue/1139 duplicate keys

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.jetbrains.annotations.NotNull;
@@ -107,8 +108,10 @@ public abstract class PanelContainerImpl extends AbstractContainerImpl implement
             return this.panelTitle;
         }
 
+
         @NotNull
         @Override
+        @JsonIgnore
         public String getExportedType() {
             return this.inner.getExportedType();
         }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | fixes #1139 
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | no
| Documentation Provided   | no (code comments and or markdown)
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

The combination of [@JsonUnwrapped](https://github.com/adobe/aem-core-wcm-components/blob/7dc6c2dbe1d5efbf21a16973752bcd75fa2f4ca0/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java#L93) and  [getExportedType](https://github.com/adobe/aem-core-wcm-components/blob/7dc6c2dbe1d5efbf21a16973752bcd75fa2f4ca0/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java#L112) method in the [JsonWrapper](https://github.com/adobe/aem-core-wcm-components/blob/7dc6c2dbe1d5efbf21a16973752bcd75fa2f4ca0/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java#L64) class causes duplicated keys. @JsonIgnore annotation on the [getExportedType](https://github.com/adobe/aem-core-wcm-components/blob/7dc6c2dbe1d5efbf21a16973752bcd75fa2f4ca0/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java#L112) method resolves this issue.