### PR TITLE
GH-1146 - Breadcrumb component cannot be edited in page template editor

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractListItemImpl.java
@@ -37,7 +37,9 @@ public abstract class AbstractListItemImpl extends AbstractComponentImpl {
 
     protected AbstractListItemImpl(String parentId, Resource resource) {
         this.parentId = parentId;
-        this.path = resource.getPath();
+        if (resource != null) {
+            this.path = resource.getPath();
+        }
         this.resource = resource;
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImpl.java
@@ -96,7 +96,7 @@ public class BreadcrumbImpl extends AbstractComponentImpl implements Breadcrumb 
         int currentLevel = currentPage.getDepth();
         while (startLevel < currentLevel) {
             Page page = currentPage.getAbsoluteParent(startLevel);
-            if (page != null) {
+            if (page != null && page.getContentResource() != null) {
                 boolean isActivePage = page.equals(currentPage);
                 if (isActivePage && hideCurrent) {
                     break;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImplTest.java
@@ -35,12 +35,14 @@ class BreadcrumbImplTest {
 
     private static final String TEST_BASE = "/breadcrumb";
     private static final String CURRENT_PAGE = "/content/breadcrumb/women/shirts/devi-sleeveless-shirt";
+    private static final String CURRENT_PAGE_2 = "/content/breadcrumb/women/shirts2/devi-sleeveless-shirt";
     private static final String BREADCRUMB_1 = CURRENT_PAGE + "/jcr:content/header/breadcrumb";
     private static final String BREADCRUMB_2 = CURRENT_PAGE + "/jcr:content/header/breadcrumb-show-hidden";
     private static final String BREADCRUMB_3 = CURRENT_PAGE + "/jcr:content/header/breadcrumb-hide-current";
     private static final String BREADCRUMB_4 = CURRENT_PAGE + "/jcr:content/header/breadcrumb-start-level";
     private static final String BREADCRUMB_5 = CURRENT_PAGE + "/jcr:content/header/breadcrumb-style-based";
     private static final String BREADCRUMB_6 = CURRENT_PAGE + "/jcr:content/header/breadcrumb-v2";
+    private static final String BREADCRUMB_7 = CURRENT_PAGE_2 + "/jcr:content/header/breadcrumb-page-without-jcrcontent";
 
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
@@ -93,6 +95,16 @@ class BreadcrumbImplTest {
     void testV2JSONExporter() {
         Breadcrumb breadcrumb = getBreadcrumbUnderTest(BREADCRUMB_6);
         Utils.testJSONExport(breadcrumb, Utils.getTestExporterJSONPath(TEST_BASE, BREADCRUMB_6));
+    }
+
+    /**
+     * Verifies that a breadcrumb item is not created when the corresponding ancestor page does not have a jcr:content node
+     */
+    @Test
+    void testBreadcrumbItemsPageWithoutJcrContent() {
+        Breadcrumb breadcrumb = getBreadcrumbUnderTest(BREADCRUMB_7);
+        checkBreadcrumbConsistency(breadcrumb, new String[]{"Women", "Devi Sleeveless Shirt"});
+        Utils.testJSONExport(breadcrumb, Utils.getTestExporterJSONPath(TEST_BASE, BREADCRUMB_7));
     }
 
     private void checkBreadcrumbConsistency(Breadcrumb breadcrumb, String[] expectedPages) {

--- a/bundles/core/src/test/resources/breadcrumb/exporter-breadcrumb-page-without-jcrcontent.json
+++ b/bundles/core/src/test/resources/breadcrumb/exporter-breadcrumb-page-without-jcrcontent.json
@@ -1,0 +1,40 @@
+{
+  "id": "breadcrumb-2f933fab4b",
+  "items": [
+    {
+      "id": "breadcrumb-2f933fab4b-item-11c305ace0",
+      "active": false,
+      "url": "/content/breadcrumb/women.html",
+      "title": "Women",
+      "dataLayer": {
+        "breadcrumb-2f933fab4b-item-11c305ace0": {
+          "@type": "cq:PageContent",
+          "xdm:linkURL": "/content/breadcrumb/women.html",
+          "dc:title": "Women"
+        }
+      },
+      ":type": "cq:PageContent"
+    },
+    {
+      "id": "breadcrumb-2f933fab4b-item-4fa0220d48",
+      "active": true,
+      "url": "/content/breadcrumb/women/shirts2/devi-sleeveless-shirt.html",
+      "title": "Devi Sleeveless Shirt",
+      "dataLayer": {
+        "breadcrumb-2f933fab4b-item-4fa0220d48": {
+          "@type": "coretest/components/structure/page",
+          "xdm:linkURL": "/content/breadcrumb/women/shirts2/devi-sleeveless-shirt.html",
+          "dc:title": "Devi Sleeveless Shirt"
+        }
+      },
+      ":type": "coretest/components/structure/page"
+    }
+  ],
+  ":type": "core/wcm/components/breadcrumb",
+  "dataLayer": {
+    "breadcrumb-2f933fab4b": {
+      "@type": "core/wcm/components/breadcrumb",
+      "repo:modifyDate": "2016-01-11T15:21:45Z"
+    }
+  }
+}

--- a/bundles/core/src/test/resources/breadcrumb/test-content.json
+++ b/bundles/core/src/test/resources/breadcrumb/test-content.json
@@ -10,90 +10,122 @@
     "jcr:created"    : "Mon Jul 18 2016 14:30:46 GMT+0200",
     "jcr:createdBy"  : "admin",
     "jcr:primaryType": "cq:Page",
-    "shirts"         : {
-        "devi-sleeveless-shirt": {
-            "jcr:content"    : {
-                "cq:lastModified"   : "Wed Jun 29 2016 14:20:46 GMT+0200",
-                "cq:lastModifiedBy" : "admin",
-                "jcr:created"       : "Mon Jul 18 2016 14:30:46 GMT+0200",
-                "jcr:createdBy"     : "admin",
-                "jcr:language"      : "en",
-                "jcr:primaryType"   : "cq:PageContent",
-                "jcr:title"         : "Devi Sleeveless Shirt",
-                "sling:resourceType": "coretest/components/structure/page",
-                "header"            : {
-                    "jcr:primaryType"        : "nt:unstructured",
-                    "sling:resourceType"     : "foundation/components/parsys",
-                    "breadcrumb"             : {
-                        "jcr:primaryType"   : "nt:unstructured",
-                        "jcr:createdBy"     : "admin",
-                        "jcr:lastModifiedBy": "admin",
-                        "jcr:created"       : "Mon Jan 11 2016 15:23:53 GMT+0100",
-                        "jcr:lastModified"  : "Mon Jan 11 2016 16:21:45 GMT+0100",
-                        "sling:resourceType": "core/wcm/components/breadcrumb"
-                    },
-                    "breadcrumb-v2"             : {
-                        "jcr:primaryType"   : "nt:unstructured",
-                        "jcr:createdBy"     : "admin",
-                        "jcr:lastModifiedBy": "admin",
-                        "jcr:created"       : "Mon Jan 11 2016 15:23:53 GMT+0100",
-                        "jcr:lastModified"  : "Mon Jan 11 2016 16:21:45 GMT+0100",
-                        "sling:resourceType": "core/wcm/components/breadcrumb/v2/breadcrumb"
-                    },
-                    "breadcrumb-start-level" : {
-                        "jcr:primaryType"   : "nt:unstructured",
-                        "jcr:createdBy"     : "admin",
-                        "jcr:lastModifiedBy": "admin",
-                        "jcr:created"       : "Mon Jan 11 2016 15:23:53 GMT+0100",
-                        "jcr:lastModified"  : "Mon Jan 11 2016 16:21:45 GMT+0100",
-                        "sling:resourceType": "core/wcm/components/breadcrumb",
-                        "startLevel"        : "3",
-                        "showHidden"        : "true"
-                    },
-                    "breadcrumb-show-hidden" : {
-                        "jcr:primaryType"   : "nt:unstructured",
-                        "jcr:createdBy"     : "admin",
-                        "jcr:lastModifiedBy": "admin",
-                        "jcr:created"       : "Mon Jan 11 2016 15:23:53 GMT+0100",
-                        "jcr:lastModified"  : "Mon Jan 11 2016 16:21:45 GMT+0100",
-                        "sling:resourceType": "core/wcm/components/breadcrumb",
-                        "showHidden"        : "true"
-                    },
-                    "breadcrumb-hide-current": {
-                        "jcr:primaryType"   : "nt:unstructured",
-                        "jcr:createdBy"     : "admin",
-                        "jcr:lastModifiedBy": "admin",
-                        "jcr:created"       : "Mon Jan 11 2016 15:23:53 GMT+0100",
-                        "jcr:lastModified"  : "Mon Jan 11 2016 16:21:45 GMT+0100",
-                        "sling:resourceType": "core/wcm/components/breadcrumb",
-                        "hideCurrent"       : "true"
-                    },
-                    "breadcrumb-style-based": {
-                        "jcr:primaryType"   : "nt:unstructured",
-                        "jcr:createdBy"     : "admin",
-                        "jcr:lastModifiedBy": "admin",
-                        "jcr:created"       : "Mon Jan 11 2016 15:23:53 GMT+0100",
-                        "jcr:lastModified"  : "Mon Jan 11 2016 16:21:45 GMT+0100",
-                        "sling:resourceType": "core/wcm/components/breadcrumb"
-                    }
-                }
-            },
-            "jcr:created"    : "Mon Jul 18 2016 14:30:46 GMT+0200",
-            "jcr:createdBy"  : "admin",
-            "jcr:primaryType": "cq:Page"
-        },
-        "jcr:content"          : {
-            "cq:lastModified"   : "Wed Jun 29 2016 14:20:46 GMT+0200",
-            "cq:lastModifiedBy" : "admin",
-            "jcr:created"       : "Mon Jul 18 2016 14:30:46 GMT+0200",
+  "shirts"         : {
+    "devi-sleeveless-shirt": {
+      "jcr:content"    : {
+        "cq:lastModified"   : "Wed Jun 29 2016 14:20:46 GMT+0200",
+        "cq:lastModifiedBy" : "admin",
+        "jcr:created"       : "Mon Jul 18 2016 14:30:46 GMT+0200",
+        "jcr:createdBy"     : "admin",
+        "jcr:language"      : "en",
+        "jcr:primaryType"   : "cq:PageContent",
+        "jcr:title"         : "Devi Sleeveless Shirt",
+        "sling:resourceType": "coretest/components/structure/page",
+        "header"            : {
+          "jcr:primaryType"        : "nt:unstructured",
+          "sling:resourceType"     : "foundation/components/parsys",
+          "breadcrumb"             : {
+            "jcr:primaryType"   : "nt:unstructured",
             "jcr:createdBy"     : "admin",
-            "jcr:primaryType"   : "cq:PageContent",
-            "jcr:title"         : "Shirts",
-            "hideInNav"         : "true",
-            "sling:resourceType": "coretest/components/structure/page"
-        },
-        "jcr:created"          : "Mon Jul 18 2016 14:30:46 GMT+0200",
-        "jcr:createdBy"        : "admin",
-        "jcr:primaryType"      : "cq:Page"
-    }
+            "jcr:lastModifiedBy": "admin",
+            "jcr:created"       : "Mon Jan 11 2016 15:23:53 GMT+0100",
+            "jcr:lastModified"  : "Mon Jan 11 2016 16:21:45 GMT+0100",
+            "sling:resourceType": "core/wcm/components/breadcrumb"
+          },
+          "breadcrumb-v2"             : {
+            "jcr:primaryType"   : "nt:unstructured",
+            "jcr:createdBy"     : "admin",
+            "jcr:lastModifiedBy": "admin",
+            "jcr:created"       : "Mon Jan 11 2016 15:23:53 GMT+0100",
+            "jcr:lastModified"  : "Mon Jan 11 2016 16:21:45 GMT+0100",
+            "sling:resourceType": "core/wcm/components/breadcrumb/v2/breadcrumb"
+          },
+          "breadcrumb-start-level" : {
+            "jcr:primaryType"   : "nt:unstructured",
+            "jcr:createdBy"     : "admin",
+            "jcr:lastModifiedBy": "admin",
+            "jcr:created"       : "Mon Jan 11 2016 15:23:53 GMT+0100",
+            "jcr:lastModified"  : "Mon Jan 11 2016 16:21:45 GMT+0100",
+            "sling:resourceType": "core/wcm/components/breadcrumb",
+            "startLevel"        : "3",
+            "showHidden"        : "true"
+          },
+          "breadcrumb-show-hidden" : {
+            "jcr:primaryType"   : "nt:unstructured",
+            "jcr:createdBy"     : "admin",
+            "jcr:lastModifiedBy": "admin",
+            "jcr:created"       : "Mon Jan 11 2016 15:23:53 GMT+0100",
+            "jcr:lastModified"  : "Mon Jan 11 2016 16:21:45 GMT+0100",
+            "sling:resourceType": "core/wcm/components/breadcrumb",
+            "showHidden"        : "true"
+          },
+          "breadcrumb-hide-current": {
+            "jcr:primaryType"   : "nt:unstructured",
+            "jcr:createdBy"     : "admin",
+            "jcr:lastModifiedBy": "admin",
+            "jcr:created"       : "Mon Jan 11 2016 15:23:53 GMT+0100",
+            "jcr:lastModified"  : "Mon Jan 11 2016 16:21:45 GMT+0100",
+            "sling:resourceType": "core/wcm/components/breadcrumb",
+            "hideCurrent"       : "true"
+          },
+          "breadcrumb-style-based": {
+            "jcr:primaryType"   : "nt:unstructured",
+            "jcr:createdBy"     : "admin",
+            "jcr:lastModifiedBy": "admin",
+            "jcr:created"       : "Mon Jan 11 2016 15:23:53 GMT+0100",
+            "jcr:lastModified"  : "Mon Jan 11 2016 16:21:45 GMT+0100",
+            "sling:resourceType": "core/wcm/components/breadcrumb"
+          }
+        }
+      },
+      "jcr:created"    : "Mon Jul 18 2016 14:30:46 GMT+0200",
+      "jcr:createdBy"  : "admin",
+      "jcr:primaryType": "cq:Page"
+    },
+    "jcr:content"          : {
+      "cq:lastModified"   : "Wed Jun 29 2016 14:20:46 GMT+0200",
+      "cq:lastModifiedBy" : "admin",
+      "jcr:created"       : "Mon Jul 18 2016 14:30:46 GMT+0200",
+      "jcr:createdBy"     : "admin",
+      "jcr:primaryType"   : "cq:PageContent",
+      "jcr:title"         : "Shirts",
+      "hideInNav"         : "true",
+      "sling:resourceType": "coretest/components/structure/page"
+    },
+    "jcr:created"          : "Mon Jul 18 2016 14:30:46 GMT+0200",
+    "jcr:createdBy"        : "admin",
+    "jcr:primaryType"      : "cq:Page"
+  },
+  "shirts2"         : {
+    "devi-sleeveless-shirt": {
+      "jcr:content"    : {
+        "cq:lastModified"   : "Wed Jun 29 2016 14:20:46 GMT+0200",
+        "cq:lastModifiedBy" : "admin",
+        "jcr:created"       : "Mon Jul 18 2016 14:30:46 GMT+0200",
+        "jcr:createdBy"     : "admin",
+        "jcr:language"      : "en",
+        "jcr:primaryType"   : "cq:PageContent",
+        "jcr:title"         : "Devi Sleeveless Shirt",
+        "sling:resourceType": "coretest/components/structure/page",
+        "header"            : {
+          "jcr:primaryType"        : "nt:unstructured",
+          "sling:resourceType"     : "foundation/components/parsys",
+          "breadcrumb-page-without-jcrcontent" : {
+            "jcr:primaryType"   : "nt:unstructured",
+            "jcr:createdBy"     : "admin",
+            "jcr:lastModifiedBy": "admin",
+            "jcr:created"       : "Mon Jan 11 2016 15:23:53 GMT+0100",
+            "jcr:lastModified"  : "Mon Jan 11 2016 16:21:45 GMT+0100",
+            "sling:resourceType": "core/wcm/components/breadcrumb"
+          }
+        }
+      },
+      "jcr:created"    : "Mon Jul 18 2016 14:30:46 GMT+0200",
+      "jcr:createdBy"  : "admin",
+      "jcr:primaryType": "cq:Page"
+    },
+    "jcr:created"          : "Mon Jul 18 2016 14:30:46 GMT+0200",
+    "jcr:createdBy"        : "admin",
+    "jcr:primaryType"      : "cq:Page"
+  }
 }


### PR DESCRIPTION
- add null check
- don't create a breadcrumb item when the corresponding page does not have a jcr:content node
- add tests
