### PR TITLE
CIF-1660 - Configurable header tag for teaser component

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -115,6 +115,11 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
     private boolean titleHidden = false;
 
     /**
+     * Flag indicating if the title type should be hidden.
+     */
+    private boolean titleTypeHidden = false;
+
+    /**
      * Flag indicating if the description should be hidden.
      */
     private boolean descriptionHidden = false;
@@ -203,7 +208,8 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
         pretitleHidden = currentStyle.get(Teaser.PN_PRETITLE_HIDDEN, pretitleHidden);
         titleHidden = currentStyle.get(Teaser.PN_TITLE_HIDDEN, titleHidden);
         descriptionHidden = currentStyle.get(Teaser.PN_DESCRIPTION_HIDDEN, descriptionHidden);
-        titleType = properties.get(Teaser.PN_TITLE_TYPE, currentStyle.get(Teaser.PN_TITLE_TYPE, titleType));
+        titleType = currentStyle.get(Teaser.PN_TITLE_TYPE, titleType);
+        titleTypeHidden = currentStyle.get(Teaser.PN_TITLE_TYPE_HIDDEN, titleTypeHidden);
         imageLinkHidden = currentStyle.get(Teaser.PN_IMAGE_LINK_HIDDEN, imageLinkHidden);
         titleLinkHidden = currentStyle.get(Teaser.PN_TITLE_LINK_HIDDEN, titleLinkHidden);
         if (imageLinkHidden) {
@@ -371,6 +377,10 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
 
     @Override
     public String getTitleType() {
+        if (!titleTypeHidden) {
+            titleType = resource.getValueMap().get(Teaser.PN_TITLE_TYPE, titleType);
+        }
+
         Utils.Heading heading = Utils.Heading.getHeading(titleType);
         if (heading != null) {
             return heading.getElement();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -117,7 +117,7 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
     /**
      * Flag indicating if the title type should be hidden.
      */
-    private boolean titleTypeHidden = false;
+    private boolean showTitleType = false;
 
     /**
      * Flag indicating if the description should be hidden.
@@ -209,7 +209,7 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
         titleHidden = currentStyle.get(Teaser.PN_TITLE_HIDDEN, titleHidden);
         descriptionHidden = currentStyle.get(Teaser.PN_DESCRIPTION_HIDDEN, descriptionHidden);
         titleType = currentStyle.get(Teaser.PN_TITLE_TYPE, titleType);
-        titleTypeHidden = currentStyle.get(Teaser.PN_TITLE_TYPE_HIDDEN, titleTypeHidden);
+        showTitleType = currentStyle.get(Teaser.PN_SHOW_TITLE_TYPE, showTitleType);
         imageLinkHidden = currentStyle.get(Teaser.PN_IMAGE_LINK_HIDDEN, imageLinkHidden);
         titleLinkHidden = currentStyle.get(Teaser.PN_TITLE_LINK_HIDDEN, titleLinkHidden);
         if (imageLinkHidden) {
@@ -377,7 +377,7 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
 
     @Override
     public String getTitleType() {
-        if (!titleTypeHidden) {
+        if (showTitleType) {
             titleType = resource.getValueMap().get(Teaser.PN_TITLE_TYPE, titleType);
         }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Teaser.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Teaser.java
@@ -120,11 +120,11 @@ public interface Teaser extends Component {
     String PN_TITLE_TYPE = "titleType";
 
     /**
-     * Name of the policy property that defines whether or not the title type is hidden.
+     * Name of the policy property that defines whether or not the title type is shown.
      *
      * @since com.adobe.cq.wcm.core.components.models 12.16.0
      */
-    String PN_TITLE_TYPE_HIDDEN = "titleTypeHidden";
+    String PN_SHOW_TITLE_TYPE = "showTitleType";
 
     /**
      * Checks if the teaser has Call-to-Action elements

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Teaser.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Teaser.java
@@ -20,8 +20,6 @@ import java.util.List;
 import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
 
-import com.adobe.cq.export.json.ComponentExporter;
-
 /**
  * Defines the {@code Teaser} Sling Model for the {@code /apps/core/wcm/components/teaser} component.
  *
@@ -120,6 +118,13 @@ public interface Teaser extends Component {
      * @since com.adobe.cq.wcm.core.components.models 12.4.0
      */
     String PN_TITLE_TYPE = "titleType";
+
+    /**
+     * Name of the policy property that defines whether or not the title type is hidden.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.16.0
+     */
+    String PN_TITLE_TYPE_HIDDEN = "titleTypeHidden";
 
     /**
      * Checks if the teaser has Call-to-Action elements

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.15.0")
+@Version("12.16.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
@@ -223,9 +223,16 @@ class TeaserImplTest {
     @Test
     void testTeaserWithTitleTypeOverride() {
         Teaser teaser = getTeaserUnderTest(TEASER_13,
-            Teaser.PN_TITLE_TYPE, "h5");
+            Teaser.PN_TITLE_TYPE, "h5", Teaser.PN_TITLE_TYPE_HIDDEN, false);
         assertEquals("h4", teaser.getTitleType(), "Expected title type is not correct");
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(TEST_BASE, "teaser13"));
+    }
+
+    @Test
+    void testTeaserWithTitleTypeOverrideHidden() {
+        Teaser teaser = getTeaserUnderTest(TEASER_13,
+            Teaser.PN_TITLE_TYPE, "h5", Teaser.PN_TITLE_TYPE_HIDDEN, true);
+        assertEquals("h5", teaser.getTitleType(), "Expected title type is not correct");
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
@@ -223,7 +223,7 @@ class TeaserImplTest {
     @Test
     void testTeaserWithTitleTypeOverride() {
         Teaser teaser = getTeaserUnderTest(TEASER_13,
-            Teaser.PN_TITLE_TYPE, "h5", Teaser.PN_TITLE_TYPE_HIDDEN, false);
+            Teaser.PN_TITLE_TYPE, "h5", Teaser.PN_SHOW_TITLE_TYPE, true);
         assertEquals("h4", teaser.getTitleType(), "Expected title type is not correct");
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(TEST_BASE, "teaser13"));
     }
@@ -231,7 +231,7 @@ class TeaserImplTest {
     @Test
     void testTeaserWithTitleTypeOverrideHidden() {
         Teaser teaser = getTeaserUnderTest(TEASER_13,
-            Teaser.PN_TITLE_TYPE, "h5", Teaser.PN_TITLE_TYPE_HIDDEN, true);
+            Teaser.PN_TITLE_TYPE, "h5", Teaser.PN_SHOW_TITLE_TYPE, false);
         assertEquals("h5", teaser.getTitleType(), "Expected title type is not correct");
     }
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/README.md
@@ -36,6 +36,7 @@ The following configuration properties are used:
 5. `./imageLinkHidden` - defines whether or not the image link is hidden
 6. `./titleLinkHidden` - defines whether or not the title link is hidden
 7. `./titleType` - stores the value for this title's HTML element type
+8. `./showTitleType` - defines whether or not the title tab dropdown menu is shown
 
 The following configuration properties are inherited from the image component:
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_design_dialog/.content.xml
@@ -62,6 +62,12 @@
                                         text="Hide title"
                                         name="./titleHidden"
                                         value="{Boolean}true"/>
+                                    <titleType
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                        text="Hide title type"
+                                        name="./titleTypeHidden"
+                                        value="{Boolean}true"/>
                                     <description
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
@@ -73,7 +79,7 @@
                             <type
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/select"
-                                fieldLabel="Title Type"
+                                fieldLabel="Default Title Type"
                                 name="./titleType"
                                 granite:class="foundation-toggleable">
                                 <items jcr:primaryType="nt:unstructured">

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_design_dialog/.content.xml
@@ -65,8 +65,9 @@
                                     <titleType
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                        text="Hide title type"
-                                        name="./titleTypeHidden"
+                                        text="Show title type"
+                                        name="./showTitleType"
+                                        uncheckedValue="false"
                                         value="{Boolean}true"/>
                                     <description
                                         jcr:primaryType="nt:unstructured"

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -86,6 +86,7 @@
                                                         name="./jcr:title"
                                                         value="${cqDesign._jcr_description}"/>
                                                     <titleType
+                                                        granite:hide="${cqDesign.titleTypeHidden}"
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                                         fieldLabel="Title Type"

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -86,7 +86,7 @@
                                                         name="./jcr:title"
                                                         value="${cqDesign._jcr_description}"/>
                                                     <titleType
-                                                        granite:hide="${cqDesign.titleTypeHidden}"
+                                                        granite:hide="${!cqDesign.showTitleType}"
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                                         fieldLabel="Title Type"


### PR DESCRIPTION
- add option to hide/display title type field in component dialog

Extends #1199 with @msagolj proposal for the dialog.

![Screenshot 2020-10-05 at 13 53 09](https://user-images.githubusercontent.com/24548615/95077006-0edbf000-0713-11eb-812d-2d2ecfcd6fb4.png)
