### PR TITLE
CQ-4309183 Inherited deep properties live copy content are not visible though the value shows in crx/de.

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v1/page/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v1/page/_cq_dialog/.content.xml
@@ -124,7 +124,7 @@
                                                 variant="sm">
                                                 <granite:data
                                                     jcr:primaryType="nt:unstructured"
-                                                    cq-msm-lockable="fragmentPath"/>
+                                                    cq-msm-lockable="variantPath"/>
                                             </variantpath>
                                             <socialmedia_type
                                                 cq:showOnCreate="{Boolean}true"


### PR DESCRIPTION


Updating value cq-msm-lockable to correct name i.e. "variantPath"

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
