### PR TITLE
Bugfix/java11 build compatibility

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -88,8 +88,8 @@
                 </dependencies>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
@@ -128,7 +128,7 @@ public class ContentFragmentImpl implements ContentFragment {
         return damContentFragment.getType();
     }
 
-    @Nullable
+    @NotNull
     @Override
     public String getName() {
         return damContentFragment.getName();
@@ -236,8 +236,8 @@ public class ContentFragmentImpl implements ContentFragment {
         }
 
         @Override
-        public @Nullable String getName() {
-            return null;
+        public @NotNull String getName() {
+            return "";
         }
 
         @Override

--- a/extensions/amp/bundle/pom.xml
+++ b/extensions/amp/bundle/pom.xml
@@ -89,8 +89,8 @@
                 </dependencies>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -286,7 +286,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>3.0.0-M3</version>
                     <executions>
                         <execution>
                             <id>enforce-maven</id>
@@ -416,9 +416,9 @@
                     <version>${jacoco.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>3.0.4</version>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>4.0.4</version>
                     <configuration>
                         <effort>Max</effort>
                         <xmlOutput>true</xmlOutput>


### PR DESCRIPTION
Update maven-enforcer-plugin to 3.0.0-M3 (due to https://issues.apache.org/jira/browse/MENFORCER-274)
Migrate from findbugs-maven-plugin to spotbugs-maven-plugin for Java11
compatibility. Also fix an issue detected by spotbugs-m-p.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  #1175 
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | Yes
| Documentation Provided   | No (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
