### PR TITLE
[Form Text] Fixes #1257: Ensure "Text Lines" is shown/hidden based on the chosen Constraint

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/_cq_dialog/.content.xml
@@ -92,7 +92,7 @@
                                                 min="{Long}1"
                                                 name="./rows"
                                                 value="2"
-                                                wrapperClass="cmp-form-textfield-rows"/>
+                                                wrapperClass="cmp-form-text__rows"/>
                                             <label
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/clientlibs/site/js/text.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/clientlibs/site/js/text.js
@@ -30,15 +30,13 @@
          *
          * @type {String}
          */
-        constraintMessage: {
-        },
+        constraintMessage: "",
         /**
          * A validation message to display if no input is supplied, but input is expected for the field.
          *
          * @type {String}
          */
-        requiredMessage: {
-        }
+        requiredMessage: ""
     };
 
     function readData(element) {


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?         | Fixes #1257
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | No
| Documentation Provided   | No (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Changes the wrapperClass to be in line with the clientlib so that the DOM node can be found and shown/hidden in `content/src/content/jcr_root/apps/core/wcm/components/form/text/v1/text/clientlibs/editor/js/editDialog.js` (`handleTextarea`)