### PR TITLE
[Container] Fixes #1187 - Simple mode broken when using Sling Model Delegation Pattern

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
@@ -265,7 +265,7 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
         if (this.resource instanceof TemplatedResource) {
             return this.resource;
         }
-        return Optional.ofNullable((Resource)this.request.adaptTo(TemplatedResource.class)).orElse(this.resource);
+        return Optional.ofNullable((Resource)this.resource.adaptTo(TemplatedResource.class)).orElse(this.resource);
     }
 
     /*


### PR DESCRIPTION
Fixes #1187

Adapt from current resource instead of current request to TemplatedResource, to avoid empty list of children when request.getResource() already returns a templated resource.