### PR TITLE
Container children are no longer rendered on the page when layout is responsiveGrid

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/responsiveGrid.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/responsiveGrid.html
@@ -17,6 +17,6 @@
     <div id="${container.id}"
          class="cmp-container"
          style="${container.backgroundStyle @ context='styleString'}">
-        <sly data-sly-resource="${resource @ resourceType='wcm/foundation/components/responsivegrid'}"></sly>
+        <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/responsivegrid'}"></sly>
     </div>
 </template>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1151 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | New not yet added, but existing ones are passing
| Documentation Provided   | Not required here
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
* resource could be a wrapped one with resourceType=`core/wcm/components/container/v1/container`, so use resource.path for rendering it as `wcm/foundation/components/responsivegrid` so that it is re-resolved with the correct resourceType.
* With the fix provided in CQ-4294035, the responsiveGrid resource info is retained and re-resolving using path has been avoided. So, before that fix, the resource had already been re-resolved, but not now.