### PR TITLE
Revert "Container children are no longer rendered on the page when layout is responsiveGrid"

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/responsiveGrid.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/responsiveGrid.html
@@ -17,6 +17,6 @@
     <div id="${container.id}"
          class="cmp-container"
          style="${container.backgroundStyle @ context='styleString'}">
-        <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/responsivegrid'}"></sly>
+        <sly data-sly-resource="${resource @ resourceType='wcm/foundation/components/responsivegrid'}"></sly>
     </div>
 </template>


### PR DESCRIPTION
* Reverts adobe/aem-core-wcm-components#1152
* The issue is now being fixed in CQ code through an alternate approach which seems more proper i.e. by adding support for `ResourceWrapper`  in the `ResponsiveGrid`
* This change done earlier in the Core components was against what is recommended in the HTL docs, hence reverting that. See - https://docs.adobe.com/content/help/en/experience-manager-htl/using/htl/block-statements.html#path-not-required