### PR TITLE
[Form Text & Form Options] Fixes #1259: Streamline form text and form options dialog

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/form/options/v2/options/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/options/v2/options/_cq_dialog/.content.xml
@@ -47,11 +47,6 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
-                                            <mainHeading
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/heading"
-                                                level="{Long}3"
-                                                text="Main"/>
                                             <optionTypes
                                                 granite:class="cmp-form-options__editor-type"
                                                 jcr:primaryType="nt:unstructured"
@@ -207,17 +202,6 @@
                                                     </options>
                                                 </items>
                                             </fromLocal>
-                                            <aboutHeading
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/heading"
-                                                level="{Long}3"
-                                                text="About"/>
-                                            <description
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="A hint for the user of what can be entered in the field."
-                                                fieldLabel="Help Message"
-                                                name="./helpMessage"/>
                                             <id
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
@@ -230,6 +214,33 @@
                             </columns>
                         </items>
                     </properties>
+                    <about
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="About"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <helpMessage
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="A hint to the user of what can be entered in the field"
+                                                fieldLabel="Help Message"
+                                                name="./helpMessage"/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </about>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/_cq_dialog/.content.xml
@@ -110,9 +110,8 @@
                                             <name
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                emptyText="The name of the field which is submitted with the form data"
-                                                fieldDescription="The name of the field which is submitted with the form data"
-                                                fieldLabel="Element Name"
+                                                fieldDescription="The name of the field, which is submitted with the form data."
+                                                fieldLabel="Name"
                                                 name="./name"
                                                 required="{Boolean}true"/>
                                             <value


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1259 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | No
| Minor: New Feature?      | No
| Major: Breaking Change?  | Possibly, if customers are overriding form/text/v2/cq:dialog and expected the "About" section to be located inside `<properties>`
| Tests Added + Pass?      | No
| Documentation Provided   | No (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
- Changes "Form Text Field"'s "Element Name" label to "Name" to be in line with "Form Options Text"
- Moves "Form Option Field"'s "About" section to a dedicated tab and removes the headings "Main" and "About"

<img src="https://user-images.githubusercontent.com/1360135/99072137-bcb0a900-25b3-11eb-8450-cc74b4e3aa80.png" width="50%">