### PR TITLE
[Containers] Separate concept of "List Items" from "Container Items" (re-worked)

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
@@ -22,11 +22,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import com.adobe.cq.wcm.core.components.util.ComponentUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
@@ -78,12 +76,7 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
     /**
      * The list of child items.
      */
-    protected List<ListItem> items;
-
-    /**
-     * The list of child resources that are components.
-     */
-    protected List<Resource> childComponents;
+    private List<ListItem> items;
 
     /**
      * The name of the child resources in the order they are to be exported.
@@ -94,19 +87,6 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
      * The background style string for this container component.
      */
     private String backgroundStyle;
-
-    /**
-     * Return (and cache) the list of children resources that are components
-     *
-     * @return List of all children resources that are components.
-     */
-    @NotNull
-    protected List<Resource> getChildren() {
-        if (childComponents == null) {
-            this.childComponents = ComponentUtils.getChildComponents(this.resource, this.request);
-        }
-        return childComponents;
-    }
 
     /**
      * Get the list of items in the container.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
@@ -18,7 +18,6 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -134,7 +133,7 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
 
     @Nullable
     @Override
-    public String getBackgroundStyle() {
+    public final String getBackgroundStyle() {
         if (this.backgroundStyle == null) {
             StringBuilder styleBuilder = new StringBuilder();
             getBackgroundImage().ifPresent(image -> styleBuilder.append("background-image:url(").append(image).append(");background-size:cover;background-repeat:no-repeat;"));
@@ -150,7 +149,7 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
 
     @NotNull
     @Override
-    public String getExportedType() {
+    public final String getExportedType() {
         return resource.getResourceType();
     }
 
@@ -160,14 +159,9 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
 
     @NotNull
     @Override
-    public String[] getExportedItemsOrder() {
+    public final String[] getExportedItemsOrder() {
         if (exportedItemsOrder == null) {
-            Map<String, ? extends ComponentExporter> models = getExportedItems();
-            if (!models.isEmpty()) {
-                exportedItemsOrder = models.keySet().toArray(ArrayUtils.EMPTY_STRING_ARRAY);
-            } else {
-                exportedItemsOrder = ArrayUtils.EMPTY_STRING_ARRAY;
-            }
+            this.exportedItemsOrder = this.getExportedItems().keySet().toArray(ArrayUtils.EMPTY_STRING_ARRAY);
         }
         return Arrays.copyOf(exportedItemsOrder, exportedItemsOrder.length);
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
@@ -17,15 +17,12 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
+import com.adobe.cq.wcm.core.components.util.ComponentUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -44,8 +41,6 @@ import com.adobe.cq.wcm.core.components.models.Container;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.models.datalayer.ContainerData;
 import com.adobe.cq.wcm.core.components.models.datalayer.builder.DataLayerBuilder;
-import com.day.cq.wcm.api.TemplatedResource;
-import com.day.cq.wcm.api.components.ComponentManager;
 import com.day.cq.wcm.api.designer.Style;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -91,16 +86,6 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
     protected List<Resource> childComponents;
 
     /**
-     * The child resources to be exported.
-     */
-    protected List<Resource> filteredChildComponents;
-
-    /**
-     * Map of the child items to be exported wherein the key is the child name, and the value is the child model.
-     */
-    protected Map<String, ? extends ComponentExporter> itemModels;
-
-    /**
      * The name of the child resources in the order they are to be exported.
      */
     private String[] exportedItemsOrder;
@@ -118,31 +103,9 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
     @NotNull
     protected List<Resource> getChildren() {
         if (childComponents == null) {
-            Resource effectiveResource = this.getEffectiveResource();
-            childComponents = Optional.ofNullable(request.getResourceResolver().adaptTo(ComponentManager.class))
-                .map(componentManager ->
-                    StreamSupport.stream(effectiveResource.getChildren().spliterator(), false)
-                        .filter(res -> Objects.nonNull(componentManager.getComponentOfResource(res))))
-                .orElseGet(Stream::empty)
-                .collect(Collectors.toList());
+            this.childComponents = ComponentUtils.getChildComponents(this.resource, this.request);
         }
         return childComponents;
-    }
-
-    /**
-     * Return (and cache) the list of children resources that are components, filtered by the Sling Model Filter. This
-     * should only be used for JSON export, for other usages refer to {@link AbstractContainerImpl#getChildren}.
-     *
-     * @return The list of children resources available for JSON export.
-     */
-    @NotNull
-    protected List<Resource> getFilteredChildren() {
-        if (filteredChildComponents == null) {
-            filteredChildComponents = new LinkedList<>();
-            slingModelFilter.filterChildResources(getChildren())
-                .forEach(filteredChildComponents::add);
-        }
-        return filteredChildComponents;
     }
 
     /**
@@ -211,12 +174,7 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
 
     @NotNull
     @Override
-    public Map<String, ? extends ComponentExporter> getExportedItems() {
-        if (itemModels == null) {
-            itemModels = getItemModels(request, ComponentExporter.class);
-        }
-        return itemModels;
-    }
+    public abstract LinkedHashMap<String, ? extends ComponentExporter> getExportedItems();
 
     @NotNull
     @Override
@@ -231,44 +189,6 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
         }
         return Arrays.copyOf(exportedItemsOrder, exportedItemsOrder.length);
     }
-
-    /**
-     * Get the models for the child resources as provided by {@link AbstractContainerImpl#getFilteredChildren()}.
-     *
-     * @param request The current request.
-     * @param modelClass The child model class.
-     * @return Map of models wherein the key is the child name, and the value is it's model.
-     */
-    protected Map<String, ComponentExporter> getItemModels(@NotNull final SlingHttpServletRequest request,
-                                                           @NotNull final Class<ComponentExporter> modelClass) {
-        Map<String, ComponentExporter> models = new LinkedHashMap<>();
-        getFilteredChildren().forEach(child -> {
-            ComponentExporter model = modelFactory.getModelFromWrappedRequest(request, child, modelClass);
-            if (model != null) {
-                models.put(child.getName(), model);
-            }
-        });
-        return models;
-    }
-
-    /**
-     * Get the effective {@link TemplatedResource} for the current resource.
-     *
-     * @return The TemplatedResource, or the current resource if it cannot be adapted to a TemplatedResource.
-     */
-    @NotNull
-    protected Resource getEffectiveResource() {
-        if (this.resource instanceof TemplatedResource) {
-            return this.resource;
-        }
-        return Optional.ofNullable((Resource)this.resource.adaptTo(TemplatedResource.class))
-                .orElse(Optional.ofNullable((Resource)this.request.adaptTo(TemplatedResource.class))
-                .orElse(this.resource));
-    }
-
-    /*
-     * DataLayer specific methods
-     */
 
     @Override
     @NotNull

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
@@ -94,6 +94,7 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
      * @return The list of items in the container.
      */
     @NotNull
+    @Deprecated
     protected abstract List<? extends ListItem> readItems();
 
     /**
@@ -123,6 +124,7 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
     @Override
     @JsonIgnore
     @NotNull
+    @Deprecated
     public List<ListItem> getItems() {
         if (items == null) {
             items = readItems().stream().map(i -> (ListItem) i).collect(Collectors.toList());

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractPanelContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractPanelContainerImpl.java
@@ -1,5 +1,5 @@
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- ~ Copyright 2018 Adobe
+ ~ Copyright 2020 Adobe
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
@@ -15,134 +15,71 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.resource.Resource;
+import com.adobe.cq.wcm.core.components.models.PanelContainer;
+import com.adobe.cq.wcm.core.components.util.ComponentUtils;
 import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.export.json.ComponentExporter;
-import com.adobe.cq.wcm.core.components.models.Container;
 import com.adobe.cq.wcm.core.components.models.ListItem;
-import com.adobe.cq.wcm.core.components.util.ComponentUtils;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
 
 /**
  * Abstract panel container model.
  */
