### PR TITLE
CIF-1660 - Configurable header tag for teaser component

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -26,7 +26,6 @@ import java.util.stream.StreamSupport;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -54,6 +53,7 @@ import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.components.Component;
 import com.day.cq.wcm.api.designer.Style;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static com.adobe.cq.wcm.core.components.internal.Utils.ID_SEPARATOR;
 
@@ -203,7 +203,7 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
         pretitleHidden = currentStyle.get(Teaser.PN_PRETITLE_HIDDEN, pretitleHidden);
         titleHidden = currentStyle.get(Teaser.PN_TITLE_HIDDEN, titleHidden);
         descriptionHidden = currentStyle.get(Teaser.PN_DESCRIPTION_HIDDEN, descriptionHidden);
-        titleType = currentStyle.get(Teaser.PN_TITLE_TYPE, titleType);
+        titleType = properties.get(Teaser.PN_TITLE_TYPE, currentStyle.get(Teaser.PN_TITLE_TYPE, titleType));
         imageLinkHidden = currentStyle.get(Teaser.PN_IMAGE_LINK_HIDDEN, imageLinkHidden);
         titleLinkHidden = currentStyle.get(Teaser.PN_TITLE_LINK_HIDDEN, titleLinkHidden);
         if (imageLinkHidden) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
@@ -41,16 +41,12 @@ import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.org.lidalia.slf4jtest.LoggingEvent.debug;
-import static uk.org.lidalia.slf4jtest.LoggingEvent.error;
 
 @ExtendWith(AemContextExtension.class)
 class TeaserImplTest {
@@ -78,6 +74,7 @@ class TeaserImplTest {
     private static final String TEASER_10 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-10";
     private static final String TEASER_11 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-11";
     private static final String TEASER_12 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-12";
+    private static final String TEASER_13 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-13";
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
     private TestLogger testLogger;
@@ -221,6 +218,14 @@ class TeaserImplTest {
         Teaser teaser = getTeaserUnderTest(TEASER_1);
         assertNull(teaser.getTitleType(), "Expected the default title type is not correct");
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(TEST_BASE, "teaser1"));
+    }
+
+    @Test
+    void testTeaserWithTitleTypeOverride() {
+        Teaser teaser = getTeaserUnderTest(TEASER_13,
+            Teaser.PN_TITLE_TYPE, "h5");
+        assertEquals("h4", teaser.getTitleType(), "Expected title type is not correct");
+        Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(TEST_BASE, "teaser13"));
     }
 
     @Test

--- a/bundles/core/src/test/resources/teaser/exporter-teaser13.json
+++ b/bundles/core/src/test/resources/teaser/exporter-teaser13.json
@@ -1,0 +1,22 @@
+{
+  "pretitle": "Teaser's Pretitle",
+  "title": "Teaser",
+  "titleType": "h4",
+  "description": "Description",
+  "linkURL": "https://www.adobe.com",
+  "actionsEnabled": false,
+  "imageLinkHidden": false,
+  "titleLinkHidden": false,
+  "actions": [],
+  "id": "teaser-2541aa8294",
+  "imagePath": "/core/content/teasers/_jcr_content/root/responsivegrid/teaser-13.coreimg.png/1490005239000/adobe-systems-logo-and-wordmark.png",
+  "dataLayer": {
+    "teaser-2541aa8294": {
+      "xdm:linkURL": "https://www.adobe.com",
+      "dc:description": "Description",
+      "@type": "core/wcm/components/teaser/v1/teaser",
+      "dc:title": "Teaser"
+    }
+  },
+  ":type": "core/wcm/components/teaser/v1/teaser"
+}

--- a/bundles/core/src/test/resources/teaser/test-content.json
+++ b/bundles/core/src/test/resources/teaser/test-content.json
@@ -150,6 +150,16 @@
                                 "text": "Adobe"
                             }
                         }
+                    },
+                    "teaser-13"          : {
+                        "jcr:primaryType"   : "nt:unstructured",
+                        "fileReference"     : "/content/dam/core/images/Adobe_Systems_logo_and_wordmark.png",
+                        "pretitle"          : "Teaser's Pretitle",
+                        "jcr:title"         : "Teaser",
+                        "jcr:description"   : "Description",
+                        "linkURL"           : "https://www.adobe.com",
+                        "sling:resourceType": "core/wcm/components/teaser/v1/teaser",
+                        "titleType"         : "h4"
                     }
                 }
             }

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/README.md
@@ -59,6 +59,7 @@ The following properties are written to JCR for this Teaser component and are ex
 8. `./jcr:description` - defines the value of the teaser description
 9. `./descriptionFromPage` - defines whether or not the description value is taken from the linked page
 10. `./id` - defines the component HTML ID attribute.
+11. `./titleType` - stores the value for this title's HTML element type
 
 ### Extending the Teaser Component
 When extending the Teaser component by using `sling:resourceSuperType`, developers need to define the `imageDelegate` property for

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -85,6 +85,43 @@
                                                         fieldLabel="Title"
                                                         name="./jcr:title"
                                                         value="${cqDesign._jcr_description}"/>
+                                                    <titleType
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                        fieldLabel="Title Type"
+                                                        name="./titleType"
+                                                        granite:class="foundation-toggleable">
+                                                        <items jcr:primaryType="nt:unstructured">
+                                                            <def
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="(default)"
+                                                                value=""/>
+                                                            <h1
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H1"
+                                                                value="h1"/>
+                                                            <h2
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H2"
+                                                                value="h2"/>
+                                                            <h3
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H3"
+                                                                value="h3"/>
+                                                            <h4
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H4"
+                                                                value="h4"/>
+                                                            <h5
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H5"
+                                                                value="h5"/>
+                                                            <h6
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H6"
+                                                                value="h6"/>
+                                                        </items>
+                                                    </titleType>
                                                     <titleFromLinkedPage
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"


### PR DESCRIPTION
- add "titleType" property in component dialog so it's possible to override the default tag

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | CIF-1660, #684
| Patch: Bug Fix?          |
| Minor: New Feature?      | yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

This PR extends the component dialog of the Teaser component with the ability to select/override the tag for the title element. See the screenshot.

![Screenshot 2020-10-05 at 10 46 17](https://user-images.githubusercontent.com/24548615/95059333-04146180-06f9-11eb-993d-985bcfb0cc03.png)

