### PR TITLE
HTML container component

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/HTMLContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/HTMLContainerImpl.java
@@ -1,0 +1,254 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2017 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+package com.adobe.cq.wcm.core.components.internal.models.v1;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.models.annotations.Exporter;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+import org.jetbrains.annotations.Nullable;
+
+import com.adobe.cq.export.json.ComponentExporter;
+import com.adobe.cq.export.json.ExporterConstants;
+import com.adobe.cq.wcm.core.components.models.HTMLContainer;
+import com.day.cq.commons.jcr.JcrConstants;
+import com.day.cq.dam.api.Asset;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.designer.Style;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * V1 HTMLContainer model implementation.
+ */
+@Model(adaptables = SlingHttpServletRequest.class, adapters = { HTMLContainer.class,
+		ComponentExporter.class }, resourceType = HTMLContainerImpl.RESOURCE_TYPE_V1)
+@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+public class HTMLContainerImpl extends AbstractComponentImpl implements HTMLContainer {
+
+	private static final String ASYNC_TYPE = "async";
+
+	private static final String DEFER_TYPE = "defer";
+
+	private static final String INLINE_TYPE = "inline";
+
+	private static final String REFERENCE_TYPE = "reference";
+
+	private static final String INCLUDE_TYPE = "includeType";
+
+	/**
+	 * Standard logger.
+	 */
+	private static final Logger LOGGER = LoggerFactory.getLogger(HTMLContainer.class);
+
+	private static final String FILE_NAME = "fileName";
+
+	private static final String CSS_FILES = "cssFiles";
+
+	private static final String HTML_FILE = "htmlFile";
+
+	protected static final String RESOURCE_TYPE_V1 = "core/wcm/components/htmlcontainer/v1/htmlcontainer";
+
+	private static final String JS_FILES = "jsFiles";
+
+	private static final String NL = StringUtils.CR + StringUtils.LF;
+
+	@Self
+	private SlingHttpServletRequest request;
+
+	@ScriptVariable
+	private Resource resource;
+
+	@ScriptVariable
+	private PageManager pageManager;
+
+	@ScriptVariable
+	private Page currentPage;
+
+	@ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
+	@JsonIgnore
+	@Nullable
+	private Style currentStyle;
+
+	@ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL, name = JcrConstants.JCR_TITLE)
+	@Nullable
+	private String title;
+
+	@ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+	@Nullable
+	private String type;
+
+	@ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+	@Nullable
+	private String linkURL;
+
+	@PostConstruct
+	private void initModel() {
+
+	}
+
+	@Override
+	public String getIncludes() {
+		StringBuffer outString = new StringBuffer();
+		outString = outString.append(getCSSIncludes());
+		outString = outString.append(getHTMLInclude());
+		outString = outString.append(getJSIncludes());
+
+		return (outString.toString());
+	}
+
+	@Override
+	@JsonIgnore
+	public StringBuffer getCSSIncludes() {
+		StringBuffer cssIncludes = new StringBuffer();
+
+		getTypedIncludes(CSS_FILES, cssIncludes);
+		return (cssIncludes);
+	}
+
+	@Override
+	@JsonIgnore
+	public StringBuffer getHTMLInclude() {
+		ValueMap properties = resource.getValueMap();
+		StringBuffer htmlInclude = new StringBuffer();
+
+		String htmlFile = (String) properties.get(HTML_FILE);
+		if (htmlFile != null) {
+			readFileIntoSB(htmlFile, htmlInclude);
+		}
+		return (htmlInclude);
+	}
+
+	@Override
+	@JsonIgnore
+	public StringBuffer getJSIncludes() {
+		StringBuffer jsIncludes = new StringBuffer();
+
+		getTypedIncludes(JS_FILES, jsIncludes);
+
+		return (jsIncludes);
+	}
+
+	// find ALL the filenames for the given type and either read the file in
+	// directly into the html
+	// page or treat it as an external link, depending on the "inlineCBox" boolean.
+	// This should
+	// reduce page size if libraries are referenced instead of inlined.
+	public StringBuffer getTypedIncludes(String type, StringBuffer typedSB) {
+		Resource typeFileNode = resource.getChild(type);
+		if (typeFileNode != null) {
+			Iterator<Resource> typeFileNodeIterator = typeFileNode.listChildren();
+			while (typeFileNodeIterator.hasNext()) {
+				Resource typeFileItemNode = typeFileNodeIterator.next();
+				String fileName = (String) (typeFileItemNode.getValueMap()).get(FILE_NAME);
+				String includeType = (String) (typeFileItemNode.getValueMap()).get(INCLUDE_TYPE);
+				LOGGER.debug("getTypedIncludes - reading " + fileName);
+
+				if (fileName != null) {
+					// includeType will be null for HTML files...
+					if (includeType == null || includeType.contentEquals(INLINE_TYPE)) {
+						if (type.contentEquals(CSS_FILES)) {
+							typedSB.append("<style type=\"text/css\">" + NL);
+
+						} else if (type.contentEquals(JS_FILES)) {
+
+							typedSB.append("<script type=\"text/javascript\">" + NL);
+
+						}
+
+						readFileIntoSB(fileName, typedSB);
+
+						if (type.contentEquals(CSS_FILES)) {
+							typedSB.append("</style>" + NL);
+
+						} else if (type.contentEquals(JS_FILES)) {
+
+							typedSB.append("</script>" + NL);
+
+						}
+
+					} else if (includeType.contentEquals(REFERENCE_TYPE) || includeType.contentEquals(DEFER_TYPE)
+							|| includeType.contentEquals(ASYNC_TYPE)) {
+						if (type.contentEquals(CSS_FILES)) {
+							typedSB.append("<link rel=\"stylesheet\" href=\"" + fileName + "\">");
+
+						} else if (type.contentEquals(JS_FILES)) {
+
+							typedSB.append("<script type=\"text/javascript\" "
+									+ (String) (includeType.contentEquals(DEFER_TYPE)
+											|| includeType.contentEquals(ASYNC_TYPE) ? includeType : "")
+									+ " src=\"" + fileName + "\"></script>");
+						}
+					}
+				}
+			}
+		}
+		return (typedSB);
+	}
+
+	private StringBuffer readFileIntoSB(String fileName, StringBuffer sb) {
+
+		Resource original;
+		Asset asset;
+		ResourceResolver resolver;
+		resolver = resource.getResourceResolver();
+		if (resolver != null) {
+			original = resolver.getResource(fileName);
+			if (original != null) {
+				asset = original.adaptTo(Asset.class);
+				if (asset != null) {
+					original = asset.getOriginal();
+
+					InputStream content = original.adaptTo(InputStream.class);
+
+					String line;
+					BufferedReader br = new BufferedReader(new InputStreamReader(content, StandardCharsets.UTF_8));
+
+					try {
+						while ((line = br.readLine()) != null) {
+							sb.append(line);
+						}
+					} catch (IOException e) {
+						LOGGER.error("ERROR reading {} into the StringBuffer: {}", fileName, e.toString());
+						e.printStackTrace();
+					}
+				}
+			}
+		}
+
+		return (sb);
+	}
+
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/HTMLContainer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/HTMLContainer.java
@@ -1,0 +1,79 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2017 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+package com.adobe.cq.wcm.core.components.models;
+
+import org.jetbrains.annotations.NotNull;
+import org.osgi.annotation.versioning.ConsumerType;
+
+import com.adobe.cq.export.json.ComponentExporter;
+//import com.adobe.cq.wcm.core.components.internal.models.v1.string;
+
+/**
+ * Defines the {@code Title} Sling Model used for the
+ * {@code /apps/core/wcm/components/title} component.
+ *
+ * @since com.adobe.cq.wcm.core.components.models 11.0.0
+ */
+@ConsumerType
+public interface HTMLContainer extends Component {
+
+	/**
+	 * Returns the text to be displayed as title.
+	 *
+	 * @return the title's text
+	 * @since com.adobe.cq.wcm.core.components.models 11.0.0; marked
+	 *        <code>default</code> in 12.1.0
+	 */
+	default StringBuffer getCSSIncludes() {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Returns the HTML element type (h1-h6) used for the markup.
+	 *
+	 * @return the element type
+	 * @since com.adobe.cq.wcm.core.components.models 11.0.0; marked
+	 *        <code>default</code> in 12.1.0
+	 */
+	default StringBuffer getHTMLInclude() {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Returns the Title's link URL, if one was set.
+	 *
+	 * @return the title's link URL, if one was set, or {@code null}
+	 * @since com.adobe.cq.wcm.core.components.models 12.4.0
+	 */
+	default StringBuffer getJSIncludes() {
+		throw new UnsupportedOperationException();
+	}
+
+	default String getIncludes() {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * @see ComponentExporter#getExportedType()
+	 * @since com.adobe.cq.wcm.core.components.models 12.2.0
+	 */
+	@NotNull
+	@Override
+	default String getExportedType() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured">
+    <htmlcontainer/>
+</jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:icon="fileHTML"
+    jcr:description="Allows inclusion of CSS, HTML, and JS files from the DAM"
+    jcr:primaryType="cq:Component"
+    jcr:title="HTML Container"
+    componentGroup=".core-wcm"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/README.md
@@ -1,0 +1,60 @@
+<!--
+Copyright 2019 Adobe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+Content Fragment (v1)
+====
+Content Fragment component written in HTL that displays the elements of a Content Fragment or a selection thereof.
+
+## Features
+* Displays the elements of a Content Fragment as an HTML description list
+* By default renders all elements of a Content Fragment
+* Can be configured to render a subset of the elements in a specific order
+* Alternative Content Fragment variations are configurable
+
+### Use Object
+The Content Fragment component uses the `com.adobe.cq.wcm.core.components.models.contentfragment.ContentFragment` Sling model as its Use-object.
+
+### Edit dialog properties
+The following JCR properties are used:
+
+1. `./fragmentPath` - defines the path to the Content Fragment to be rendered
+2. `./variationName` - defines the variation to use to render the elements (optional: if not present, the master variation is used)
+3. `./elementNames` - multi-valued property defining the elements to be rendered and in which order (optional: if not present, all elements are rendered)
+4. `./paragraphScope` - defines if all or a range of paragraphs are to be rendered (only used in paragraph mode)
+5. `./paragraphRange` - defines the range(s) of paragraphs to be rendered (only used in paragraph mode and if paragraphs are restricted to ranges)
+6. `./paragraphHeadings` - defines if headings should count as paragraphs (only used in paragraph mode and if paragraphs are restricted to ranges)
+7. `./id` - defines the component HTML ID attribute.
+
+## BEM description
+```
+BLOCK cmp-contentfragment
+  MOD cmp-contentfragment--<name>
+    ELEMENT cmp-contentfragment__title
+    ELEMENT cmp-contentfragment__description
+    ELEMENT cmp-contentfragment__elements
+    ELEMENT cmp-contentfragment__element
+        MOD cmp-contentfragment__element--<name>
+    ELEMENT cmp-contentfragment__element-title
+    ELEMENT cmp-contentfragment__element-value
+```
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v1
+* **Compatibility**: AEM 6.3
+* **Status**: production-ready
+* **Documentation**: [https://www.adobe.com/go/aem\_cmp\_contentfragment\_v1](https://www.adobe.com/go/aem_cmp_contentfragment_v1)
+* **Component Library**: [https://www.adobe.com/go/aem\_cmp\_library\_cf](https://www.adobe.com/go/aem_cmp_library_cf)

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/README.md
@@ -14,47 +14,38 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-Content Fragment (v1)
+HTML Container (v1)
 ====
-Content Fragment component written in HTL that displays the elements of a Content Fragment or a selection thereof.
+HTML Container component written in HTL that displays the contents of the selected HTML file using the provided CSS and JS.
 
 ## Features
-* Displays the elements of a Content Fragment as an HTML description list
-* By default renders all elements of a Content Fragment
-* Can be configured to render a subset of the elements in a specific order
-* Alternative Content Fragment variations are configurable
+* Allows authors to use arbitrary HTML and required CSS and JS files.
+* Requires the files to be placed into the DAM to enforce some element of code review and checkin (i.e. peer review before placing into the DAM).
+* Multiple CSS and JS files are supported, but only one HTML file is supported per HTML Container Component.
+* CSS files support "inline" and "reference" inclusion capability.
+* JS files support "async", "inline", "defer", and "reference" inclusion capability.
 
 ### Use Object
-The Content Fragment component uses the `com.adobe.cq.wcm.core.components.models.contentfragment.ContentFragment` Sling model as its Use-object.
+The HTML Container component uses the `com.adobe.cq.wcm.core.components.models.HTMLContainer` Sling model as its Use-object.
 
 ### Edit dialog properties
 The following JCR properties are used:
 
-1. `./fragmentPath` - defines the path to the Content Fragment to be rendered
-2. `./variationName` - defines the variation to use to render the elements (optional: if not present, the master variation is used)
-3. `./elementNames` - multi-valued property defining the elements to be rendered and in which order (optional: if not present, all elements are rendered)
-4. `./paragraphScope` - defines if all or a range of paragraphs are to be rendered (only used in paragraph mode)
-5. `./paragraphRange` - defines the range(s) of paragraphs to be rendered (only used in paragraph mode and if paragraphs are restricted to ranges)
-6. `./paragraphHeadings` - defines if headings should count as paragraphs (only used in paragraph mode and if paragraphs are restricted to ranges)
-7. `./id` - defines the component HTML ID attribute.
+1. `./includeType` - defines how CSS or JS files are included, i.e. async (JS), defer (JS), inline (CSS, JS), reference (CSS, JS).
+2. `./htmlFile` - the full path to the HTML file.
+3. `./fileName` - Used in multifield elements for CSS and JS tabs, the full path to the CSS, or JS file.
+4. `./id` - defines the component HTML ID attribute.
 
-## BEM description
-```
-BLOCK cmp-contentfragment
-  MOD cmp-contentfragment--<name>
-    ELEMENT cmp-contentfragment__title
-    ELEMENT cmp-contentfragment__description
-    ELEMENT cmp-contentfragment__elements
-    ELEMENT cmp-contentfragment__element
-        MOD cmp-contentfragment__element--<name>
-    ELEMENT cmp-contentfragment__element-title
-    ELEMENT cmp-contentfragment__element-value
-```
+Error checking is provided to ensure only CSS files are included on the CSS tab, HTML files on the HTML tab, and JS files on the JS tab.
+
+Files are included in CSS, HTML, JS order with appropriate script and style tags inserted.  HTML has no additional tags added.  The HTML should not have head or body tags.
+
 
 ## Information
 * **Vendor**: Adobe
 * **Version**: v1
-* **Compatibility**: AEM 6.3
+* **Compatibility**: AEM 6.5
 * **Status**: production-ready
-* **Documentation**: [https://www.adobe.com/go/aem\_cmp\_contentfragment\_v1](https://www.adobe.com/go/aem_cmp_contentfragment_v1)
+* **Documentation**: [https://www.adobe.com/go/aem\_cmp\_htmlcontainer\_v1
+](https://www.adobe.com/go/aem_cmp_contentfragment_v1)
 * **Component Library**: [https://www.adobe.com/go/aem\_cmp\_library\_cf](https://www.adobe.com/go/aem_cmp_library_cf)

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/_cq_design_dialog/.content.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:description="Content Fragment Design Dialog"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Content Fragment Design"
+    sling:resourceType="cq/gui/components/authoring/dialog">
+    <content
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <tabs
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/tabs"
+                maximized="{Boolean}true">
+                <items jcr:primaryType="nt:unstructured">
+                    <properties
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Main"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <defaultPath
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                defaultValue="/content/dam"
+                                fieldDescription="Default path pointing to location of CSS, HTML, JS folders (i.e. the parent of the CSS/HTML/JS folders)"
+                                fieldLabel="Default Path"
+                                name="./defaultPath"/>
+                        </items>
+                    </properties>
+                    <styletab
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_design/styletab"/>
+                </items>
+            </tabs>
+        </items>
+    </content>
+</jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/_cq_dialog/.content.xml
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="HTML Container"
+    sling:resourceType="cq/gui/components/authoring/dialog"
+    extraClientlibs="[core.wcm.components.commons.editor.dialog.childreneditor.v1,core.wcm.components.tabs.v1.editor]"
+    helpPath="https://www.adobe.com/go/aem_cmp_htmlcontainer_v1"
+    trackingFeature="core-components:htmlcontainer:v1">
+    <content
+        granite:class="cmp-tabs__editor"
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <tabs
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/tabs"
+                maximized="{Boolean}true">
+                <items jcr:primaryType="nt:unstructured">
+                    <general
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="General"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        granite:class="cq-RichText-FixedColumn-column"
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <id
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="HTML ID attribute to apply to the component."
+                                                fieldLabel="ID"
+                                                name="./id"/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </general>
+                    <cssIncludes
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="CSS Includes"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <cssItems
+                                                granite:class="foundation-toggleable cmp-teaser__editor-multifield_actions"
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                                composite="{Boolean}true"
+                                                fieldDescription="Add all your CSS files">
+                                                <field
+                                                    granite:class="cmp-teaser__editor-action"
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/container"
+                                                    name="./cssFiles">
+                                                    <items jcr:primaryType="nt:unstructured">
+                                                        <includeMethod
+                                                            granite:class="cq-dialog-dropdown-showhide"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                            fieldDescription="Select a method for including each file.  Inline puts the CSS file's contents directly into the page, and Reference references the file."
+                                                            fieldLabel="Include method"
+                                                            name="./includeType">
+                                                            <granite:data
+                                                                jcr:primaryType="nt:unstructured"
+                                                                cq-dialog-dropdown-showhide-target=".list-option-listfrom-showhide-target"/>
+                                                            <items jcr:primaryType="nt:unstructured">
+                                                                <inline
+                                                                    granite:hide="${cqDesign.disableChildren}"
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    text="Inline"
+                                                                    value="inline"/>
+                                                                <reference
+                                                                    granite:hide="${cqDesign.disableStatic}"
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    text="Reference"
+                                                                    value="reference"/>
+                                                            </items>
+                                                        </includeMethod>
+                                                        <link
+                                                            granite:class="cmp-teaser__editor-actionField"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                            emptyText="CSS File"
+                                                            name="fileName"
+                                                            required="{Boolean}true"
+                                                            rootPath="${not empty cqDesign.defaultPath ? cqDesign.defaultPath : '/content/dam'}">
+                                                            <granite:data
+                                                                jcr:primaryType="nt:unstructured"
+                                                                cmp-teaser-v1-dialog-edit-hook="actionLink"
+                                                                css-should-contain=".css"/>
+                                                        </link>
+                                                    </items>
+                                                </field>
+                                            </cssItems>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </cssIncludes>
+                    <htmlIncludes
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="HTML Include"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <link
+                                                granite:class="cmp-teaser__editor-actionField"
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                emptyText="HTML File"
+                                                fieldDescription="Add one HTML file"
+                                                name="./htmlFile"
+                                                required="{Boolean}true"
+                                                rootPath="${not empty cqDesign.defaultPath ? cqDesign.defaultPath : '/content/dam'}">
+                                                <granite:data
+                                                    jcr:primaryType="nt:unstructured"
+                                                    cmp-teaser-v1-dialog-edit-hook="actionLink"
+                                                    html-should-contain=".html"/>
+                                            </link>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </htmlIncludes>
+                    <jsIncludes
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="JS Includes"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <jsItems
+                                                granite:class="foundation-toggleable cmp-teaser__editor-multifield_actions"
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                                composite="{Boolean}true"
+                                                fieldDescription="Add all your JS files.  ">
+                                                <field
+                                                    granite:class="cmp-teaser__editor-action"
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/container"
+                                                    name="./jsFiles">
+                                                    <items jcr:primaryType="nt:unstructured">
+                                                        <includeMethod
+                                                            granite:class="cq-dialog-dropdown-showhide"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                            fieldDescription="Select a method for including each file.  Async uses the 'async' modifier, Defer uses the 'defer' modifier, Inline puts the JS file's contents directly into the page, and Reference just references the file (without the async or defer modifiers)."
+                                                            fieldLabel="Include method"
+                                                            name="./includeType">
+                                                            <granite:data
+                                                                jcr:primaryType="nt:unstructured"
+                                                                cq-dialog-dropdown-showhide-target=".list-option-listfrom-showhide-target"/>
+                                                            <items jcr:primaryType="nt:unstructured">
+                                                                <async
+                                                                    granite:hide="${cqDesign.disableChildren}"
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    text="Async"
+                                                                    value="async"/>
+                                                                <defer
+                                                                    granite:hide="${cqDesign.disableChildren}"
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    text="Defer"
+                                                                    value="defer"/>
+                                                                <inline
+                                                                    granite:hide="${cqDesign.disableChildren}"
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    text="Inline"
+                                                                    value="inline"/>
+                                                                <reference
+                                                                    granite:hide="${cqDesign.disableStatic}"
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    text="Reference"
+                                                                    value="reference"/>
+                                                            </items>
+                                                        </includeMethod>
+                                                        <link
+                                                            granite:class="cmp-teaser__editor-actionField"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                            emptyText="JS File"
+                                                            name="fileName"
+                                                            required="{Boolean}true"
+                                                            rootPath="${not empty cqDesign.defaultPath ? cqDesign.defaultPath : '/content/dam'}">
+                                                            <granite:data
+                                                                jcr:primaryType="nt:unstructured"
+                                                                cmp-teaser-v1-dialog-edit-hook="actionLink"
+                                                                js-should-contain=".js"/>
+                                                        </link>
+                                                    </items>
+                                                </field>
+                                            </jsItems>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </jsIncludes>
+                </items>
+            </tabs>
+            <include-clientlibs
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/includeclientlibs"
+                js="core.wcm.components.htmlcontainer.v1.dialog"/>
+        </items>
+    </content>
+</jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/_cq_editConfig.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:EditConfig">
+    <cq:inplaceEditing
+        jcr:primaryType="cq:InplaceEditingConfig"
+        active="{Boolean}true"
+        editorType="contentfragment"/>
+    <cq:dropTargets jcr:primaryType="nt:unstructured">
+        <contentfragment
+            jcr:primaryType="cq:DropTargetConfig"
+            accept="[application/vnd.adobe.contentfragment]"
+            groups="[media]"
+            propertyName="./fragmentPath">
+            <parameters
+                jcr:primaryType="nt:unstructured"
+                displayMode="multi"
+                elementNames=""
+                paragraphHeadings=""
+                paragraphRange=""
+                paragraphScope=""
+                variationName=""/>
+        </contentfragment>
+    </cq:dropTargets>
+    <cq:listeners
+        jcr:primaryType="cq:EditListenersConfig"
+        afterdelete="function (properties) { $(document).trigger('cq-contentfragment-delete'); }"
+        afteredit="function (properties) { $(document).trigger('cq-contentfragment-edit'); }"
+        afterinsert="function (properties) { $(document).trigger('cq-contentfragment-insert'); }"/>
+</jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/authoring/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/authoring/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[core.wcm.components.contentfragment.v1.authoring,cq.authoring.editor.hook]"
+    dependencies="[cq.authoring.editor.core]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/authoring/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/authoring/js.txt
@@ -1,0 +1,18 @@
+###############################################################################
+# Copyright 2019 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=js
+editAction.js

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/authoring/js/editAction.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/authoring/js/editAction.js
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright 2019 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+(function($, ns) {
+    "use strict";
+
+    // class of the content fragment
+    var CLASS_CONTENTFRAGMENT = "cmp-contentfragment";
+    // name of the attribute on the content fragment storing its path
+    var ATTRIBUTE_PATH = "data-cmp-contentfragment-path";
+    // base URL of the editor
+    var EDITOR_URL = "/editor.html";
+
+    var ContentFragmentEditor = ns.util.createClass({
+
+        constructor: function() {
+        },
+
+        canEdit: function(editable) {
+            // return true if the editable contains a content fragment having a path attribute
+            return $(editable.dom).find("." + CLASS_CONTENTFRAGMENT + "[" + ATTRIBUTE_PATH + "]").length > 0;
+        },
+
+        setUp: function(editable) {
+            // get the path of the content fragment
+            var fragmentPath = $(editable.dom).find("." + CLASS_CONTENTFRAGMENT).attr(ATTRIBUTE_PATH);
+            if (fragmentPath) {
+                var fragmentEditUrl = EDITOR_URL + fragmentPath;
+                var fragment = ns.CFM.Fragments.adaptToFragment(editable.dom);
+                if (fragment && typeof fragment.variation !== "undefined" && fragment.variation !== "master") {
+                    fragmentEditUrl = fragmentEditUrl + "?variation=" + fragment.variation;
+                }
+                // open the editor in a new window
+                window.open(Granite.HTTP.externalize(fragmentEditUrl));
+            }
+        }
+
+    });
+
+    ns.editor.register("contentfragment", new ContentFragmentEditor());
+
+})(jQuery, Granite.author);

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/dialog/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[core.wcm.components.htmlcontainer.v1.dialog]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/dialog/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/dialog/js.txt
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright 2019 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=js
+#editDialog.js
+htmlcontainer.js

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/dialog/js/editDialog.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/dialog/js/editDialog.js
@@ -1,0 +1,521 @@
+/*******************************************************************************
+ * Copyright 2019 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+(function(window, $, channel, Granite, Coral) {
+    "use strict";
+
+    // class of the edit dialog content
+    var CLASS_EDIT_DIALOG = "cmp-contentfragment__editor";
+
+    // field selectors
+    var SELECTOR_FRAGMENT_PATH = "[name='./fragmentPath']";
+    var SELECTOR_ELEMENT_NAMES_CONTAINER = "[data-element-names-container='true']";
+    var SELECTOR_ELEMENT_NAMES = "[data-granite-coral-multifield-name='./elementNames']";
+    var SELECTOR_SINGLE_TEXT_ELEMENT = "[data-single-text-selector='true']";
+    var SELECTOR_ELEMENT_NAMES_ADD = SELECTOR_ELEMENT_NAMES + " > [is=coral-button]";
+    var SELECTOR_VARIATION_NAME = "[name='./variationName']";
+    var SELECTOR_DISPLAY_MODE_RADIO_GROUP = "[data-display-mode-radio-group='true']";
+    var SELECTOR_DISPLAY_MODE_CHECKED = "[name='./displayMode']:checked";
+    var SELECTOR_PARAGRAPH_CONTROLS = ".cmp-contentfragment__editor-paragraph-controls";
+    var SELECTOR_PARAGRAPH_SCOPE = "[name='./paragraphScope']";
+    var SELECTOR_PARAGRAPH_RANGE = "[name='./paragraphRange']";
+    var SELECTOR_PARAGRAPH_HEADINGS = "[name='./paragraphHeadings']";
+
+    // mode in which only one multiline text element could be selected for display
+    var SINGLE_TEXT_DISPLAY_MODE = "singleText";
+
+    // ui helper
+    var ui = $(window).adaptTo("foundation-ui");
+
+    // dialog texts
+    var confirmationDialogTitle = Granite.I18n.get("Warning");
+    var confirmationDialogMessage = Granite.I18n.get("Please confirm replacing the current content fragment and its configuration");
+    var confirmationDialogCancel = Granite.I18n.get("Cancel");
+    var confirmationDialogConfirm = Granite.I18n.get("Confirm");
+    var errorDialogTitle = Granite.I18n.get("Error");
+    var errorDialogMessage = Granite.I18n.get("Failed to load the elements of the selected content fragment");
+
+    // the fragment path field (foundation autocomplete)
+    var fragmentPath;
+
+    // the paragraph controls (field set)
+    var paragraphControls;
+    // the tab containing paragraph control
+    var paragraphControlsTab;
+
+    // keeps track of the current fragment path
+    var currentFragmentPath;
+
+    var editDialog;
+
+    var elementsController;
+
+    /**
+     * A class which encapsulates the logic related to element selectors and variation name selector.
+     */
+    var ElementsController = function() {
+        // container which contains either single elements select field or a multifield of element selectors
+        this.elementNamesContainer = editDialog.querySelector(SELECTOR_ELEMENT_NAMES_CONTAINER);
+        // element container resource path
+        this.elementsContainerPath = this.elementNamesContainer.dataset.fieldPath;
+        this.fetchedState = null;
+        this._updateFields();
+    };
+
+    /**
+     * Updates the member fields of this class according to current dom of dialog.
+     */
+    ElementsController.prototype._updateFields = function() {
+        // The multifield containing element selector dropdowns
+        this.elementNames = editDialog.querySelector(SELECTOR_ELEMENT_NAMES);
+        // The add button in multifield
+        this.addElement = this.elementNames ? this.elementNames.querySelector(SELECTOR_ELEMENT_NAMES_ADD) : undefined;
+        // The dropdown containing element selector for multiline text elements only. Either this or the elementNames
+        // multifield should be visible to user at a time.
+        this.singleTextSelector = editDialog.querySelector(SELECTOR_SINGLE_TEXT_ELEMENT);
+        // the variation name field (select)
+        this.variationName = editDialog.querySelector(SELECTOR_VARIATION_NAME);
+        this.variationNamePath = this.variationName.dataset.fieldPath;
+    };
+
+    /**
+     * Disable all the fields of this controller.
+     */
+    ElementsController.prototype.disableFields = function() {
+        if (this.addElement) {
+            this.addElement.setAttribute("disabled", "");
+        }
+        if (this.singleTextSelector) {
+            this.singleTextSelector.setAttribute("disabled", "");
+        }
+        if (this.variationName) {
+            this.variationName.setAttribute("disabled", "");
+        }
+    };
+
+    /**
+     * Enable all the fields of this controller.
+     */
+    ElementsController.prototype.enableFields = function() {
+        if (this.addElement) {
+            this.addElement.removeAttribute("disabled");
+        }
+        if (this.singleTextSelector) {
+            this.singleTextSelector.removeAttribute("disabled");
+        }
+        if (this.variationName) {
+            this.variationName.removeAttribute("disabled");
+        }
+    };
+
+    /**
+     * Resets all the fields of this controller.
+     */
+    ElementsController.prototype.resetFields = function() {
+        if (this.elementNames) {
+            this.elementNames.items.clear();
+        }
+        if (this.singleTextSelector) {
+            this.singleTextSelector.value = "";
+        }
+        if (this.variationName) {
+            this.variationName.value = "";
+        }
+    };
+
+    /**
+     * Creates an http request object for retrieving fragment's element names or variation names and returns it.
+     *
+     * @param {String} displayMode - displayMode parameter for element name request. Should be "singleText" or "multi"
+     * @param {String} type - type of request. It can have the following values -
+     * 1. "variation" for getting variation names
+     * 2. "elements" for getting element names
+     * @returns {Object} the resulting request
+     */
+    ElementsController.prototype.prepareRequest = function(displayMode, type) {
+        if (typeof displayMode === "undefined") {
+            displayMode = editDialog.querySelector(SELECTOR_DISPLAY_MODE_CHECKED).value;
+        }
+        var data = {
+            fragmentPath: fragmentPath.value,
+            displayMode: displayMode
+        };
+        var url;
+        if (type === "variation") {
+            url = Granite.HTTP.externalize(this.variationNamePath) + ".html";
+        } else if (type === "elements") {
+            url = Granite.HTTP.externalize(this.elementsContainerPath) + ".html";
+        }
+        var request = $.get({
+            url: url,
+            data: data
+        });
+        return request;
+    };
+
+    /**
+     * Retrieves the html for element names and variation names and keeps the fetched values as "fetchedState" member.
+     *
+     * @param {String} displayMode - display mode to use as parameter of element names request
+     * @param {Function} callback - function to execute when response is received
+     */
+    ElementsController.prototype.testGetHTML = function(displayMode, callback) {
+        var elementNamesRequest = this.prepareRequest(displayMode, "elements");
+        var variationNameRequest = this.prepareRequest(displayMode, "variation");
+        var self = this;
+        // wait for requests to load
+        $.when(elementNamesRequest, variationNameRequest).then(function(result1, result2) {
+            var newElementNames = $(result1[0]).find(SELECTOR_ELEMENT_NAMES)[0];
+            var newSingleTextSelector = $(result1[0]).find(SELECTOR_SINGLE_TEXT_ELEMENT)[0];
+            var newVariationName = $(result2[0]).find(SELECTOR_VARIATION_NAME)[0];
+            // get the fields from the resulting markup and create a test state
+            Coral.commons.ready(newElementNames, function() {
+                Coral.commons.ready(newSingleTextSelector, function() {
+                    Coral.commons.ready(newVariationName, function() {
+                        self.fetchedState = {
+                            elementNames: newElementNames,
+                            singleTextSelector: newSingleTextSelector,
+                            variationName: newVariationName,
+                            elementNamesContainerHTML: result1[0],
+                            variationNameHTML: result2[0]
+                        };
+                        callback();
+                    });
+                });
+            });
+
+        }, function() {
+            // display error dialog if one of the requests failed
+            ui.prompt(errorDialogTitle, errorDialogMessage, "error");
+        });
+    };
+
+    /**
+     * Checks if the current states of element names, single text selector and variation names match with those
+     * present in fetchedState.
+     *
+     * @returns {Boolean} true if the states match or if there was no current state, false otherwise
+     */
+    ElementsController.prototype.testStateForUpdate = function() {
+        // check if some element names are currently configured
+        if (this.elementNames && this.elementNames.items.length > 0) {
+            // if we're unsetting the current fragment we need to reset the config
+            if (!this.fetchedState || !this.fetchedState.elementNames) {
+                return false;
+            }
+            // compare the items of the current and new element names fields
+            var currentItems = this.elementNames.template.content.querySelectorAll("coral-select-item");
+            var newItems = this.fetchedState.elementNames.template.content.querySelectorAll("coral-select-item");
+            if (!itemsAreEqual(currentItems, newItems)) {
+                return false;
+            }
+        }
+
+        if (this.singleTextSelector && this.singleTextSelector.items.length > 0) {
+            // if we're unsetting the current fragment we need to reset the config
+            if (!this.fetchedState || !this.fetchedState.singleTextSelector) {
+                return false;
+            }
+            // compare the items of the current and new element names fields
+            var currentSingleTextItems = this.singleTextSelector.querySelectorAll("coral-select-item");
+            var newSingleTextItems = this.fetchedState.singleTextSelector.querySelectorAll("coral-select-item");
+            if (!itemsAreEqual(currentSingleTextItems, newSingleTextItems)) {
+                return false;
+            }
+        }
+
+        // check if a variation is currently configured
+        if (this.variationName.value && this.variationName.value !== "master") {
+            // if we're unsetting the current fragment we need to reset the config
+            if (!this.fetchedState || !this.fetchedState.variationName) {
+                return false;
+            }
+            // compare the items of the current and new variation name fields
+            if (!itemsAreEqual(this.variationName.items.getAll(), this.fetchedState.variationName.items.getAll())) {
+                return false;
+            }
+        }
+
+        return true;
+    };
+
+    /**
+     * Replace the current state with the values present in fetchedState and discard the fetchedState thereafter.
+     */
+    ElementsController.prototype.saveFetchedState = function() {
+        if (!this.fetchedState) {
+            return;
+        }
+        if (!this.elementNames && !this.singleTextSelector) {
+            this._updateElementsHTML(this.fetchedState.elementNamesContainerHTML);
+        } else if (this.fetchedState.elementNames) {
+            if (this.fetchedState.elementNames.template.content.children) {
+                this._updateElementsDOM(this.fetchedState.elementNames);
+            } else {
+                // if the content of template is not accessible through the DOM (IE 11!),
+                // then use the HTML to update the elements multifield
+                this._updateElementsHTML(this.fetchedState.elementNamesContainerHTML);
+            }
+        } else {
+            this._updateElementsDOM(this.fetchedState.singleTextSelector);
+        }
+        this._updateVariationDOM(this.fetchedState.variationName);
+        this.discardFetchedState();
+    };
+
+    /**
+     * Discard the fetchedState data.
+     */
+    ElementsController.prototype.discardFetchedState = function() {
+        this.fetchedState = null;
+    };
+
+    /**
+     * Retrieve element names and update the current element names with the retrieved data.
+     *
+     * @param {String} displayMode - selected display mode of the component
+     */
+    ElementsController.prototype.fetchAndUpdateElementsHTML = function(displayMode) {
+        var elementNamesRequest = this.prepareRequest(displayMode, "elements");
+        var self = this;
+        // wait for requests to load
+        $.when(elementNamesRequest).then(function(result) {
+            self._updateElementsHTML(result);
+        }, function() {
+            // display error dialog if one of the requests failed
+            ui.prompt(errorDialogTitle, errorDialogMessage, "error");
+        });
+    };
+
+    /**
+     * Updates inner html of element container.
+     *
+     * @param {String} html - outerHTML value for elementNamesContainer
+     */
+    ElementsController.prototype._updateElementsHTML = function(html) {
+        this.elementNamesContainer.innerHTML = $(html)[0].innerHTML;
+        this._updateFields();
+    };
+
+    /**
+     * Updates dom of element container with the passed dom. If the passed dom is multifield, the current multifield
+     * template would be replaced with the dom's template otherwise the dom would used as the new singleTextSelector
+     * member.
+     *
+     * @param {HTMLElement} dom - new dom
+     */
+    ElementsController.prototype._updateElementsDOM = function(dom) {
+        if (dom.tagName === "CORAL-MULTIFIELD") {
+            // replace the element names multifield's template
+            this.elementNames.template = dom.template;
+        } else {
+            dom.value = this.singleTextSelector.value;
+            this.singleTextSelector.parentNode.replaceChild(dom, this.singleTextSelector);
+            this.singleTextSelector = dom;
+            this.singleTextSelector.removeAttribute("disabled");
+        }
+        this._updateFields();
+    };
+
+    /**
+     * Updates dom of variation name select dropdown.
+     *
+     * @param {HTMLElement} dom - dom for variation name dropdown
+     */
+    ElementsController.prototype._updateVariationDOM = function(dom) {
+        // replace the variation name select, keeping its value
+        dom.value = this.variationName.value;
+        this.variationName.parentNode.replaceChild(dom, this.variationName);
+        this.variationName = dom;
+        this.variationName.removeAttribute("disabled");
+        this._updateFields();
+    };
+
+    function initialize(dialog) {
+        // get path of component being edited
+        editDialog = dialog;
+
+        // get the fields
+        fragmentPath = dialog.querySelector(SELECTOR_FRAGMENT_PATH);
+        paragraphControls = dialog.querySelector(SELECTOR_PARAGRAPH_CONTROLS);
+        paragraphControlsTab = dialog.querySelector("coral-tabview").tabList.items.getAll()[1];
+
+        // initialize state variables
+        currentFragmentPath = fragmentPath.value;
+        elementsController = new ElementsController();
+
+        // disable add button and variation name if no content fragment is currently set
+        if (!currentFragmentPath) {
+            elementsController.disableFields();
+        }
+        // enable / disable the paragraph controls
+        setParagraphControlsState();
+        // hide/show paragraph control tab
+        updateParagraphControlTabState();
+
+        // register change listener
+        $(fragmentPath).on("foundation-field-change", onFragmentPathChange);
+        $(document).on("change", SELECTOR_PARAGRAPH_SCOPE, setParagraphControlsState);
+        var $radioGroup = $(dialog).find(SELECTOR_DISPLAY_MODE_RADIO_GROUP);
+        $radioGroup.on("change", function(e) {
+            elementsController.fetchAndUpdateElementsHTML(e.target.value);
+            updateParagraphControlTabState();
+        });
+    }
+
+    /**
+     * Executes after the fragment path has changed. Shows a confirmation dialog to the user if the current
+     * configuration is to be reset and updates the fields to reflect the newly selected content fragment.
+     */
+    function onFragmentPathChange() {
+        // if the fragment was reset (i.e. the fragment path was deleted)
+        if (!fragmentPath.value) {
+            var canKeepConfig = elementsController.testStateForUpdate();
+            if (canKeepConfig) {
+                // There was no current configuration. We just need to disable fields.
+                currentFragmentPath = fragmentPath.value;
+                elementsController.disableFields();
+                return;
+            }
+            // There was some current configuration. Show a confirmation dialog
+            confirmFragmentChange(null, null, elementsController.disableFields, elementsController);
+            // don't do anything else
+            return;
+        }
+
+        elementsController.testGetHTML(editDialog.querySelector(SELECTOR_DISPLAY_MODE_CHECKED).value, function() {
+            // check if we can keep the current configuration, in which case no confirmation dialog is necessary
+            var canKeepConfig = elementsController.testStateForUpdate();
+            if (canKeepConfig) {
+                if (!currentFragmentPath) {
+                    elementsController.enableFields();
+                }
+                currentFragmentPath = fragmentPath.value;
+                // its okay to save fetched state
+                elementsController.saveFetchedState();
+                return;
+            }
+            // else show a confirmation dialog
+            confirmFragmentChange(elementsController.discardFetchedState, elementsController,
+                elementsController.saveFetchedState, elementsController);
+        });
+
+    }
+
+    /**
+     * Presents the user with a confirmation dialog if the current configuration needs to be reset as a result
+     * of the content fragment change.
+     *
+     * @param {Function} cancelCallback - callback to call if change is cancelled
+     * @param {Object} cancelCallbackScope - scope (value of "this" keyword) for cancelCallback
+     * @param {Function} confirmCallback a callback to execute after the change is confirmed
+     * @param {Object} confirmCallbackScope - the scope (value of "this" keyword) to use for confirmCallback
+     */
+    function confirmFragmentChange(cancelCallback, cancelCallbackScope, confirmCallback, confirmCallbackScope) {
+
+        ui.prompt(confirmationDialogTitle, confirmationDialogMessage, "warning", [{
+            text: confirmationDialogCancel,
+            handler: function() {
+                // reset the fragment path to its previous value
+                requestAnimationFrame(function() {
+                    fragmentPath.value = currentFragmentPath;
+                });
+                if (cancelCallback) {
+                    cancelCallback.call(cancelCallbackScope);
+                }
+            }
+        }, {
+            text: confirmationDialogConfirm,
+            primary: true,
+            handler: function() {
+                // reset the current configuration
+                elementsController.resetFields();
+                // update the current fragment path
+                currentFragmentPath = fragmentPath.value;
+                // execute callback
+                if (confirmCallback) {
+                    confirmCallback.call(confirmCallbackScope);
+                }
+            }
+        }]);
+    }
+
+    /**
+     * Compares two arrays containing select items, returning true if the arrays have the same size and all contained
+     * items have the same value and label.
+     *
+     * @param {Array} a1 - first array to compare
+     * @param {Array} a2 - second array to compare
+     * @returns {Boolean} true if both arrays are equal, false otherwise
+     */
+    function itemsAreEqual(a1, a2) {
+        // verify that the arrays have the same length
+        if (a1.length !== a2.length) {
+            return false;
+        }
+        for (var i = 0; i < a1.length; i++) {
+            var item1 = a1[i];
+            var item2 = a2[i];
+            if (item1.attributes.value.value !== item2.attributes.value.value ||
+                item1.textContent !== item2.textContent) {
+                // the values or labels of the current items didn't match
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Enables or disables the paragraph range and headings field depending on the state of the paragraph scope field.
+     */
+    function setParagraphControlsState() {
+        // get the selected scope radio button (might not be present at all)
+        var scope = paragraphControls.querySelector(SELECTOR_PARAGRAPH_SCOPE + "[checked]");
+        if (scope) {
+            // enable or disable range and headings fields according to the scope value
+            var range = paragraphControls.querySelector(SELECTOR_PARAGRAPH_RANGE);
+            var headings = paragraphControls.querySelector(SELECTOR_PARAGRAPH_HEADINGS);
+            if (scope.value === "range") {
+                range.removeAttribute("disabled");
+                headings.removeAttribute("disabled");
+            } else {
+                range.setAttribute("disabled", "");
+                headings.setAttribute("disabled", "");
+            }
+        }
+    }
+
+    // Toggles the display of paragraph control tab depending on display mode
+    function updateParagraphControlTabState() {
+        var displayMode = editDialog.querySelector(SELECTOR_DISPLAY_MODE_CHECKED).value;
+        if (displayMode === SINGLE_TEXT_DISPLAY_MODE) {
+            paragraphControlsTab.hidden = false;
+        } else {
+            paragraphControlsTab.hidden = true;
+        }
+    }
+
+    /**
+     * Initializes the dialog after it has loaded.
+     */
+    channel.on("foundation-contentloaded", function(e) {
+        if (e.target.getElementsByClassName(CLASS_EDIT_DIALOG).length > 0) {
+            Coral.commons.ready(e.target, function(dialog) {
+                initialize(dialog);
+            });
+        }
+    });
+
+})(window, jQuery, jQuery(document), Granite, Coral);

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/dialog/js/htmlcontainer.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/clientlibs/editor/dialog/js/htmlcontainer.js
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright 2020 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+/*console.log("Client library called");
+
+$(document).on("foundation-contentloaded", function(e) {
+    var container = e.target;
+	alert("hello world!");
+    console.log("foundation-contentloaded was fired.");
+    console.log(container);
+});
+
+*/
+
+/* deal with *.html */
+$(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
+  selector: "[data-html-should-contain]",
+  validate: function(el) {
+
+    console.log('validating text ends with ' + shouldContain);
+    console.log('input should end with ' + shouldContain);
+
+    var shouldContain = el.getAttribute("data-html-should-contain");  //.html
+
+
+
+    var input = el.value;  //input added by author
+
+    if (input.endsWith(shouldContain) == false ) {
+      return "The filename should end with " + shouldContain + ". It's current value is " + el.value + ".";
+    } 
+  }
+});
+
+
+/* deal with *.css */
+$(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
+  selector: "[data-css-should-contain]",
+  validate: function(el) {
+
+    console.log('validating text ends with ' + shouldContain);
+    console.log('input should end with ' + shouldContain);
+
+    var shouldContain = el.getAttribute("data-css-should-contain");  //.css
+
+    var input = el.value;  //input added by author
+
+    if (input.endsWith(shouldContain) == false) {
+      return "The filename(s) should end with " + shouldContain + ". It's current value is " + el.value + ".";
+    } 
+  }
+});
+
+
+
+/* deal with *.js */
+$(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
+  selector: "[data-js-should-contain]",
+  validate: function(el) {
+
+    console.log('validating text ends with ' + shouldContain);
+    console.log('input should end with ' + shouldContain);
+
+    var shouldContain = el.getAttribute("data-js-should-contain");  //.js
+
+    var input = el.value;  //input added by author
+
+    if (input.endsWith(shouldContain) == false) {
+      return "The filename(s) should end with " + shouldContain + ". It's current value is " + el.value + ".";
+
+    } 
+  }
+});
+

--- a/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/htmlcontainer.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/htmlcontainer/v1/htmlcontainer/htmlcontainer.html
@@ -1,0 +1,40 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2019 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<div data-sly-use.htmlcontainer="com.adobe.cq.wcm.core.components.models.HTMLContainer"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
+     data-sly-use.template="core/wcm/components/commons/v1/templates.html"
+     id="${component.id}"
+     class="cmp-htmlcontainer">
+
+
+
+<sly data-sly-test="${wcmmode.edit}">
+   <div class="cq-placeholder cq-marker-start" data-emptytext="HTML Container"></div>
+
+	${htmlcontainer.includes @ context='unsafe'} 
+
+
+</sly>
+
+<sly data-sly-test="${wcmmode.preview}">
+	${htmlcontainer.includes @ context='unsafe'} 
+
+</sly>
+
+
+<p data-sly-list="${component.getResourceType}">${item.name}</p>
+
+</div>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | New component - HTML Container component
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | No - **** TO-DO -   
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
The HTML component addresses customers' needs/desires to write their own HTML, while implementing some element of formality by forcing them to use only files in the DAM.  Instead of customers just free-handing code that hasn't undergone any form of peer review, hopefully this component will force them to review the HTML/CSS/JS and put it into the DAM.  

The component allows for multiple CSS and JS files to support the one HTML file.  The CSS files can be brought in inline or via reference, while the JS files can be brought in via async, defer, reference and inline.