### PR TITLE
When publishing a page, its context-aware configuration should also b…

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider.java
@@ -28,6 +28,8 @@ import com.adobe.cq.wcm.core.components.config.HtmlPageItemsConfig;
 import com.adobe.cq.wcm.core.components.internal.DataLayerConfig;
 import com.adobe.cq.wcm.core.components.internal.services.pdfviewer.PdfViewerCaConfig;
 import com.day.cq.commons.jcr.JcrConstants;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.reference.Reference;
 import com.day.cq.wcm.api.reference.ReferenceProvider;
 
@@ -52,6 +54,15 @@ public class CaConfigReferenceProvider implements ReferenceProvider {
     @Override
     public List<Reference> findReferences(Resource resource) {
         List<Reference> references = new ArrayList<>();
+        // If the resource is not part of a page: stop the processing
+        PageManager pageManager = resource.getResourceResolver().adaptTo(PageManager.class);
+        if (pageManager == null) {
+            return references;
+        }
+        Page page = pageManager.getContainingPage(resource);
+        if (page == null) {
+            return references;
+        }
         addCaConfigReference(HtmlPageItemsConfig.class.getName(), resource, references);
         addCaConfigReference(DataLayerConfig.class.getName(), resource, references);
         addCaConfigReference(PdfViewerCaConfig.class.getName(), resource, references);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider.java
@@ -25,9 +25,13 @@ import org.apache.sling.caconfig.resource.ConfigurationResourceResolver;
 import org.osgi.service.component.annotations.Component;
 
 import com.adobe.cq.wcm.core.components.config.HtmlPageItemsConfig;
+import com.adobe.cq.wcm.core.components.internal.DataLayerConfig;
+import com.adobe.cq.wcm.core.components.internal.services.pdfviewer.PdfViewerCaConfig;
 import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.reference.Reference;
 import com.day.cq.wcm.api.reference.ReferenceProvider;
+
+import static com.adobe.cq.wcm.core.components.util.ComponentUtils.NN_SLING_CONFIGS;
 
 /**
  * Provides Context Aware Configuration references for a given resource.
@@ -37,7 +41,6 @@ import com.day.cq.wcm.api.reference.ReferenceProvider;
 )
 public class CaConfigReferenceProvider implements ReferenceProvider {
 
-    private static final String NN_SLING_CONFIGS = "sling:configs";
     private static final String CA_CONFIG_REFERENCE_TYPE = "caconfig";
 
     /**
@@ -49,12 +52,18 @@ public class CaConfigReferenceProvider implements ReferenceProvider {
     @Override
     public List<Reference> findReferences(Resource resource) {
         List<Reference> references = new ArrayList<>();
-        Resource configResource = configurationResourceResolver.getResource(resource, NN_SLING_CONFIGS, HtmlPageItemsConfig.class.getName());
+        addCaConfigReference(HtmlPageItemsConfig.class.getName(), resource, references);
+        addCaConfigReference(DataLayerConfig.class.getName(), resource, references);
+        addCaConfigReference(PdfViewerCaConfig.class.getName(), resource, references);
+        return references;
+    }
+
+    private void addCaConfigReference(String configName, Resource resource, List<Reference> references) {
+        Resource configResource = configurationResourceResolver.getResource(resource, NN_SLING_CONFIGS, configName);
         if (configResource != null) {
             ValueMap properties = configResource.getValueMap();
             Calendar lastModified = properties.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class);
-            references.add(new Reference(CA_CONFIG_REFERENCE_TYPE, HtmlPageItemsConfig.class.getName(), configResource, (lastModified != null) ? lastModified.getTimeInMillis() : -1));
+            references.add(new Reference(CA_CONFIG_REFERENCE_TYPE, configName, configResource, (lastModified != null) ? lastModified.getTimeInMillis() : -1));
         }
-        return references;
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider.java
@@ -1,0 +1,60 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.caconfig.resource.ConfigurationResourceResolver;
+import org.osgi.service.component.annotations.Component;
+
+import com.adobe.cq.wcm.core.components.config.HtmlPageItemsConfig;
+import com.day.cq.commons.jcr.JcrConstants;
+import com.day.cq.wcm.api.reference.Reference;
+import com.day.cq.wcm.api.reference.ReferenceProvider;
+
+/**
+ * Provides Context Aware Configuration references for a given resource.
+ */
+@Component(
+        service = ReferenceProvider.class
+)
+public class CaConfigReferenceProvider implements ReferenceProvider {
+
+    private static final String NN_SLING_CONFIGS = "sling:configs";
+    private static final String CA_CONFIG_REFERENCE_TYPE = "caconfig";
+
+    /**
+     * The @{@link ConfigurationResourceResolver} service.
+     */
+    @org.osgi.service.component.annotations.Reference
+    private ConfigurationResourceResolver configurationResourceResolver;
+
+    @Override
+    public List<Reference> findReferences(Resource resource) {
+        List<Reference> references = new ArrayList<>();
+        Resource configResource = configurationResourceResolver.getResource(resource, NN_SLING_CONFIGS, HtmlPageItemsConfig.class.getName());
+        if (configResource != null) {
+            ValueMap properties = configResource.getValueMap();
+            Calendar lastModified = properties.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class);
+            references.add(new Reference(CA_CONFIG_REFERENCE_TYPE, HtmlPageItemsConfig.class.getName(), configResource, (lastModified != null) ? lastModified.getTimeInMillis() : -1));
+        }
+        return references;
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/util/ComponentUtils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/util/ComponentUtils.java
@@ -36,6 +36,11 @@ import java.util.Optional;
 public final class ComponentUtils {
 
     /**
+     * Name of the node holding the context aware configurations below /conf/{site-name};
+     */
+    public static final String NN_SLING_CONFIGS = "sling:configs";
+
+    /**
      * Name of the separator character used between prefix and hash when generating an ID, e.g. image-5c7e0ef90d
      */
     public static final String ID_SEPARATOR = "-";

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProviderTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProviderTest.java
@@ -1,0 +1,79 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services;
+
+import java.util.List;
+
+import org.apache.sling.api.resource.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.adobe.cq.wcm.core.components.config.HtmlPageItemsConfig;
+import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
+import com.adobe.cq.wcm.core.components.testing.MockConfigurationResourceResolver;
+import com.day.cq.wcm.api.reference.Reference;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(AemContextExtension.class)
+class CaConfigReferenceProviderTest {
+
+    private static final String TEST_BASE = "/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider";
+    private static final String TEST_PAGE = "/content/mysite/page";
+    private static final String TEST_COMPONENT = TEST_PAGE + "/jcr:content/par/title";
+    private static final String SLING_CONFIGS_ROOT = "/conf/mysite/sling:configs";
+
+    private CaConfigReferenceProvider caConfigReferenceProvider;
+
+    protected final AemContext context = CoreComponentTestContext.newAemContext();
+
+    @BeforeEach
+    void setUp() {
+        context.load().json(TEST_BASE + "/test-content.json", TEST_PAGE);
+        MockConfigurationResourceResolver mockConfigurationResourceResolver = new MockConfigurationResourceResolver(context.resourceResolver(), SLING_CONFIGS_ROOT);
+        context.registerInjectActivateService(mockConfigurationResourceResolver);
+        caConfigReferenceProvider = context.registerInjectActivateService(new CaConfigReferenceProvider());
+    }
+
+    void loadHtmlPageItemsConfig() {
+        context.load().json(TEST_BASE + "/test-sling-configs.json", SLING_CONFIGS_ROOT);
+    }
+
+    @Test
+    void testFindReferences() {
+        loadHtmlPageItemsConfig();
+        Resource resource = context.resourceResolver().getResource(TEST_COMPONENT);
+        List<Reference> references = caConfigReferenceProvider.findReferences(resource);
+        assertEquals(1, references.size());
+        Reference reference = references.get(0);
+        Resource expectedReferenceRes = context.resourceResolver().getResource(SLING_CONFIGS_ROOT + "/" + HtmlPageItemsConfig.class.getName());
+        assertEquals("caconfig", reference.getType());
+        assertEquals(HtmlPageItemsConfig.class.getName(), reference.getName());
+        if (expectedReferenceRes != null) {
+            assertEquals(expectedReferenceRes.getPath(), reference.getResource().getPath());
+        }
+        assertEquals(1602683813696L, reference.getLastModified());
+    }
+
+    @Test
+    void testNoReferences() {
+        Resource resource = context.resourceResolver().getResource(TEST_COMPONENT);
+        List<Reference> references = caConfigReferenceProvider.findReferences(resource);
+        assertEquals(0, references.size());
+    }
+}

--- a/bundles/core/src/test/resources/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider/test-content.json
+++ b/bundles/core/src/test/resources/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider/test-content.json
@@ -1,0 +1,26 @@
+{
+    "jcr:primaryType": "cq:Page",
+    "jcr:createdBy"  : "admin",
+    "jcr:created"    : "Wed Jan 13 2016 15:56:31 GMT+0100",
+    "jcr:content"    : {
+        "jcr:primaryType"   : "cq:PageContent",
+        "jcr:createdBy"     : "admin",
+        "jcr:created"       : "Wed Jan 13 2016 15:56:31 GMT+0100",
+        "cq:lastModified"   : "Wed Jan 13 2016 16:14:51 GMT+0100",
+        "sling:resourceType": "core/wcm/components/page/v1/page",
+        "cq:lastModifiedBy" : "admin",
+        "par"               : {
+            "jcr:primaryType"     : "nt:unstructured",
+            "sling:resourceType"  : "wcm/foundation/components/parsys",
+            "title"     : {
+                "jcr:primaryType"   : "nt:unstructured",
+                "jcr:createdBy"     : "admin",
+                "jcr:title"         : "Hello World",
+                "jcr:lastModifiedBy": "admin",
+                "jcr:created"       : "Wed Jan 13 2016 15:58:25 GMT+0100",
+                "jcr:lastModified"  : "Wed Jan 13 2016 16:14:51 GMT+0100",
+                "sling:resourceType": "core/wcm/components/title/v1/title"
+            }
+        }
+    }
+}

--- a/bundles/core/src/test/resources/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider/test-sling-configs.json
+++ b/bundles/core/src/test/resources/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider/test-sling-configs.json
@@ -1,0 +1,32 @@
+{
+    "com.adobe.cq.wcm.core.components.config.HtmlPageItemsConfig": {
+        "jcr:primaryType": "nt:unstructured",
+        "jcr:lastModified": "2020-10-14T15:56:53.696+02:00",
+        "prefixPath"     : "/_theme",
+        "theme.css"      : {
+            "jcr:primaryType": "nt:unstructured",
+            "element"        : "link",
+            "location"       : "header",
+            "attributes"     : {
+                "jcr:primaryType": "nt:unstructured",
+                "href"           : "/theme.css"
+            }
+        },
+        "theme.js"       : {
+            "jcr:primaryType": "nt:unstructured",
+            "element"        : "script",
+            "location"       : "footer",
+            "attributes"     : {
+                "jcr:primaryType": "nt:unstructured",
+                "src"            : "/theme.js"
+            }
+        },
+        "meta"           : {
+            "jcr:primaryType": "nt:unstructured",
+            "element"        : "meta"
+        },
+        "invalid"        : {
+            "jcr:primaryType": "nt:unstructured"
+        }
+    }
+}


### PR DESCRIPTION
…e published

- use a reference provider to get the configuration node: AEM will automatically add this reference to the ones that will be published
- add tests

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1217
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
