### PR TITLE
Publish JavaDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CircleCI](https://circleci.com/gh/adobe/aem-core-wcm-components.svg?style=svg)](https://circleci.com/gh/adobe/aem-core-wcm-components)
 [![Code Coverage](https://codecov.io/gh/adobe/aem-core-wcm-components/branch/master/graph/badge.svg)](https://codecov.io/gh/adobe/aem-core-wcm-components)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.adobe.cq/core.wcm.components.all/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.adobe.cq/core.wcm.components.all)
+[![javadoc](https://javadoc.io/badge2/com.adobe.cq/core.wcm.components.core/javadoc.svg)](https://javadoc.io/doc/com.adobe.cq/core.wcm.components.core)
 
 Set of standardized Web Content Management (WCM) components for [Adobe Experience Manager (AEM)](https://www.adobe.com/marketing/experience-manager.html) to speed up development time and reduce maintenance cost of your websites.
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -324,7 +324,7 @@
                             <link>https://docs.oracle.com/javaee/7/api/</link>
                             <link>https://docs.adobe.com/docs/en/spec/jsr170/javadocs/jcr-2.0/</link>
                             <link>https://sling.apache.org/apidocs/sling9/</link>
-                            <link>https://helpx.adobe.com/experience-manager/6-5/sites/developing/using/reference-materials/javadoc</link>
+                            <link>https://helpx.adobe.com/experience-manager/6-5/sites/developing/using/reference-materials/javadoc/</link>
                             <link>https://jackrabbit.apache.org/api/2.12/</link>
                             <link>https://osgi.org/javadoc/r6/core/</link>
                             <link>https://osgi.org/javadoc/r6/annotation/</link>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -315,22 +315,22 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.2.0</version>
                     <configuration>
-                        <stylesheet>maven</stylesheet>
+                        <additionalJOption>--frames</additionalJOption>
                         <encoding>${project.build.sourceEncoding}</encoding>
                         <links>
                             <link>https://docs.oracle.com/javase/${aem.java.version}/docs/api/</link>
                             <link>https://docs.oracle.com/javaee/7/api/</link>
                             <link>https://docs.adobe.com/docs/en/spec/jsr170/javadocs/jcr-2.0/</link>
                             <link>https://sling.apache.org/apidocs/sling9/</link>
-                            <link>https://helpx.adobe.com/experience-manager/6-3/sites/developing/using/reference-materials/javadoc/</link>
+                            <link>https://helpx.adobe.com/experience-manager/6-5/sites/developing/using/reference-materials/javadoc</link>
                             <link>https://jackrabbit.apache.org/api/2.12/</link>
                             <link>https://osgi.org/javadoc/r6/core/</link>
                             <link>https://osgi.org/javadoc/r6/annotation/</link>
                             <link>https://osgi.org/javadoc/r6/cmpn/</link>
                         </links>
-                        <excludePackageNames>*.impl:*.internal</excludePackageNames>
+                        <excludePackageNames>*.impl:*.internal:*.internal.*</excludePackageNames>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
fixed #1191 
- added link to external hosted javadoc 
- fixed styling issues for generated javadoc
- updated to lastest maven-javadoc-plugin version