-public abstract class AbstractPanelContainerImpl extends AbstractContainerImpl implements Container {
+public abstract class AbstractPanelContainerImpl extends AbstractContainerImpl implements PanelContainer {
 
     /**
      * Map of the child items to be exported wherein the key is the child name, and the value is the child model.
      */
-    protected LinkedHashMap<String, ComponentExporter> itemModels;
+    private LinkedHashMap<String, ? extends ComponentExporter> itemModels;
 
     /**
      * List of child panels in this panel container.
      */
-    private List<Resource> panelItems;
+    private List<PanelContainerItemImpl> panelItems;
 
     @Override
     @NotNull
-    protected List<PanelContainerListItemImpl> readItems() {
+    @Deprecated
+    protected final List<ListItem> readItems() {
         return getChildren().stream()
-            .map(res -> new PanelContainerListItemImpl(res, getId(), component, getCurrentPage()))
+            .map(res -> new PanelContainerListItemImpl(res.getResource(), getId(), this.component, this.getCurrentPage()))
             .collect(Collectors.toList());
     }
 
-    /**
-     * Return (and cache) the list of children resources that are components
-     *
-     * @return List of all children resources that are components.
-     */
     @NotNull
-    protected List<Resource> getChildren() {
+    @Override
+    public final List<PanelContainerItemImpl> getChildren() {
         if (this.panelItems == null) {
-            this.panelItems = ComponentUtils.getChildComponents(this.resource, this.request);
+            this.panelItems = ComponentUtils.getChildComponents(this.resource, this.request).stream()
+                .map(item -> new PanelContainerItemImpl(item, this))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
         }
         return this.panelItems;
     }
 
-    @Override
     @NotNull
+    @Override
     public final LinkedHashMap<String, ? extends ComponentExporter> getExportedItems() {
         if (this.itemModels == null) {
-            this.itemModels = ComponentUtils.getComponentModels(this.slingModelFilter,
-                this.modelFactory,
-                this.getChildren(),
-                this.request,
-                ComponentExporter.class);
-            this.itemModels.entrySet().forEach(entry ->
-                getItems().stream()
-                    .filter(Objects::nonNull)
-                    .filter(item -> StringUtils.isNotEmpty(item.getName()) && StringUtils.equals(item.getName(), entry.getKey()))
-                    .findFirst()
-                    .ifPresent(match -> entry.setValue(new JsonWrapper(entry.getValue(), match)))
-            );
+            this.itemModels = this.getChildren().stream()
+                .map(i -> i.getComponentExporter(this.slingModelFilter, this.modelFactory, this.request))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(
+                    Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (a, b) -> a,
+                        LinkedHashMap::new));
         }
         return this.itemModels;
-    }
-
-    /**
-     * Wrapper class used to add specific properties of the container items to the JSON serialization of the underlying container item model
-     */
-    static class JsonWrapper implements ComponentExporter {
-
-        /**
-         * The wrapped ComponentExporter.
-         */
-        @NotNull
-        private final ComponentExporter inner;
-
-        /**
-         * The panel title.
-         */
-        private final String panelTitle;
-
-        /**
-         * Construct the wrapper.
-         *
-         * @param inner The ComponentExporter to be wrapped.
-         * @param item The panel item.
-         */
-        JsonWrapper(@NotNull final ComponentExporter inner, @NotNull final ListItem item) {
-            this.inner = inner;
-            this.panelTitle = item.getTitle();
-        }
-
-        /**
-         * Get the underlying ComponentExporter that is wrapped by this wrapper.
-         *
-         * @return the underlying container item model
-         */
-        @JsonUnwrapped
-        @NotNull
-        public ComponentExporter getInner() {
-            return this.inner;
-        }
-
-        /**
-         * Get the panel title.
-         *
-         * @return the container item title
-         */
-        @JsonProperty(PanelContainerListItemImpl.PN_PANEL_TITLE)
-        @JsonInclude()
-        public String getPanelTitle() {
-            return this.panelTitle;
-        }
-
-        @NotNull
-        @Override
-        @JsonIgnore
-        public String getExportedType() {
-            return this.inner.getExportedType();
-        }
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractPanelContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractPanelContainerImpl.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.export.json.ComponentExporter;
@@ -42,12 +43,30 @@ public abstract class AbstractPanelContainerImpl extends AbstractContainerImpl i
      */
     protected LinkedHashMap<String, ComponentExporter> itemModels;
 
+    /**
+     * List of child panels in this panel container.
+     */
+    private List<Resource> panelItems;
+
     @Override
     @NotNull
     protected List<PanelContainerListItemImpl> readItems() {
         return getChildren().stream()
             .map(res -> new PanelContainerListItemImpl(res, getId(), component, getCurrentPage()))
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Return (and cache) the list of children resources that are components
+     *
+     * @return List of all children resources that are components.
+     */
+    @NotNull
+    protected List<Resource> getChildren() {
+        if (this.panelItems == null) {
+            this.panelItems = ComponentUtils.getChildComponents(this.resource, this.request);
+        }
+        return this.panelItems;
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractPanelContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractPanelContainerImpl.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 /**
  * Abstract panel container model.
  */
-public abstract class PanelContainerImpl extends AbstractContainerImpl implements Container {
+public abstract class AbstractPanelContainerImpl extends AbstractContainerImpl implements Container {
 
     @Override
     @NotNull

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
@@ -50,7 +50,7 @@ import com.day.cq.wcm.api.designer.Style;
     name = ExporterConstants.SLING_MODEL_EXPORTER_NAME,
     extensions = ExporterConstants.SLING_MODEL_EXTENSION
 )
-public class AccordionImpl extends PanelContainerImpl implements Accordion {
+public class AccordionImpl extends AbstractPanelContainerImpl implements Accordion {
 
     /**
      * Resource type.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImpl.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import com.adobe.cq.wcm.core.components.models.Component;
-import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
@@ -131,27 +129,15 @@ public class AccordionImpl extends AbstractPanelContainerImpl implements Accordi
         return null;
     }
 
-    /*
-     * DataLayerProvider implementation of field getters
-     */
-
     @Override
     public String[] getDataLayerShownItems() {
-        if (expandedItems == null) {
-            return new String[0];
-        }
-
-        if (expandedItemIds == null) {
-            List<String> expandedItemsName = Arrays.asList(expandedItems);
-
-            expandedItemIds = this.getItems().stream()
-                .filter(item -> expandedItemsName.contains(item.getName()))
-                .map(Component::getData)
-                .filter(Objects::nonNull)
-                .map(ComponentData::getId)
+        if (this.expandedItemIds == null) {
+            List<String> expandedItemsName = Arrays.asList(this.getExpandedItems());
+            this.expandedItemIds = this.getChildren().stream()
+                .filter(item -> expandedItemsName.contains(item.getResource().getName()))
+                .map(PanelContainerItemImpl::getId)
                 .toArray(String[]::new);
         }
-
         return Arrays.copyOf(expandedItemIds, expandedItemIds.length);
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
@@ -45,7 +45,7 @@ import org.jetbrains.annotations.Nullable;
     adapters = {Carousel.class, ComponentExporter.class, ContainerExporter.class},
     resourceType = CarouselImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
-public class CarouselImpl extends PanelContainerImpl implements Carousel {
+public class CarouselImpl extends AbstractPanelContainerImpl implements Carousel {
 
     /**
      * The resource type.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
@@ -15,7 +15,6 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
-import java.util.List;
 import java.util.Optional;
 
 import javax.annotation.PostConstruct;
@@ -33,8 +32,6 @@ import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.models.Carousel;
-import com.adobe.cq.wcm.core.components.models.ListItem;
-import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -129,20 +126,11 @@ public class CarouselImpl extends AbstractPanelContainerImpl implements Carousel
         return accessibilityLabel;
     }
 
-    /*
-     * DataLayerProvider implementation of field getters
-     */
-
     @Override
     public String[] getDataLayerShownItems() {
-        String[] shownItems = new String[0];
-        List<ListItem> items = getItems();
-        if (!items.isEmpty()) {
-            ComponentData componentData = items.get(0).getData();
-            if (componentData != null) {
-                shownItems = new String[] {componentData.getId()};
-            }
-        }
-        return shownItems;
+        return this.getChildren().stream().findFirst()
+            .map(PanelContainerItemImpl::getId)
+            .map(id -> new String[] {id})
+            .orElse(null);
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ContainerItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ContainerItemImpl.java
@@ -1,0 +1,50 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1;
+
+
+import com.adobe.cq.wcm.core.components.models.ContainerItem;
+import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An individual item found within a {@link com.adobe.cq.wcm.core.components.models.Container}.
+ */
+public final class ContainerItemImpl implements ContainerItem {
+
+    /**
+     * The resource for this container item.
+     */
+    @NotNull
+    private final Resource resource;
+
+    /**
+     * Construct a container Item.
+     *
+     * @param resource The resource for this container item.
+     */
+    public ContainerItemImpl(@NotNull final Resource resource) {
+        this.resource = resource;
+    }
+
+    @Override
+    @NotNull
+    public Resource getResource() {
+        return this.resource;
+    }
+
+
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
@@ -75,7 +75,8 @@ public class LayoutContainerImpl extends AbstractContainerImpl implements Layout
 
     @Override
     @NotNull
-    protected List<ResourceListItemImpl> readItems() {
+    @Deprecated
+    protected final List<ResourceListItemImpl> readItems() {
         return getChildren().stream()
             .map(res -> new ResourceListItemImpl(res, getId(), component))
             .collect(Collectors.toList());

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
@@ -15,16 +15,17 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 
+import com.adobe.cq.export.json.ComponentExporter;
+import com.adobe.cq.wcm.core.components.util.ComponentUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.wcm.core.components.models.LayoutContainer;
@@ -41,15 +42,14 @@ public class LayoutContainerImpl extends AbstractContainerImpl implements Layout
     protected static final String RESOURCE_TYPE_V1 = "core/wcm/components/container/v1/container";
 
     /**
-     * The current resource.
-     */
-    @ScriptVariable
-    private Resource resource;
-
-    /**
      * The layout type.
      */
     private LayoutType layout;
+
+    /**
+     * Map of the child items to be exported wherein the key is the child name, and the value is the child model.
+     */
+    private LinkedHashMap<String, ComponentExporter> itemModels;
 
     /**
      * Initialize the model.
@@ -73,6 +73,19 @@ public class LayoutContainerImpl extends AbstractContainerImpl implements Layout
         return getChildren().stream()
             .map(res -> new ResourceListItemImpl(res, getId(), component))
             .collect(Collectors.toList());
+    }
+
+    @Override
+    @NotNull
+    public final LinkedHashMap<String, ? extends ComponentExporter> getExportedItems() {
+        if (this.itemModels == null) {
+            this.itemModels = ComponentUtils.getComponentModels(this.slingModelFilter,
+                this.modelFactory,
+                this.getChildren(),
+                this.request,
+                ComponentExporter.class);
+        }
+        return this.itemModels;
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
@@ -25,6 +25,7 @@ import javax.annotation.PostConstruct;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.wcm.core.components.util.ComponentUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.jetbrains.annotations.NotNull;
 
@@ -52,6 +53,11 @@ public class LayoutContainerImpl extends AbstractContainerImpl implements Layout
     private LinkedHashMap<String, ComponentExporter> itemModels;
 
     /**
+     * List of items in this container.
+     */
+    private List<Resource> items;
+
+    /**
      * Initialize the model.
      */
     @PostConstruct
@@ -73,6 +79,19 @@ public class LayoutContainerImpl extends AbstractContainerImpl implements Layout
         return getChildren().stream()
             .map(res -> new ResourceListItemImpl(res, getId(), component))
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Return (and cache) the list of children resources that are components
+     *
+     * @return List of all children resources that are components.
+     */
+    @NotNull
+    protected List<Resource> getChildren() {
+        if (this.items == null) {
+            this.items = ComponentUtils.getChildComponents(this.resource, this.request);
+        }
+        return this.items;
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerImpl.java
@@ -39,9 +39,9 @@ public abstract class PanelContainerImpl extends AbstractContainerImpl implement
 
     @Override
     @NotNull
-    protected List<PanelContainerItemImpl> readItems() {
+    protected List<PanelContainerListItemImpl> readItems() {
         return getChildren().stream()
-            .map(res -> new PanelContainerItemImpl(res, getId(), component, getCurrentPage()))
+            .map(res -> new PanelContainerListItemImpl(res, getId(), component, getCurrentPage()))
             .collect(Collectors.toList());
     }
 
@@ -102,7 +102,7 @@ public abstract class PanelContainerImpl extends AbstractContainerImpl implement
          *
          * @return the container item title
          */
-        @JsonProperty(PanelContainerItemImpl.PN_PANEL_TITLE)
+        @JsonProperty(PanelContainerListItemImpl.PN_PANEL_TITLE)
         @JsonInclude()
         public String getPanelTitle() {
             return this.panelTitle;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
@@ -1,0 +1,201 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1;
+
+import com.adobe.cq.export.json.ComponentExporter;
+import com.adobe.cq.export.json.SlingModelFilter;
+import com.adobe.cq.wcm.core.components.models.Component;
+import com.adobe.cq.wcm.core.components.models.PanelContainerItem;
+import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
+import com.adobe.cq.wcm.core.components.models.datalayer.builder.DataLayerBuilder;
+import com.adobe.cq.wcm.core.components.util.ComponentUtils;
+import com.day.cq.commons.jcr.JcrConstants;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.factory.ModelFactory;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.AbstractMap;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Optional;
+
+/**
+ * An individual panel found within a {@link com.adobe.cq.wcm.core.components.models.PanelContainer}.
+ */
+public final class PanelContainerItemImpl implements PanelContainerItem {
+
+    /**
+     * Prefix prepended to the item ID.
+     */
+    private static final String PANEL_ITEM_ID_PREFIX = "item";
+
+    /**
+     * The resource for this container item.
+     */
+    @NotNull
+    private final Resource resource;
+
+    /**
+     * The ID of this panel.
+     */
+    @NotNull
+    private final String id;
+
+    /**
+     * The data type of this panel.
+     */
+    @NotNull
+    private final String dataType;
+
+    /**
+     * Construct a panel.
+     *
+     * @param resource The container item for this panel.
+     * @param container The container component that contains this panel.
+     */
+    public PanelContainerItemImpl(@NotNull final Resource resource, @NotNull final Component container) {
+        this.resource = resource;
+        this.id = ComponentUtils.generateId(
+            StringUtils.join(container.getId(), ComponentUtils.ID_SEPARATOR, PANEL_ITEM_ID_PREFIX),
+            this.resource.getPath());
+        this.dataType =  String.join("/",
+            Optional.ofNullable(container.getData()).map(ComponentData::getType).orElseGet(container::getExportedType),
+            PANEL_ITEM_ID_PREFIX);
+    }
+
+    @Override
+    @NotNull
+    public Resource getResource() {
+        return this.resource;
+    }
+
+    @Override
+    @Nullable
+    public String getTitle() {
+        return Optional.ofNullable(this.resource.getValueMap().get(PN_PANEL_TITLE, String.class))
+            .orElseGet(() -> this.resource.getValueMap().get(JcrConstants.JCR_TITLE, String.class));
+    }
+
+    @Override
+    @NotNull
+    public String getId() {
+        return this.id;
+    }
+
+    /**
+     * Gets the last modified date of the container item resource, or the creation date if no modification date is set.
+     *
+     * @return The date that the container item resource was modified, or created, or null if neither property exists.
+     */
+    private Date getLastModifiedDate() {
+        return // Note: this can be simplified in JDK 11
+            Optional.ofNullable(resource.getValueMap().get(JcrConstants.JCR_LASTMODIFIED, Calendar.class))
+                .map(Calendar::getTime)
+                .orElseGet(() ->
+                    Optional.ofNullable(resource.getValueMap().get(JcrConstants.JCR_CREATED, Calendar.class))
+                        .map(Calendar::getTime)
+                        .orElse(null));
+    }
+
+    @Override
+    @NotNull
+    public ComponentData getData() {
+        return DataLayerBuilder.forComponent()
+            .withId(this::getId)
+            .withLastModifiedDate(this::getLastModifiedDate)
+            .withType(() -> this.dataType)
+            .withTitle(this::getTitle)
+            .build();
+    }
+
+    /**
+     * Gets the component exporter for this container item.
+     *
+     * @param slingModelFilter The sling model filter service.
+     * @param modelFactory The model factory service.
+     * @param request The current request.
+     * @return A single map entry with the resource name as the key and the component exporter as the value if the resource
+     * can be adapted to a component exporter via the model factory, empty if not.
+     */
+    public Optional<java.util.Map.Entry<String, ComponentExporter>> getComponentExporter(@NotNull final SlingModelFilter slingModelFilter,
+                                                                                         @NotNull final ModelFactory modelFactory,
+                                                                                         @NotNull SlingHttpServletRequest request) {
+        return ComponentUtils.getComponentModels(slingModelFilter, modelFactory, Collections.singletonList(this.getResource()), request, ComponentExporter.class)
+            .entrySet().stream()
+            .findFirst()
+            .map(i -> new AbstractMap.SimpleEntry<>(i.getKey(), new JsonWrapper(i.getValue())));
+
+    }
+
+    /**
+     * Wrapper class used to add specific properties of the container items to the JSON serialization of the underlying container item model
+     */
+    private final class JsonWrapper implements ComponentExporter {
+
+        /**
+         * The wrapped ComponentExporter.
+         */
+        @NotNull
+        private final ComponentExporter inner;
+
+
+        /**
+         * Construct the wrapper.
+         *
+         * @param inner The ComponentExporter to be wrapped.
+         */
+        JsonWrapper(@NotNull final ComponentExporter inner) {
+            this.inner = inner;
+        }
+
+        /**
+         * Get the underlying ComponentExporter that is wrapped by this wrapper.
+         *
+         * @return the underlying container item model
+         */
+        @JsonUnwrapped
+        @NotNull
+        public ComponentExporter getInner() {
+            return this.inner;
+        }
+
+        /**
+         * Get the panel title.
+         *
+         * @return the container item title
+         */
+        @JsonProperty(PanelContainerItemImpl.PN_PANEL_TITLE)
+        @JsonInclude()
+        public String getPanelTitle() {
+            return getTitle();
+        }
+
+        @NotNull
+        @Override
+        @JsonIgnore
+        public String getExportedType() {
+            return this.inner.getExportedType();
+        }
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerListItemImpl.java
@@ -28,6 +28,7 @@ import com.day.cq.wcm.api.components.Component;
 /**
  * Panel container item implementation.
  */
+@Deprecated
 public class PanelContainerListItemImpl extends ResourceListItemImpl implements ListItem {
 
     /**
@@ -43,6 +44,7 @@ public class PanelContainerListItemImpl extends ResourceListItemImpl implements 
      * @param component The component.
      * @param currentPage The current page.
      */
+    @Deprecated
     public PanelContainerListItemImpl(@NotNull final Resource resource, final String parentId, final Component component,
                                   final Page currentPage) {
         super(resource, parentId, component);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerListItemImpl.java
@@ -28,7 +28,7 @@ import com.day.cq.wcm.api.components.Component;
 /**
  * Panel container item implementation.
  */
-public class PanelContainerItemImpl extends ResourceListItemImpl implements ListItem {
+public class PanelContainerListItemImpl extends ResourceListItemImpl implements ListItem {
 
     /**
      * Name of the property that contains the panel item's title.
@@ -40,9 +40,11 @@ public class PanelContainerItemImpl extends ResourceListItemImpl implements List
      *
      * @param resource The resource.
      * @param parentId The ID of the containing component.
+     * @param component The component.
+     * @param currentPage The current page.
      */
-    public PanelContainerItemImpl(@NotNull final Resource resource, final String parentId, Component component,
-                                  Page currentPage) {
+    public PanelContainerListItemImpl(@NotNull final Resource resource, final String parentId, final Component component,
+                                  final Page currentPage) {
         super(resource, parentId, component);
         setCurrentPage(currentPage);
         title = Optional.ofNullable(resource.getValueMap().get(PN_PANEL_TITLE, String.class))

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
@@ -28,6 +28,7 @@ import com.day.cq.wcm.api.components.Component;
 /**
  * Resource-backed list item implementation.
  */
+@Deprecated
 public class ResourceListItemImpl extends AbstractListItemImpl implements ListItem {
 
     /**
@@ -56,6 +57,7 @@ public class ResourceListItemImpl extends AbstractListItemImpl implements ListIt
      * @param resource The resource.
      * @param parentId The ID of the containing component.
      */
+    @Deprecated
     public ResourceListItemImpl(@NotNull final Resource resource, final String parentId, final Component component) {
         super(parentId, resource, component);
         ValueMap valueMap = resource.getValueMap();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
@@ -15,38 +15,31 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
-import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.StreamSupport;
 
+import com.adobe.cq.wcm.core.components.models.PanelContainerItem;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
-import org.apache.sling.models.annotations.injectorspecific.Self;
-import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.export.json.ExporterConstants;
-import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.models.Tabs;
-import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
-import com.day.cq.wcm.api.components.ComponentManager;
 
 /**
  * Tabs model implementation.
  */
 @Model(adaptables = SlingHttpServletRequest.class,
-       adapters = {Tabs.class, ComponentExporter.class, ContainerExporter.class},
-       resourceType = TabsImpl.RESOURCE_TYPE)
+    adapters = {Tabs.class, ComponentExporter.class, ContainerExporter.class},
+    resourceType = TabsImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME,
-          extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+    extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class TabsImpl extends AbstractPanelContainerImpl implements Tabs {
 
     /**
@@ -69,59 +62,39 @@ public class TabsImpl extends AbstractPanelContainerImpl implements Tabs {
     private String accessibilityLabel;
 
     /**
-     * The current resource.
-     */
-    @SlingObject
-    private Resource resource;
-
-    /**
-     * The current request.
-     */
-    @Self
-    SlingHttpServletRequest request;
-
-    /**
      * The name of the active item.
      */
     private String activeItemName;
 
     @Override
     public String getActiveItem() {
-        if (activeItemName == null) {
+        if (this.activeItemName == null) {
             this.activeItemName = Optional.ofNullable(this.activeItem)
                 .map(resource::getChild)
                 .map(Resource::getName)
-                .orElseGet(() ->
-                    Optional.ofNullable(request.getResourceResolver().adaptTo(ComponentManager.class))
-                        .flatMap(componentManager -> StreamSupport.stream(resource.getChildren().spliterator(), false)
-                            .filter(Objects::nonNull)
-                            .filter(res -> Objects.nonNull(componentManager.getComponentOfResource(res)))
-                            .findFirst()
-                            .map(Resource::getName))
-                        .orElse(null));
+                .orElseGet(() -> this.getChildren().stream()
+                    .findFirst()
+                    .map(PanelContainerItem::getResource)
+                    .map(Resource::getName)
+                    .orElse(null));
         }
-        return activeItemName;
+        return this.activeItemName;
     }
 
     @Override
     @Nullable
     public String getAccessibilityLabel() {
-        return accessibilityLabel;
+        return this.accessibilityLabel;
     }
 
-    /*
-     * DataLayerProvider implementation of field getters
-     */
     @Override
     public String[] getDataLayerShownItems() {
         String activeItemName = getActiveItem();
-        List<ListItem> items = getItems();
-        return items.stream()
-            .filter(e -> StringUtils.equals(e.getName(), activeItemName))
+        return this.getChildren().stream()
+            .filter(e -> StringUtils.equals(e.getResource().getName(), activeItemName))
             .findFirst()
-            .map(ListItem::getData)
-            .map(ComponentData::getId)
-            .map(item -> new String[]{item})
+            .map(PanelContainerItemImpl::getId)
+            .map(id -> new String[]{id})
             .orElseGet(() -> new String[0]);
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
@@ -47,7 +47,7 @@ import com.day.cq.wcm.api.components.ComponentManager;
        resourceType = TabsImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME,
           extensions = ExporterConstants.SLING_MODEL_EXTENSION)
-public class TabsImpl extends PanelContainerImpl implements Tabs {
+public class TabsImpl extends AbstractPanelContainerImpl implements Tabs {
 
     /**
      * The resource type.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Accordion.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Accordion.java
@@ -23,7 +23,7 @@ import org.osgi.annotation.versioning.ConsumerType;
  * @since com.adobe.cq.wcm.core.components.models 12.8.0
  */
 @ConsumerType
-public interface Accordion extends Container {
+public interface Accordion extends PanelContainer {
 
     /**
      * Name of the configuration policy property that stores the default value for the accordion heading's HTML element.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
@@ -23,7 +23,7 @@ import org.osgi.annotation.versioning.ConsumerType;
  * @since com.adobe.cq.wcm.core.components.models 12.5.0
  */
 @ConsumerType
-public interface Carousel extends Container {
+public interface Carousel extends PanelContainer {
 
     /**
      * Name of the resource property that indicates whether to automatically transition between slides, or not.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Container.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Container.java
@@ -27,7 +27,11 @@ import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
 
 /**
- * A base interface to be extended by containers such as the {@link Carousel}, {@link Tabs} and {@link Accordion} models.
+ * A base interface to be extended by all containers.
+ *
+ * A container is a component that provides access to child resources.
+ * If the container contains panels, such as the {@link Carousel}, {@link Tabs} and {@link Accordion} models, then
+ * the {@link PanelContainer} class should be used instead.
  *
  * @since com.adobe.cq.wcm.core.components.models 12.5.0
  */
@@ -80,6 +84,18 @@ public interface Container extends Component, ContainerExporter {
     @Deprecated
     @JsonIgnore
     default List<ListItem> getItems() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a list of container items.
+     *
+     * @return List of container items.
+     * @since com.adobe.cq.wcm.core.components.models 12.17.0
+     */
+    @NotNull
+    @JsonIgnore
+    default List<? extends ContainerItem> getChildren() {
         throw new UnsupportedOperationException();
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Container.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Container.java
@@ -18,6 +18,7 @@ package com.adobe.cq.wcm.core.components.models;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ConsumerType;
@@ -73,8 +74,11 @@ public interface Container extends Component, ContainerExporter {
      *
      * @return List of container items
      * @since com.adobe.cq.wcm.core.components.models 12.5.0
+     * @deprecated since 12.17.0 - use {@link #getChildren()}
      */
     @NotNull
+    @Deprecated
+    @JsonIgnore
     default List<ListItem> getItems() {
         throw new UnsupportedOperationException();
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ContainerItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ContainerItem.java
@@ -1,0 +1,42 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.annotation.versioning.ConsumerType;
+
+/**
+ * Interface for a single item in a container.
+ * Every container item has at least a resource.
+ *
+ * @since com.adobe.cq.wcm.core.components.models 12.17.0
+ */
+@ConsumerType
+public interface ContainerItem {
+
+    /**
+     * Gets the resource for this container item.
+     *
+     * @return The resource for this container item.
+     */
+    @NotNull
+    @JsonIgnore
+    default Resource getResource() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/PanelContainer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/PanelContainer.java
@@ -1,5 +1,5 @@
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- ~ Copyright 2018 Adobe
+ ~ Copyright 2020 Adobe
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
@@ -15,33 +15,22 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.models;
 
+import org.jetbrains.annotations.NotNull;
 import org.osgi.annotation.versioning.ConsumerType;
 
+import java.util.List;
+
 /**
- * Defines the {@code Tabs} Sling Model used for the {@code /apps/core/wcm/components/tabs} component.
+ * A base interface for all containers that contain panels.
  *
- * @since com.adobe.cq.wcm.core.components.models 12.5.0
+ * @since com.adobe.cq.wcm.core.components.models 12.17.0
  */
 @ConsumerType
-public interface Tabs extends PanelContainer {
+public interface PanelContainer extends Container {
 
-    /**
-     * Returns the default active item
-     *
-     * @return The default active item
-     * @since com.adobe.cq.wcm.core.components.models 12.5.0
-     */
-    default String getActiveItem() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Returns an accessibility label that describes the tabs.
-     *
-     * @return an accessibility label for tabs
-     * @since com.adobe.cq.wcm.core.components.models 12.9.0
-     */
-    default String getAccessibilityLabel() {
+    @Override
+    @NotNull
+    default List<? extends PanelContainerItem> getChildren() {
         throw new UnsupportedOperationException();
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/PanelContainerItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/PanelContainerItem.java
@@ -1,0 +1,69 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.models;
+
+import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ConsumerType;
+
+/**
+ * Interface for a container item that is a panel.
+ * In addition to having a resource, a panel container item also includes a title, ID, and data layer object.
+ *
+ * @since com.adobe.cq.wcm.core.components.models 12.17.0
+ */
+@ConsumerType
+public interface PanelContainerItem extends ContainerItem {
+
+    /**
+     * Name of the property that contains the panel item's title.
+     */
+    String PN_PANEL_TITLE = "cq:panelTitle";
+
+    /**
+     * Gets the panel item's title.
+     *
+     * @return The title of the panel item.
+     */
+    @Nullable
+    default String getTitle() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Gets the ID for this panel.
+     * Note: this is not the ID of the contained item - this is the ID of the panel its self.
+     *
+     * @return The ID for this panel.
+     */
+    @NotNull
+    default String getId() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Gets the data layer object for this panel.
+     * Note: this is not the data layer object for the contained item - this is the data layer object for the panel its
+     * self.
+     *
+     * @return The data layer object for this panel.
+     */
+    @NotNull
+    default ComponentData getData() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.18.0")
+@Version("12.19.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/util/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/util/package-info.java
@@ -18,7 +18,7 @@
  *      This package defines utility classes exposed by the Adobe Experience Manager Core WCM Components Bundle.
  * </p>
  */
-@Version("1.0.0")
+@Version("1.1.0")
 package com.adobe.cq.wcm.core.components.util;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImplTest.java
@@ -16,8 +16,11 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 
+import com.adobe.cq.export.json.ComponentExporter;
 import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
@@ -59,10 +62,17 @@ public class AbstractContainerImplTest {
 
 
     private static class ContainerImpl extends AbstractContainerImpl {
+
         @Override
         @NotNull
         protected List<ListItem> readItems() {
             return new ArrayList<>();
+        }
+
+        @Override
+        @NotNull
+        public LinkedHashMap<String, ? extends ComponentExporter> getExportedItems() {
+            return new LinkedHashMap<>();
         }
 
         @Override

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImplTest.java
@@ -16,7 +16,6 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -25,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.Container;
+import com.adobe.cq.wcm.core.components.models.ContainerItem;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
@@ -56,7 +56,7 @@ public class AbstractContainerImplTest {
     @Test
     public void testEmptyContainer() {
         Container container = new ContainerImpl();
-        List<ListItem> items = container.getItems();
+        List<? extends ContainerItem> items = container.getChildren();
         assertEquals(0, items.size());
     }
 
@@ -67,6 +67,12 @@ public class AbstractContainerImplTest {
         @NotNull
         @Deprecated
         protected final List<ListItem> readItems() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @NotNull
+        public List<? extends ContainerItem> getChildren() {
             return new ArrayList<>();
         }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImplTest.java
@@ -65,7 +65,8 @@ public class AbstractContainerImplTest {
 
         @Override
         @NotNull
-        protected List<ListItem> readItems() {
+        @Deprecated
+        protected final List<ListItem> readItems() {
             return new ArrayList<>();
         }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractPanelTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractPanelTest.java
@@ -1,0 +1,62 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1;
+
+import com.adobe.cq.wcm.core.components.Utils;
+import com.adobe.cq.wcm.core.components.models.Container;
+import com.adobe.cq.wcm.core.components.models.ListItem;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Shared tests for all panel containers.
+ */
+public class AbstractPanelTest {
+
+    /**
+     * Verify the data layer for the specified container and it's children.
+     *
+     * @param container The container.
+     * @param testBase The test base.
+     * @param containerName The container name.
+     */
+    protected void verifyPanelDataLayer(Container container, String testBase, String containerName) {
+        Utils.testJSONDataLayer(container.getData(), Utils.getTestDataModelJSONPath(testBase, containerName));
+        for (ListItem item : container.getItems()) {
+            Utils.testJSONDataLayer(item.getData(), Utils.getTestDataModelJSONPath(testBase, containerName + "-" + item.getName()));
+        }
+    }
+
+    /**
+     * Verify the list items for the specified container.
+     *
+     * @param expectedItems The expected items.
+     * @param items The actual items.
+     */
+    protected void verifyContainerListItems(Object[][] expectedItems, List<ListItem> items) {
+        assertEquals(expectedItems.length, items.size(), "The container contains a different number of items than expected.");
+        int index = 0;
+        for (ListItem item : items) {
+            assertEquals(expectedItems[index][0], item.getName(), "The panel item's name is not what was expected.");
+            assertEquals(expectedItems[index][1], item.getTitle(), "The panel item's title is not what was expected: " + item.getTitle());
+            assertEquals(expectedItems[index][2], item.getId(), "The panel item's id is not what was expected: " + item.getId());
+            assertEquals(expectedItems[index][3], item.getPath(), "The panel item's path is not what was expected: " + item.getPath());
+            index++;
+        }
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractPanelTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractPanelTest.java
@@ -16,8 +16,9 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import com.adobe.cq.wcm.core.components.Utils;
-import com.adobe.cq.wcm.core.components.models.Container;
 import com.adobe.cq.wcm.core.components.models.ListItem;
+import com.adobe.cq.wcm.core.components.models.PanelContainer;
+import com.adobe.cq.wcm.core.components.models.PanelContainerItem;
 
 import java.util.List;
 
@@ -35,10 +36,28 @@ public class AbstractPanelTest {
      * @param testBase The test base.
      * @param containerName The container name.
      */
-    protected void verifyPanelDataLayer(Container container, String testBase, String containerName) {
+    protected void verifyPanelDataLayer(PanelContainer container, String testBase, String containerName) {
         Utils.testJSONDataLayer(container.getData(), Utils.getTestDataModelJSONPath(testBase, containerName));
-        for (ListItem item : container.getItems()) {
-            Utils.testJSONDataLayer(item.getData(), Utils.getTestDataModelJSONPath(testBase, containerName + "-" + item.getName()));
+        for (PanelContainerItem item : container.getChildren()) {
+            Utils.testJSONDataLayer(item.getData(), Utils.getTestDataModelJSONPath(testBase, containerName + "-" + item.getResource().getName()));
+        }
+    }
+
+    /**
+     * Verify the panel container items items for the specified container.
+     *
+     * @param expectedItems The expected items.
+     * @param items The actual items.
+     */
+    protected void verifyContainerItems(Object[][] expectedItems, List<? extends PanelContainerItem> items) {
+        assertEquals(expectedItems.length, items.size(), "The tabs contains a different number of items than expected.");
+        int index = 0;
+        for (PanelContainerItem item : items) {
+            assertEquals(expectedItems[index][0], item.getResource().getName(), "The panel item's name is not what was expected.");
+            assertEquals(expectedItems[index][1], item.getTitle(), "The panel item's title is not what was expected: " + item.getTitle());
+            assertEquals(expectedItems[index][2], item.getId(), "The panel item's id is not what was expected: " + item.getId());
+            assertEquals(expectedItems[index][3], item.getResource().getPath(), "The panel item's path is not what was expected: " + item.getResource().getPath());
+            index++;
         }
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImplTest.java
@@ -65,6 +65,7 @@ class AccordionImplTest extends AbstractPanelTest {
                 {"item_2", "Accordion Panel 2", "accordion-dbb1cb7797-item-2761bc217f", ACCORDION_1 + "/item_2"},
         };
         verifyContainerListItems(expectedItems, accordion.getItems());
+        verifyContainerItems(expectedItems, accordion.getChildren());
         assertArrayEquals(new String[]{"item_2"}, accordion.getExpandedItems());
         assertFalse(accordion.isSingleExpansion());
         Utils.testJSONExport(accordion, Utils.getTestExporterJSONPath(TEST_BASE, "accordion1"));

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AccordionImplTest.java
@@ -15,8 +15,6 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
-import java.util.List;
-
 import org.apache.sling.api.resource.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +23,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.Accordion;
-import com.adobe.cq.wcm.core.components.models.ListItem;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
@@ -35,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
-class AccordionImplTest {
+class AccordionImplTest extends AbstractPanelTest {
 
     private static final String TEST_BASE = "/accordion";
     private static final String TEST_ROOT_PAGE = "/content";
@@ -64,13 +61,14 @@ class AccordionImplTest {
     void testAccordionWithItems() {
         Accordion accordion = getAccordionUnderTest(ACCORDION_1);
         Object[][] expectedItems = {
-                {"item_1", "Accordion Item 1"},
-                {"item_2", "Accordion Panel 2"},
+                {"item_1", "Accordion Item 1", "accordion-dbb1cb7797-item-abc04b451e", ACCORDION_1 + "/item_1"},
+                {"item_2", "Accordion Panel 2", "accordion-dbb1cb7797-item-2761bc217f", ACCORDION_1 + "/item_2"},
         };
-        verifyAccordionItems(expectedItems, accordion.getItems());
+        verifyContainerListItems(expectedItems, accordion.getItems());
         assertArrayEquals(new String[]{"item_2"}, accordion.getExpandedItems());
         assertFalse(accordion.isSingleExpansion());
         Utils.testJSONExport(accordion, Utils.getTestExporterJSONPath(TEST_BASE, "accordion1"));
+        verifyPanelDataLayer(accordion, TEST_BASE, "accordion1");
     }
 
     @Test
@@ -83,10 +81,10 @@ class AccordionImplTest {
     void testAccordionSingleExpansion() {
         Accordion accordion = getAccordionUnderTest(ACCORDION_3);
         Object[][] expectedItems = {
-                {"item_1", "Accordion Item 1"},
-                {"item_2", "Accordion Panel 2"},
+                {"item_1", "Accordion Item 1", "accordion-96bc1a6527-item-30a13c07d8", ACCORDION_3 + "/item_1"},
+                {"item_2", "Accordion Panel 2", "accordion-96bc1a6527-item-831c5ecd0f", ACCORDION_3 + "/item_2"},
         };
-        verifyAccordionItems(expectedItems, accordion.getItems());
+        verifyContainerListItems(expectedItems, accordion.getItems());
         assertArrayEquals(new String[]{"item_2"}, accordion.getExpandedItems());
         assertTrue(accordion.isSingleExpansion());
         Utils.testJSONExport(accordion, Utils.getTestExporterJSONPath(TEST_BASE, "accordion3"));
@@ -99,15 +97,5 @@ class AccordionImplTest {
             context.contentPolicyMapping(resource.getResourceType(), properties);
         }
         return context.request().adaptTo(Accordion.class);
-    }
-
-    private void verifyAccordionItems(Object[][] expectedItems, List<ListItem> items) {
-        assertEquals(expectedItems.length, items.size(), "The accordion contains a different number of items than expected.");
-        int index = 0;
-        for (ListItem item : items) {
-            assertEquals(expectedItems[index][0], item.getName(), "The accordion item's name is not what was expected.");
-            assertEquals(expectedItems[index][1], item.getTitle(), "The accordion item's title is not what was expected: " + item.getTitle());
-            index++;
-        }
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImplTest.java
@@ -72,6 +72,7 @@ class CarouselImplTest extends AbstractPanelTest {
                 { "item_3", "Carousel Panel 3", "carousel-c39ba25916-item-aeaad4f462", CAROUSEL_1 + "/item_3" },
         };
         verifyContainerListItems(expectedItems, carousel.getItems());
+        verifyContainerItems(expectedItems, carousel.getChildren());
         Utils.testJSONExport(carousel, Utils.getTestExporterJSONPath(TEST_BASE, "carousel1"));
         verifyPanelDataLayer(carousel, TEST_BASE, "carousel1");
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImplTest.java
@@ -15,7 +15,6 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
-import java.util.List;
 import java.util.Objects;
 
 import org.apache.sling.api.scripting.SlingBindings;
@@ -30,19 +29,18 @@ import com.adobe.cq.sightly.WCMBindings;
 import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.Carousel;
-import com.adobe.cq.wcm.core.components.models.ListItem;
-import com.adobe.cq.wcm.core.components.util.ComponentUtils;
 import com.day.cq.wcm.api.components.Component;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
 @ExtendWith(AemContextExtension.class)
-class CarouselImplTest {
+class CarouselImplTest extends AbstractPanelTest {
 
     private static final String TEST_BASE = "/carousel";
     private static final String CONTENT_ROOT = "/content";
@@ -69,14 +67,13 @@ class CarouselImplTest {
     void testCarouselWithItems() {
         Carousel carousel = getCarouselUnderTest(CAROUSEL_1);
         Object[][] expectedItems = {
-                { "item_1", "Teaser 1", "cq:Component/item",
-                        "/content/carousel/jcr:content/root/responsivegrid/carousel-1/item_1" },
-                { "item_2", "Teaser 2", "cq:Component/item",
-                        "/content/carousel/jcr:content/root/responsivegrid/carousel-1/item_2" },
-                { "item_3", "Carousel Panel 3", "cq:Component/item",
-                        "/content/carousel/jcr:content/root/responsivegrid/carousel-1/item_3" }, };
-        verifyCarouselItems(expectedItems, carousel.getItems(), carousel.getId());
+                { "item_1", "Teaser 1", "carousel-c39ba25916-item-6204f971ea", CAROUSEL_1 + "/item_1" },
+                { "item_2", "Teaser 2", "carousel-c39ba25916-item-7d7da28085", CAROUSEL_1 + "/item_2" },
+                { "item_3", "Carousel Panel 3", "carousel-c39ba25916-item-aeaad4f462", CAROUSEL_1 + "/item_3" },
+        };
+        verifyContainerListItems(expectedItems, carousel.getItems());
         Utils.testJSONExport(carousel, Utils.getTestExporterJSONPath(TEST_BASE, "carousel1"));
+        verifyPanelDataLayer(carousel, TEST_BASE, "carousel1");
     }
 
     @Test
@@ -97,24 +94,5 @@ class CarouselImplTest {
         slingBindings.put(WCMBindings.COMPONENT, component);
         request.setAttribute(SlingBindings.class.getName(), slingBindings);
         return context.request().adaptTo(Carousel.class);
-    }
-
-    private void verifyCarouselItems(Object[][] expectedItems, List<ListItem> items, String carouselId) {
-        assertEquals(expectedItems.length, items.size(), "The carousel contains a different number of items than expected.");
-        int index = 0;
-        for (ListItem item : items) {
-            assertEquals(expectedItems[index][0], item.getName(), "The carousel item's name is not what was expected.");
-            assertEquals(expectedItems[index][1], item.getTitle(), "The carousel item's title is not what was expected: " + item.getTitle());
-            assertEquals(expectedItems[index][3], item.getPath(), "The carousel item's path is not what was expected: " + item.getPath());
-
-            if (item.getData() != null) {
-                assertNotEquals(item.getData().getJson(), "{}", "The carousel item's data layer string is empty");
-                assertEquals(expectedItems[index][1], item.getData().getTitle(), "The carousel item's data layer title is not what was expected: " + item.getData().getTitle());
-                assertEquals(expectedItems[index][2], item.getData().getType(), "The carousel item's data layer type is not what was expected: " + item.getData().getType());
-                assertEquals(ComponentUtils.generateId(carouselId + "-item", (String) expectedItems[index][3]),
-                        item.getData().getId(), "The carousel item's data layer id is not what was expected: " + item.getData().getId());
-            }
-            index++;
-        }
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImplTest.java
@@ -16,18 +16,17 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.testing.mock.osgi.MapUtil;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
-import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.models.Tabs;
 import com.day.cq.wcm.api.Page;
 import io.wcm.testing.mock.aem.junit5.AemContext;
@@ -39,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(AemContextExtension.class)
-class TabsImplTest {
+class TabsImplTest extends AbstractPanelTest {
 
     private static final String TEST_BASE = "/tabs";
     private static final String CONTENT_ROOT = "/content";
@@ -65,36 +64,40 @@ class TabsImplTest {
         Tabs tabs = getTabsUnderTest(TABS_EMPTY);
         assertEquals(0, tabs.getItems().size());
         Utils.testJSONExport(tabs, Utils.getTestExporterJSONPath(TEST_BASE, "tabs0"));
+        Utils.testJSONDataLayer(tabs.getData(), Utils.getTestDataModelJSONPath(TEST_BASE, "tabs0"));
     }
 
     @Test
     void testTabsWithItems() {
         Tabs tabs = getTabsUnderTest(TABS_1);
         Object[][] expectedItems = {
-            {"item_1", "Tab 1"},
-            {"item_2", "Tab Panel 2"},
+            {"item_1", "Tab 1", "tabs-3dc934841b-item-b69b839e33", TABS_1 + "/item_1"},
+            {"item_2", "Tab Panel 2", "tabs-3dc934841b-item-7fea3384a5", TABS_1 + "/item_2"},
         };
-        verifyTabItems(expectedItems, tabs.getItems());
+        verifyContainerListItems(expectedItems, tabs.getItems());
         assertEquals("item_2", tabs.getActiveItem());
         Utils.testJSONExport(tabs, Utils.getTestExporterJSONPath(TEST_BASE, "tabs1"));
+        verifyPanelDataLayer(tabs, TEST_BASE, "tabs1");
     }
 
     @Test
     void testTabsWithNestedTabs() {
         Tabs tabs = getTabsUnderTest(TABS_2);
         Utils.testJSONExport(tabs, Utils.getTestExporterJSONPath(TEST_BASE, "tabs2"));
+        Utils.testJSONDataLayer(tabs.getData(), Utils.getTestDataModelJSONPath(TEST_BASE, "tabs2"));
     }
 
     @Test
     void testTabsDefaultActiveItem() {
         Tabs tabs = getTabsUnderTest(TABS_3);
         Object[][] expectedItems = {
-            {"item_1", "Tab 1"},
-            {"item_2", "Tab Panel 2"},
+            {"item_1", "Tab 1", "tabs-73c57b3627-item-25f537bb7f", TABS_3 + "/item_1"},
+            {"item_2", "Tab Panel 2", "tabs-73c57b3627-item-e7df981a47", TABS_3 + "/item_2"},
         };
-        verifyTabItems(expectedItems, tabs.getItems());
+        verifyContainerListItems(expectedItems, tabs.getItems());
         assertEquals("item_1", tabs.getActiveItem());
         Utils.testJSONExport(tabs, Utils.getTestExporterJSONPath(TEST_BASE, "tabs3"));
+        verifyPanelDataLayer(tabs, TEST_BASE, "tabs3");
     }
 
     @Test
@@ -159,16 +162,6 @@ class TabsImplTest {
         context.currentResource(resourcePath);
         context.request().setContextPath(CONTEXT_PATH);
         return context.request().adaptTo(Tabs.class);
-    }
-
-    private void verifyTabItems(Object[][] expectedItems, List<ListItem> items) {
-        assertEquals(expectedItems.length, items.size(), "The tabs contains a different number of items than expected.");
-        int index = 0;
-        for (ListItem item : items) {
-            assertEquals(expectedItems[index][0], item.getName(), "The tabs item's name is not what was expected.");
-            assertEquals(expectedItems[index][1], item.getTitle(), "The tabs item's title is not what was expected: " + item.getTitle());
-            index++;
-        }
     }
 
     private Resource createTabsResource(Object... properties) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImplTest.java
@@ -75,6 +75,7 @@ class TabsImplTest extends AbstractPanelTest {
             {"item_2", "Tab Panel 2", "tabs-3dc934841b-item-7fea3384a5", TABS_1 + "/item_2"},
         };
         verifyContainerListItems(expectedItems, tabs.getItems());
+        verifyContainerItems(expectedItems, tabs.getChildren());
         assertEquals("item_2", tabs.getActiveItem());
         Utils.testJSONExport(tabs, Utils.getTestExporterJSONPath(TEST_BASE, "tabs1"));
         verifyPanelDataLayer(tabs, TEST_BASE, "tabs1");
@@ -95,6 +96,7 @@ class TabsImplTest extends AbstractPanelTest {
             {"item_2", "Tab Panel 2", "tabs-73c57b3627-item-e7df981a47", TABS_3 + "/item_2"},
         };
         verifyContainerListItems(expectedItems, tabs.getItems());
+        verifyContainerItems(expectedItems, tabs.getChildren());
         assertEquals("item_1", tabs.getActiveItem());
         Utils.testJSONExport(tabs, Utils.getTestExporterJSONPath(TEST_BASE, "tabs3"));
         verifyPanelDataLayer(tabs, TEST_BASE, "tabs3");

--- a/bundles/core/src/test/resources/accordion/data-accordion1-item_1.json
+++ b/bundles/core/src/test/resources/accordion/data-accordion1-item_1.json
@@ -1,0 +1,6 @@
+{
+    "accordion-dbb1cb7797-item-abc04b451e": {
+        "@type": "cq:Component/item",
+        "dc:title": "Accordion Item 1"
+    }
+}

--- a/bundles/core/src/test/resources/accordion/data-accordion1-item_1.json
+++ b/bundles/core/src/test/resources/accordion/data-accordion1-item_1.json
@@ -1,6 +1,6 @@
 {
     "accordion-dbb1cb7797-item-abc04b451e": {
-        "@type": "cq:Component/item",
+        "@type": "core/wcm/components/accordion/v1/accordion/item",
         "dc:title": "Accordion Item 1"
     }
 }

--- a/bundles/core/src/test/resources/accordion/data-accordion1-item_2.json
+++ b/bundles/core/src/test/resources/accordion/data-accordion1-item_2.json
@@ -1,0 +1,6 @@
+{
+    "accordion-dbb1cb7797-item-2761bc217f": {
+        "@type": "cq:Component/item",
+        "dc:title": "Accordion Panel 2"
+    }
+}

--- a/bundles/core/src/test/resources/accordion/data-accordion1-item_2.json
+++ b/bundles/core/src/test/resources/accordion/data-accordion1-item_2.json
@@ -1,6 +1,6 @@
 {
     "accordion-dbb1cb7797-item-2761bc217f": {
-        "@type": "cq:Component/item",
+        "@type": "core/wcm/components/accordion/v1/accordion/item",
         "dc:title": "Accordion Panel 2"
     }
 }

--- a/bundles/core/src/test/resources/accordion/data-accordion1.json
+++ b/bundles/core/src/test/resources/accordion/data-accordion1.json
@@ -1,0 +1,8 @@
+{
+    "accordion-dbb1cb7797": {
+        "shownItems": [
+            "accordion-dbb1cb7797-item-2761bc217f"
+        ],
+        "@type": "core/wcm/components/accordion/v1/accordion"
+    }
+}

--- a/bundles/core/src/test/resources/carousel/data-carousel1-item_1.json
+++ b/bundles/core/src/test/resources/carousel/data-carousel1-item_1.json
@@ -1,6 +1,6 @@
 {
     "carousel-c39ba25916-item-6204f971ea": {
-        "@type": "cq:Component/item",
+        "@type": "core/wcm/components/carousel/v1/carousel/item",
         "dc:title": "Teaser 1"
     }
 }

--- a/bundles/core/src/test/resources/carousel/data-carousel1-item_1.json
+++ b/bundles/core/src/test/resources/carousel/data-carousel1-item_1.json
@@ -1,0 +1,6 @@
+{
+    "carousel-c39ba25916-item-6204f971ea": {
+        "@type": "cq:Component/item",
+        "dc:title": "Teaser 1"
+    }
+}

--- a/bundles/core/src/test/resources/carousel/data-carousel1-item_2.json
+++ b/bundles/core/src/test/resources/carousel/data-carousel1-item_2.json
@@ -1,6 +1,6 @@
 {
     "carousel-c39ba25916-item-7d7da28085": {
-        "@type": "cq:Component/item",
+        "@type": "core/wcm/components/carousel/v1/carousel/item",
         "dc:title": "Teaser 2"
     }
 }

--- a/bundles/core/src/test/resources/carousel/data-carousel1-item_2.json
+++ b/bundles/core/src/test/resources/carousel/data-carousel1-item_2.json
@@ -1,0 +1,6 @@
+{
+    "carousel-c39ba25916-item-7d7da28085": {
+        "@type": "cq:Component/item",
+        "dc:title": "Teaser 2"
+    }
+}

--- a/bundles/core/src/test/resources/carousel/data-carousel1-item_3.json
+++ b/bundles/core/src/test/resources/carousel/data-carousel1-item_3.json
@@ -1,0 +1,6 @@
+{
+    "carousel-c39ba25916-item-aeaad4f462": {
+        "@type": "cq:Component/item",
+        "dc:title": "Carousel Panel 3"
+    }
+}

--- a/bundles/core/src/test/resources/carousel/data-carousel1-item_3.json
+++ b/bundles/core/src/test/resources/carousel/data-carousel1-item_3.json
@@ -1,6 +1,6 @@
 {
     "carousel-c39ba25916-item-aeaad4f462": {
-        "@type": "cq:Component/item",
+        "@type": "core/wcm/components/carousel/v1/carousel/item",
         "dc:title": "Carousel Panel 3"
     }
 }

--- a/bundles/core/src/test/resources/carousel/data-carousel1.json
+++ b/bundles/core/src/test/resources/carousel/data-carousel1.json
@@ -1,0 +1,8 @@
+{
+    "carousel-c39ba25916": {
+        "shownItems": [
+            "carousel-c39ba25916-item-6204f971ea"
+        ],
+        "@type": "core/wcm/components/carousel/v1/carousel"
+    }
+}

--- a/bundles/core/src/test/resources/tabs/data-tabs0.json
+++ b/bundles/core/src/test/resources/tabs/data-tabs0.json
@@ -1,0 +1,6 @@
+{
+    "tabs-3bd052d24e": {
+        "shownItems": [],
+        "@type": "core/wcm/components/tabs/v1/tabs"
+    }
+}

--- a/bundles/core/src/test/resources/tabs/data-tabs1-item_1.json
+++ b/bundles/core/src/test/resources/tabs/data-tabs1-item_1.json
@@ -1,0 +1,6 @@
+{
+    "tabs-3dc934841b-item-b69b839e33": {
+        "@type": "core/wcm/components/tabs/v1/tabs/item",
+        "dc:title": "Tab 1"
+    }
+}

--- a/bundles/core/src/test/resources/tabs/data-tabs1-item_2.json
+++ b/bundles/core/src/test/resources/tabs/data-tabs1-item_2.json
@@ -1,0 +1,6 @@
+{
+    "tabs-3dc934841b-item-7fea3384a5": {
+        "@type": "core/wcm/components/tabs/v1/tabs/item",
+        "dc:title": "Tab Panel 2"
+    }
+}

--- a/bundles/core/src/test/resources/tabs/data-tabs1.json
+++ b/bundles/core/src/test/resources/tabs/data-tabs1.json
@@ -1,0 +1,8 @@
+{
+    "tabs-3dc934841b": {
+        "shownItems": [
+            "tabs-3dc934841b-item-7fea3384a5"
+        ],
+        "@type": "core/wcm/components/tabs/v1/tabs"
+    }
+}

--- a/bundles/core/src/test/resources/tabs/data-tabs2.json
+++ b/bundles/core/src/test/resources/tabs/data-tabs2.json
@@ -1,0 +1,8 @@
+{
+    "tabs-673620f4d1": {
+        "shownItems": [
+            "tabs-673620f4d1-item-0ae34790af"
+        ],
+        "@type": "core/wcm/components/tabs/v1/tabs"
+    }
+}

--- a/bundles/core/src/test/resources/tabs/data-tabs3-item_1.json
+++ b/bundles/core/src/test/resources/tabs/data-tabs3-item_1.json
@@ -1,0 +1,7 @@
+{
+    "tabs-73c57b3627-item-25f537bb7f": {
+        "@type": "core/wcm/components/tabs/v1/tabs/item",
+        "repo:modifyDate": "2016-07-27T13:17:43Z",
+        "dc:title": "Tab 1"
+    }
+}

--- a/bundles/core/src/test/resources/tabs/data-tabs3-item_2.json
+++ b/bundles/core/src/test/resources/tabs/data-tabs3-item_2.json
@@ -1,0 +1,6 @@
+{
+    "tabs-73c57b3627-item-e7df981a47": {
+        "@type": "core/wcm/components/tabs/v1/tabs/item",
+        "dc:title": "Tab Panel 2"
+    }
+}

--- a/bundles/core/src/test/resources/tabs/data-tabs3.json
+++ b/bundles/core/src/test/resources/tabs/data-tabs3.json
@@ -1,0 +1,8 @@
+{
+    "tabs-73c57b3627": {
+        "shownItems": [
+            "tabs-73c57b3627-item-25f537bb7f"
+        ],
+        "@type": "core/wcm/components/tabs/v1/tabs"
+    }
+}

--- a/bundles/core/src/test/resources/tabs/test-content.json
+++ b/bundles/core/src/test/resources/tabs/test-content.json
@@ -157,6 +157,7 @@
                             "jcr:primaryType"   : "nt:unstructured",
                             "jcr:title"         : "Tab 1",
                             "jcr:description"   : "Tab 1 description",
+                            "jcr:lastModified"  : "Wed Jul 27 2016 16:17:43 GMT+0300",
                             "sling:resourceType": "core/wcm/components/responsivegrid",
                             "item_1_1": {
                                 "jcr:primaryType"   : "nt:unstructured",

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/accordion.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/accordion.html
@@ -20,30 +20,30 @@
      data-cmp-data-layer="${accordion.data.json}"
      data-cmp-single-expansion="${accordion.singleExpansion}"
      data-placeholder-text="${wcmmode.edit && 'Please drag Accordion item components here' @ i18n}">
-    <div data-sly-test="${accordion.items.size > 0}"
-         data-sly-repeat.item="${accordion.items}"
+    <div data-sly-test="${accordion.children.size > 0}"
+         data-sly-repeat.item="${accordion.children}"
          class="cmp-accordion__item"
          data-cmp-hook-accordion="item"
          data-cmp-data-layer="${item.data.json}"
          id="${item.id}"
-         data-cmp-expanded="${item.name in accordion.expandedItems}">
+         data-cmp-expanded="${item.resource.name in accordion.expandedItems}">
         <h3 data-sly-element="${accordion.headingElement @ context='elementName'}"
             class="cmp-accordion__header">
             <button id="${item.id}-button"
-                    class="cmp-accordion__button${item.name in accordion.expandedItems ? ' cmp-accordion__button--expanded' : ''}"
+                    class="cmp-accordion__button${item.resource.name in accordion.expandedItems ? ' cmp-accordion__button--expanded' : ''}"
                     aria-controls="${item.id}-panel"
                     data-cmp-hook-accordion="button">
                 <span class="cmp-accordion__title">${item.title}</span>
                 <span class="cmp-accordion__icon"></span>
             </button>
         </h3>
-        <div data-sly-resource="${item.name @ decorationTagName='div'}"
+        <div data-sly-resource="${item.resource @ decorationTagName='div'}"
              data-cmp-hook-accordion="panel"
              id="${item.id}-panel"
-             class="cmp-accordion__panel${item.name in accordion.expandedItems ? ' cmp-accordion__panel--expanded' : ' cmp-accordion__panel--hidden'}"
+             class="cmp-accordion__panel${item.resource.name in accordion.expandedItems ? ' cmp-accordion__panel--expanded' : ' cmp-accordion__panel--hidden'}"
              role="region"
              aria-labelledby="${item.id}-button"></div>
     </div>
     <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
-         data-sly-test="${(wcmmode.edit || wcmmode.preview) && accordion.items.size < 1}"></sly>
+         data-sly-test="${(wcmmode.edit || wcmmode.preview) && accordion.children.size < 1}"></sly>
 </div>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -14,7 +14,6 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.carousel="com.adobe.cq.wcm.core.components.models.Carousel"
-     data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      id="${carousel.id}"
      class="cmp-carousel"
      role="group"
@@ -27,17 +26,17 @@
      data-cmp-autopause-disabled="${carousel.autopauseDisabled}"
      data-cmp-data-layer="${carousel.data.json}"
      data-placeholder-text="${wcmmode.edit && 'Please add Carousel components here' @ i18n}">
-    <div data-sly-test="${carousel.items && carousel.items.size > 0}"
+    <div data-sly-test="${carousel.children && carousel.children.size > 0}"
          class="cmp-carousel__content"
          aria-atomic="false"
          aria-live="${carousel.autoplay ? 'off' : 'polite'}">
-        <div data-sly-repeat.item="${carousel.items}"
-             data-sly-resource="${item.name @ decorationTagName='div'}"
+        <div data-sly-repeat.item="${carousel.children}"
+             data-sly-resource="${item.resource @ decorationTagName='div'}"
              id="${item.id}"
              class="cmp-carousel__item${itemList.first ? ' cmp-carousel__item--active' : ''}"
              role="tabpanel"
              aria-roledescription="slide"
-             aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.items.size], i18n}"
+             aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.children.size], i18n}"
              data-cmp-data-layer="${item.data.json}"
              data-cmp-hook-carousel="item"></div>
         <div class="cmp-carousel__actions">
@@ -76,7 +75,7 @@
             role="tablist"
             aria-label="${'Choose a slide to display' @ i18n}"
             data-cmp-hook-carousel="indicators">
-            <li data-sly-repeat.item="${carousel.items}"
+            <li data-sly-repeat.item="${carousel.children}"
                 class="cmp-carousel__indicator${itemList.first ? ' cmp-carousel__indicator--active' : ''}"
                 role="tab"
                 aria-controls="${carousel.id}-item-${itemList.index}"
@@ -85,5 +84,5 @@
         </ol>
     </div>
     <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
-         data-sly-test="${(wcmmode.edit || wcmmode.preview) && carousel.items.size < 1}"></sly>
+         data-sly-test="${(wcmmode.edit || wcmmode.preview) && carousel.children.size < 1}"></sly>
 </div>

--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/container.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/container.html
@@ -17,7 +17,7 @@
     <sly data-sly-test.responsive="${container.layout == 'RESPONSIVE_GRID'}"
          data-sly-use.responsiveGridTemplate="responsiveGrid.html"
          data-sly-call="${responsiveGridTemplate.responsiveGrid @ container=container}"></sly>
-    <sly data-sly-test.simple="${!responsive}"
+    <sly data-sly-test="${!responsive}"
          data-sly-use.simpleTemplate="simple.html"
          data-sly-call="${simpleTemplate.simple @ container=container}"></sly>
 </sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/simple.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/simple.html
@@ -15,8 +15,7 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <template data-sly-template.simple="${ @ container}">
     <sly data-sly-test="${wcmmode.edit}" data-sly-use.allowed="com.day.cq.wcm.foundation.AllowedComponentList"></sly>
-    <div data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-         id="${container.id}"
+    <div id="${container.id}"
          class="cmp-container${wcmmode.edit ? ' {0}': '' @ format=[allowed.cssClass]}"
          style="${container.backgroundStyle @ context='styleString'}">
         <sly data-sly-test.isAllowedApplicable="${allowed.isApplicable}"
@@ -24,7 +23,7 @@
              data-sly-use.allowedTemplate="allowedcomponents.html"
              data-sly-call="${allowedTemplate.allowedcomponents @ title=allowed.title, components=allowed.components}"></sly>
         <sly data-sly-test="${!isAllowedApplicable}"
-             data-sly-repeat="${container.items}" data-sly-resource="${item.path @ decoration=true}"></sly>
+             data-sly-repeat="${container.children}" data-sly-resource="${item.resource @ decoration=true}"></sly>
         <sly data-sly-test="${!isAllowedApplicable && !wcmmode.disabled}"
              data-sly-resource="${resource.path @ resourceType='core/wcm/components/container/v1/container/new', appendPath='/*', decorationTagName='div', cssClassName='new section'}" />
     </div>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/body.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/body.html
@@ -15,4 +15,4 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <sly data-sly-use.templatedContainer="com.day.cq.wcm.foundation.TemplatedContainer"
      data-sly-repeat.child="${templatedContainer.structureResources}"
-     data-sly-resource="${child.path @ resourceType=child.resourceType, decorationTagName='div'}"></sly>
+     data-sly-resource="${child @ resourceType=child.resourceType, decorationTagName='div'}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
@@ -14,35 +14,34 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.tabs="com.adobe.cq.wcm.core.components.models.Tabs"
-     data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      id="${tabs.id}"
      class="cmp-tabs"
      data-cmp-is="tabs"
      data-cmp-data-layer="${tabs.data.json}"
      data-placeholder-text="${wcmmode.edit && 'Please drag Tab components here' @ i18n}">
-    <ol data-sly-test="${tabs.items && tabs.items.size > 0}"
-        data-sly-list.tab="${tabs.items}"
+    <ol data-sly-test="${tabs.children && tabs.children.size > 0}"
+        data-sly-list.tab="${tabs.children}"
         role="tablist"
         class="cmp-tabs__tablist"
         aria-label="${tabs.accessibilityLabel}"
         aria-multiselectable="false">
-        <sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
-        <li role="tab"
+        <li data-sly-set.isActive="${tab.resource.name == tabs.activeItem}"
+            role="tab"
             id="${tab.id}-tab"
             class="cmp-tabs__tab${isActive ? ' cmp-tabs__tab--active' : ''}"
             aria-controls="${tab.id}-tabpanel"
             tabindex="${isActive ? '0' : '-1'}"
             data-cmp-hook-tabs="tab">${tab.title}</li>
     </ol>
-    <div data-sly-repeat.item="${tabs.items}"
-         data-sly-resource="${item.name @ decorationTagName='div'}"
+    <div data-sly-repeat.item="${tabs.children}"
+         data-sly-resource="${item.resource @ decorationTagName='div'}"
          id="${item.id}"
          role="tabpanel"
          aria-labelledby="${item.id}"
          tabindex="0"
-         class="cmp-tabs__tabpanel${item.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
+         class="cmp-tabs__tabpanel${item.resource.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
          data-cmp-hook-tabs="tabpanel"
          data-cmp-data-layer="${item.data.json}"></div>
     <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
-         data-sly-test="${(wcmmode.edit || wcmmode.preview) && tabs.items.size < 1}"></sly>
+         data-sly-test="${(wcmmode.edit || wcmmode.preview) && tabs.children.size < 1}"></sly>
 </div>

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/sidebar/simple.amp.html
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/sidebar/simple.amp.html
@@ -18,7 +18,7 @@
     <button on="tap:${container.id @ context = 'attribute'}.toggle" class="cmp-examples-show-menu cmp-examples-button" data-cmp-examples-is="showMenu" aria-label="${'Show Menu' @ i18n}">
         <i class="cmp-examples-show-menu--mid-line"></i>
     </button>
-    <amp-sidebar data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+    <amp-sidebar
         layout="nodisplay"
         id="${container.id}"
         class="cmp-container${wcmmode.edit ? ' {0}': '' @ format=[allowed.cssClass]}"
@@ -28,7 +28,7 @@
              data-sly-use.allowedTemplate="allowedcomponents.html"
              data-sly-call="${allowedTemplate.allowedcomponents @ title=allowed.title, components=allowed.components}"></sly>
         <sly data-sly-test="${!isAllowedApplicable}"
-             data-sly-repeat="${container.items}" data-sly-resource="${item.path @ decoration=true}"></sly>
+             data-sly-repeat="${container.children}" data-sly-resource="${item.resource @ decoration=true}"></sly>
         <sly data-sly-test="${!isAllowedApplicable && !wcmmode.disabled}"
              data-sly-resource="${resource.path @ resourceType='core/wcm/components/container/v1/container/new', appendPath='/*', decorationTagName='div', cssClassName='new section'}" />
     </amp-sidebar>

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/accordion/v1/accordion/amp.html
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/accordion/v1/accordion/amp.html
@@ -14,18 +14,18 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <amp-accordion data-sly-use.accordion="com.adobe.cq.wcm.core.components.models.Accordion"
-               data-sly-test="${accordion.items && accordion.items.size > 0}"
+               data-sly-test="${accordion.children && accordion.children.size > 0}"
                class="cmp-accordion"
                expand-single-section="${accordion.singleExpansion}">
-    <section data-sly-repeat.item="${accordion.items}"
+    <section data-sly-repeat.item="${accordion.children}"
              class="cmp-accordion__item"
-             expanded="${item.name in accordion.expandedItems}">
+             expanded="${item.resource.name in accordion.expandedItems}">
         <h3 data-sly-element="${accordion.headingElement @ context='elementName'}"
             class="cmp-accordion__header">
             <span class="cmp-accordion__title">${item.title}</span>
             <span class="cmp-accordion__icon"></span>
         </h3>
-        <div data-sly-resource="${item.name @ decorationTagName='div'}"
+        <div data-sly-resource="${item.resource @ decorationTagName='div'}"
              class="cmp-accordion__panel"
              role="region"></div>
     </section>

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/carousel/v1/carousel/amp.html
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/carousel/v1/carousel/amp.html
@@ -14,8 +14,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <amp-carousel data-sly-use.carousel="com.adobe.cq.wcm.core.components.models.Carousel"
-              data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-              data-sly-test="${carousel.items && carousel.items.size > 0}"
+              data-sly-test="${carousel.children && carousel.children.size > 0}"
               class="cmp-carousel"
               role="group"
               aria-label="${carousel.accessibilityLabel}"
@@ -26,9 +25,9 @@
               layout="responsive"
               width="350"
               height="200">
-    <div data-sly-repeat.item="${carousel.items}"
-         data-sly-resource="${item.name @ decorationTagName='div', selectors='amp'}"
+    <div data-sly-repeat.item="${carousel.children}"
+         data-sly-resource="${item.resource @ decorationTagName='div', selectors='amp'}"
          class="cmp-carousel__item"
          role="tabpanel"
-         aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.items.size], i18n}"></div>
+         aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.children.size], i18n}"></div>
 </amp-carousel>

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/tabs/v1/tabs/amp.html
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/tabs/v1/tabs/amp.html
@@ -14,20 +14,19 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <amp-selector data-sly-use.tabs="com.adobe.cq.wcm.core.components.models.Tabs"
-              data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-              data-sly-test="${tabs.items && tabs.items.size > 0}"
-              data-sly-list.item="${tabs.items}"
+              data-sly-test="${tabs.children && tabs.children.size > 0}"
+              data-sly-list.item="${tabs.children}"
               class="cmp-tabs tabs-with-flex"
               role="tablist">
     <div id="${item.id}-tab"
          class="cmp-tabs__tab"
          option
-         selected="${item.name == tabs.activeItem}"
+         selected="${item.resource.name == tabs.activeItem}"
          role="tab"
          aria-controls="${item.id}">${item.title}</div>
     <div id="${item.id}"
          aria-labelledby="${item.id}-tab"
-         data-sly-resource="${item.name @ decorationTagName='div'}"
+         data-sly-resource="${item.resource @ decorationTagName='div'}"
          role="tabpanel"
          class="cmp-tabs__tabpanel"></div>
 </amp-selector>


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1031
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | yes
| Major: Breaking Change?  | no
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

This PR is intended to resolve #1031 and largely resolves #999 (although, the OOTB responsive grid still has some issues).

Despite the discussion in #1031 that indicated a preference to add the method `ListItem#getResource()` as a simple solution that preserves backwards compatibility; I could not bring myself to write that solution because I feel that it further commits to the idea that `ListItems` and `ContainerItems` are the same thing, and would impose restrictions on the API that introduce limitations that do not need to exist. 

I think that the suggested change in this PR provides a path forward that will be clearer and open more possibilities, while still maintaining backwards compatibility. I will provide a more complete rational for the the changes:

### What is a List Item, and why is it different than a container item?
Let us look at the `ListItem` interface:
```
ListItem {
    URL?,
    title?,
    description?,
    lastModified?,
    path?,
    name?
}
```
Note that everything in this interface is Nullable.

Specifically, the URL field is always set in a `ListItem`, unless that list item is used as an item in a container, in which case it is never set. It is my opinion that this type of mutual exclusivity in an API is a code smell that indicates that we are potentially dealing with two different concepts. 

If we look to the `path` field and it's description - "the path of this ListItem" - things become even more confusing. What does the "path of this ListItem" mean? is it the path portion of the URL? is it the same as the URL? Is it the resource path? In fact it is the page path for any page based list item, the resource path for a resource based list item, the action link in a teaser CTA (which may or may not be a resource path), or null. The Teaser CTA List Item is an interesting example, because the path in this case does not always have to be the path of a resource in AEM. 

In a container list item, it is assumed that the path is the path of the resource; however, the API is not expressive enough to make this contract clear. The `ListItem` API doesn't even guarantee that the referenced item exists inside of AEM. Indeed, there are numerous feature requests to facilitate including external list items in components such as the `List` component or `Navigation` component.

One statement that is (currently) true, is that a `ListItem` is either acting as a Link (or CTA, or Anchor, or whatever you want to call it), in which case it has a meaningful URL; or, it acts as a container item, in which case it has a path that points to a resource and does not have a meaningful URL.

The two concepts that I believe have been conflated into one are the concept of a "Link" and the concept of a "Container Item".
A link has a URL, a container item has a Resource. This is a fundamental difference that should be able to be expressed in the API in a meaningful way.

### How to express this difference

The proposed solution is to introduce a new interface for `ContainerItem`

```
ContainerItem {
    resource
} 
```

Access to the resource is the only thing that a container item has to provide to be meaningful.
The `Container` interface is then updated to have the method `#getChildren()` which returns a list of `ContainerItems`.

The `ListItem` interface is left alone to preserve backwards compatibility, and `Container` implementations still provide access to these `ListItems`; however, the method for accessing them is marked as deprecated in favor of using the new `ContainerItem` instead.

### What about Panel Containers
The `PanelContainer` is a special case of a `Container`.
Instead of simply returning `ContainerItems`, they will return `PanelContainerItems`

in fact, the `Container#getChildren()` method is generic in that it only promises to return a list of objects that implement the `ContainerItem` interface; thus, different container component models are free to provide any type of container item, so long as that container item implements or extends the `ContainerItem` interface (i.e. provides access to the resource that is being contained). Other than the requirement to provide access to the resource that is being contained, which is the one thing that makes a container a container, the component model is free to add any other data to the container item.

This is seen with the `PanelContainerItem` which provides access to the resource, but also has the additional metadata of the panel title, id, and data layer object. Unlike the current panel implementations, the `PanelContainerItem` does not pretend to be a `Component`, when it is not. Under the current implementation, Panels are not components. The Panel Container is a Component, the contained item is a component, but the panel its self is not.

### How does this distinction help us going forward?
This distinction allows for tighter, more expressive, and more reliable APIs that are easier to understand. 
If you are providing a list of resources then you are a container - every item _must_ provide a resource. This is consistent with the concept of containers in AEM, and is consistent with how these items are rendered in Sling (i.e. render the resources).

If you cannot make the promise that these items are resources that can be rendered, then this is not a container and is just a list of things. While it is true that both a Container component and a List component are lists, they are only lists in the dictionary sense of the word "list".

Going forward, it might be useful to be specific about exactly what a `ListItem` is - perhaps even renaming the `ListItem` interface to `Link`, or something similar. Every use of the `ListItem`, outside of containers, is a link. 

| Component | Type
| --- | ----
| List | list of links
| navigation | list of links
| breadcrumb | list of links
| language navigation | list of links
| teaser CTAs | list of links

Potentially, in the future, a unified strategy for handling `Links` will be created, at which point all of these components should return links or lists of links, and certain attributes of the `ListItem` (such as URL) can be defined as being explicitly not null.

Another benefit of this separation of the concepts of Links and Container Items is that the Container components don't necessarily guarantee that the contents of a container are editable, or even that the resources provided via the `ContainerItem` are not synthetic or wrapped. 

Although all of the current container components in this project use container items to imply that the contained item is an immediate child node of the container node - this isn't really a thing that Sling cares about; so long as you do not need to rely on the JCR path to resolve that resource. This fact is already leveraged in AEM core for the concept of `TemplatedResources`.

If a container isn't just child nodes, then it can be used to provide entirely synthetic child resources that can (and should) be rendered based on their own resource types. This provides a clear path forward for implementing features such as "Teaser Lists" and "Image Lists" - where the teasers, images, or any other type of content, can be discovered by the model using any strategy and then synthetic resources prepared and returned. Indeed, it becomes relatively easy to implement this functionality. A component such as a Teaser List wouldn't even need custom front end HTL - the layout container in simple mode would suffice so long as the model implementation returned teaser-compatible resources. That isn't to say you wouldn't change the HTL, just that it's not a heavy lift to implement these features in the Core Components or client projects.

Just to give a clear idea of the utility of this approach, here is an example of how a Teaser List component would be implemented
```JAVA
// normal model stuff, presumably implements TeaserList interface which implements the Container interface
public class TeaserListImpl implements Container {

    public List<ContainerItem> getChildren() {
        // find pages, probably using similar logic to the current list component
        // create synthetic resources that specify the resource type = teaser, and set the target to the page
        // return those resources as container items
    }
}


