### PR TITLE
Add missing cq:isContainer property for example components

### DIFF
--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/accordion/.content.xml
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/accordion/.content.xml
@@ -15,6 +15,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:isContainer="{Boolean}true"
     jcr:description="Accordion Component for the Core Components Library"
     jcr:primaryType="cq:Component"
     jcr:title="Accordion"

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/carousel/.content.xml
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/carousel/.content.xml
@@ -15,6 +15,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:isContainer="{Boolean}true"
     jcr:description="Carousel Component for the Core Components Library"
     jcr:primaryType="cq:Component"
     jcr:title="Carousel"

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/tabs/.content.xml
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/tabs/.content.xml
@@ -15,8 +15,9 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-          jcr:description="Tabs Component for the Core Components Library"
-          jcr:primaryType="cq:Component"
-          jcr:title="Tabs"
-          sling:resourceSuperType="core/wcm/extensions/amp/components/tabs/v1/tabs"
-          componentGroup="Core Components Examples"/>
+    cq:isContainer="{Boolean}true"
+    jcr:description="Tabs Component for the Core Components Library"
+    jcr:primaryType="cq:Component"
+    jcr:title="Tabs"
+    sling:resourceSuperType="core/wcm/extensions/amp/components/tabs/v1/tabs"
+    componentGroup="Core Components Examples"/>

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/carousel/v1/carousel/.content.xml
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/carousel/v1/carousel/.content.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2019 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     cq:icon="imageCarousel"
     cq:isContainer="{Boolean}true"

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/tabs/v1/tabs/.content.xml
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/tabs/v1/tabs/.content.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2019 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     cq:icon="multiple"
     cq:isContainer="{Boolean}true"


### PR DESCRIPTION
add missing `cq:isContainer` for example components as this property is not inherited in AEM 6.4