### PR TITLE
Fixes #1148 Make sure allowed components are displayed in template editor

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/responsiveGrid.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/responsiveGrid.html
@@ -14,8 +14,9 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <template data-sly-template.responsiveGrid="${ @ container}">
-    <div id="${container.id}"
-         class="cmp-container"
+  <sly data-sly-test="${wcmmode.edit}" data-sly-use.allowed="com.day.cq.wcm.foundation.AllowedComponentList"></sly>
+  <div id="${container.id}"
+        class="cmp-container${wcmmode.edit ? ' {0}': '' @ format=[allowed.cssClass]}"
          style="${container.backgroundStyle @ context='styleString'}">
         <sly data-sly-resource="${resource @ resourceType='wcm/foundation/components/responsivegrid'}"></sly>
     </div>


### PR DESCRIPTION
Fixes #1148

This PR effectively solves the problem described in #1148, but in a unelegant way: it calls `com.day.cq.wcm.foundation.AllowedComponentList` twice, and applies its CSS to the wrapper element twice. The source of the problem that in responsive grid mode there are two wrapper elements around the container content, and the `aem-AllowedComponent--list` CSS is set on the inner one of those two.

A cleaner solution would be to no longer make a delegation to `wcm/foundation/components/responsivegrid/responsivegrid` but instead incorporate the logic of `/libs/wcm/foundation/components/responsivegrid/responsivegrid.html` and making sure there is only one wrapper element. But with this change updates to the AEM OOTB responsive grid HTL will no longer be reflected in the core component - not sure if this is a problem.