### PR TITLE
Fixes #1187 (2nd try): try to get TemplatedResource from current resource, and fallback to current request's resource

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
@@ -261,7 +261,9 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
         if (this.resource instanceof TemplatedResource) {
             return this.resource;
         }
-        return Optional.ofNullable((Resource)this.request.adaptTo(TemplatedResource.class)).orElse(this.resource);
+        return Optional.ofNullable((Resource)this.resource.adaptTo(TemplatedResource.class))
+                .orElse(Optional.ofNullable((Resource)this.request.adaptTo(TemplatedResource.class))
+                .orElse(this.resource));
     }
 
     /*


### PR DESCRIPTION
Fixes #1187 

the first PR that was included in 2.12.0 was reverted in 2.12.2 (see [here](https://github.com/adobe/aem-core-wcm-components/issues/1187#issuecomment-724828689)) - this is a new PR which should over all use cases.