### PR TITLE
[HTML Page Items] Improve HtmlPageItemsConfig by exposing the whole config as API

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/config/AttributeConfig.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/config/AttributeConfig.java
@@ -13,12 +13,26 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-/**
- * <p>
- *      This package defines the context-aware configurations used by the WCM Core Components
- * </p>
- */
-@Version("2.0.0")
 package com.adobe.cq.wcm.core.components.config;
 
-import org.osgi.annotation.versioning.Version;
+import org.apache.sling.caconfig.annotation.Property;
+
+public @interface AttributeConfig {
+    /**
+     * Returns the name of the attribute.
+     *
+     * @return The name of the attribute - if left empty the attribute won't be rendered out
+     * @since com.adobe.cq.wcm.core.components.config 2.0.0
+     */
+    @Property(label = "Name")
+    String name() default "";
+
+    /**
+     * Returns the value of the attribute.
+     *
+     * @return The value of the attribute
+     * @since com.adobe.cq.wcm.core.components.config 2.0.0
+     */
+    @Property(label = "Value")
+    String value() default "";
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/config/HtmlPageItemConfig.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/config/HtmlPageItemConfig.java
@@ -1,0 +1,68 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.config;
+
+import org.apache.sling.caconfig.annotation.Property;
+
+/**
+ * Context-aware configuration holding information on an item to be included in pages:
+ * - scripts
+ * - links
+ * - meta
+ * This configuration is meant to be used as a context-aware resource.
+ * See <a href="https://sling.apache.org/documentation/bundles/context-aware-configuration/context-aware-configuration.html#context-aware-resources">Context-Aware Resources</a>
+ */
+public @interface HtmlPageItemConfig {
+    /**
+     * Returns the type of element that should be rendered.
+     *
+     * @return The type of element to render
+     * @since com.adobe.cq.wcm.core.components.config 2.0.0
+     */
+    @Property(label = "Element", description = "The type of element that should be rendered: Either 'link', 'script' or 'meta'.", property = {
+        "widgetType=dropdown",
+        "dropdownOptions=["
+            + "{'value':'link','description':'<link>'},"
+            + "{'value':'script','description':'<script>'},"
+            + "{'value':'meta','description':'<meta>'}"
+            + "]"
+    })
+    String element();
+
+    /**
+     * Returns the location of where the element should be rendered.
+     *
+     * @return The location where to render the element
+     * @since com.adobe.cq.wcm.core.components.config 2.0.0
+     */
+    @Property(label = "Location", description = "The location where to render the element: Either in the header or in the footer.", property = {
+        "widgetType=dropdown",
+        "dropdownOptions=["
+            + "{'value':'header','description':'Header'},"
+            + "{'value':'footer','description':'Footer'}"
+            + "]"
+    })
+    String location();
+
+    /**
+     * The attributes to render as part of the element.
+     *
+     * @return The attributes of the element to render
+     * @since com.adobe.cq.wcm.core.components.config 2.0.0
+     */
+    @Property(label = "Attributes")
+    AttributeConfig[] attributes() default {};
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/config/HtmlPageItemsConfig.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/config/HtmlPageItemsConfig.java
@@ -20,46 +20,47 @@ import org.apache.sling.caconfig.annotation.Property;
 
 /**
  * Context-aware configuration holding information on items to be included in pages:
- *      - scripts
- *      - links
- *      - meta
- *  This configuration is meant to be used as a context-aware resource.
- *  See <a href="https://sling.apache.org/documentation/bundles/context-aware-configuration/context-aware-configuration.html#context-aware-resources">Context-Aware Resources</a>
+ * - scripts
+ * - links
+ * - meta
+ * This configuration is meant to be used as a context-aware resource.
+ * See <a href="https://sling.apache.org/documentation/bundles/context-aware-configuration/context-aware-configuration.html#context-aware-resources">Context-Aware Resources</a>
+ * <p>
+ * Assumed structure:
  *
- *  Assumed structure:
- *
- *  <pre>
+ * <pre>
  *      com.adobe.cq.wcm.core.components.config.HtmlPageItemsConfig
  *          - prefixPath="/some/path"
- *          + item01
- *              - element=["link"|"script"|"meta"]
- *              - location=["header"|"footer"]
- *              + attributes
- *                  - attributeName01="attributeValue01"
- *                  - attributeName02="attributeValue02"
+ *          + items
+ *              + item01
+ *                  - element=["link"|"script"|"meta"]
+ *                  - location=["header"|"footer"]
+ *                  + attributes
+ *                      - attributeName01="attributeValue01"
+ *                      - attributeName02="attributeValue02"
+ *                      ...
+ *              + item02
+ *                  ...
  *              ...
- *          + item02
- *              ...
- *          ...
  *  </pre>
  */
 @Configuration(label = "Page Items", description = "Context-Aware Configuration for items that will be included in the page")
 public @interface HtmlPageItemsConfig {
-
-    /**
-     * Name of the property that stores the path that will be prefixed to all href's and src's
-     *
-     * @since com.adobe.cq.wcm.core.components.config 1.0.0
-     */
-    String PN_PREFIX_PATH = "prefixPath";
-
     /**
      * Returns the path that will be prefixed to all href's and src's
      *
      * @return The prefix path
-     *
      * @since com.adobe.cq.wcm.core.components.config 1.0.0
      */
     @Property(label = "Prefix path")
     String prefixPath() default "";
+
+    /**
+     * Returns the items to render.
+     *
+     * @return The array of items to render
+     * @since com.adobe.cq.wcm.core.components.config 2.0.0
+     */
+    @Property(label = "Items")
+    HtmlPageItemConfig[] items() default {};
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/HtmlPageItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/HtmlPageItemImpl.java
@@ -15,34 +15,33 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v2;
 
+import com.adobe.cq.wcm.core.components.config.AttributeConfig;
+import com.adobe.cq.wcm.core.components.config.HtmlPageItemConfig;
+import com.adobe.cq.wcm.core.components.models.HtmlPageItem;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ValueMap;
-import org.jetbrains.annotations.NotNull;
-
-import com.adobe.cq.wcm.core.components.models.HtmlPageItem;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 public class HtmlPageItemImpl implements HtmlPageItem {
 
     String prefixPath;
-    Resource resource;
-    ValueMap properties;
+    HtmlPageItemConfig config;
     Element element;
     Location location;
     Map<String, String> attributes;
 
-    public HtmlPageItemImpl(@NotNull String prefixPath, @NotNull Resource resource) {
+    public HtmlPageItemImpl(@NotNull String prefixPath, @NotNull HtmlPageItemConfig config) {
         this.prefixPath = prefixPath;
-        this.resource = resource;
-        this.properties = resource.getValueMap();
+        this.config = config;
     }
 
     @Override
     public Element getElement() {
         if (element == null) {
-            element = Element.fromString(properties.get(HtmlPageItem.PN_ELEMENT, String.class));
+            element = Element.fromString(config.element());
         }
         return element;
     }
@@ -50,7 +49,7 @@ public class HtmlPageItemImpl implements HtmlPageItem {
     @Override
     public Location getLocation() {
         if (location == null) {
-            location = Location.fromString(properties.get(HtmlPageItem.PN_LOCATION, String.class));
+            location = Location.fromString(config.location());
         }
         return location;
     }
@@ -59,18 +58,15 @@ public class HtmlPageItemImpl implements HtmlPageItem {
     public Map<String, String> getAttributes() {
         if (attributes == null) {
             attributes = new LinkedHashMap<>();
-            Resource attributesNode = resource.getChild(HtmlPageItem.NN_ATTRIBUTES);
-            if (attributesNode != null) {
-                ValueMap attributesProperties = attributesNode.getValueMap();
-                for (String attrName : getElement().getAttributeNames()) {
-                    String attrValue = attributesProperties.get(attrName, String.class);
-                    if (attrValue != null) {
-                        if ((getElement() == Element.LINK && HtmlPageItem.PN_HREF.equals(attrName)) ||
-                                (getElement() == Element.SCRIPT && HtmlPageItem.PN_SRC.equals(attrName))) {
-                            attrValue = prefixPath + attrValue;
-                        }
-                        attributes.put(attrName, attrValue);
+            for (AttributeConfig attributeConfig : config.attributes()) {
+                String attrName = attributeConfig.name();
+                String attrValue = attributeConfig.value();
+                if (isNotEmpty(attrName)) {
+                    if ((getElement() == Element.LINK && HtmlPageItem.PN_HREF.equals(attrName)) ||
+                        (getElement() == Element.SCRIPT && HtmlPageItem.PN_SRC.equals(attrName))) {
+                        attrValue = prefixPath + attrValue;
                     }
+                    attributes.put(attrName, attrValue);
                 }
             }
         }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
@@ -26,11 +26,11 @@ import java.util.stream.Stream;
 
 import javax.annotation.PostConstruct;
 
+import com.adobe.cq.wcm.core.components.config.HtmlPageItemConfig;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.caconfig.resource.ConfigurationResourceResolver;
+import org.apache.sling.caconfig.ConfigurationBuilder;
+import org.apache.sling.caconfig.ConfigurationResolver;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
@@ -102,10 +102,10 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     private ProductInfoProvider productInfoProvider;
 
     /**
-     * The @{@link ConfigurationResourceResolver} service.
+     * The @{@link ConfigurationResolver} service.
      */
     @OSGiService
-    private ConfigurationResourceResolver configurationResourceResolver;
+    private ConfigurationResolver configurationResolver;
 
     /**
      * The current request.
@@ -276,14 +276,12 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     public @NotNull List<HtmlPageItem> getHtmlPageItems() {
         if (htmlPageItems == null) {
             htmlPageItems = new LinkedList<>();
-            Resource configResource = configurationResourceResolver.getResource(resource, "sling:configs", HtmlPageItemsConfig.class.getName());
-            if (configResource != null) {
-                ValueMap properties = configResource.getValueMap();
-                for (Resource child : configResource.getChildren()) {
-                    HtmlPageItem item = new HtmlPageItemImpl(properties.get(HtmlPageItemsConfig.PN_PREFIX_PATH, StringUtils.EMPTY), child);
-                    if (item.getElement() != null) {
-                        htmlPageItems.add(item);
-                    }
+            ConfigurationBuilder configurationBuilder = configurationResolver.get(resource);
+            HtmlPageItemsConfig config = configurationBuilder.as(HtmlPageItemsConfig.class);
+            for (HtmlPageItemConfig itemConfig : config.items()) {
+                HtmlPageItem item = new HtmlPageItemImpl(StringUtils.defaultString(config.prefixPath()), itemConfig);
+                if (item.getElement() != null) {
+                    htmlPageItems.add(item);
                 }
             }
         }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/HtmlPageItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/HtmlPageItem.java
@@ -33,18 +33,21 @@ public interface HtmlPageItem {
      * Property name that defines the type of the HTML element rendered by the page item
      * @since com.adobe.cq.wcm.core.components.models 12.16.0
      */
+    @Deprecated(since = "13.0.0", forRemoval = true)
     String PN_ELEMENT = "element";
 
     /**
      * Property that defines the location (header or footer) where the page item should be inserted
      * @since com.adobe.cq.wcm.core.components.models 12.16.0
      */
+    @Deprecated(since = "13.0.0", forRemoval = true)
     String PN_LOCATION = "location";
 
     /**
      * Sub-node that holds the page item's attributes
      * @since com.adobe.cq.wcm.core.components.models 12.16.0
      */
+    @Deprecated(since = "13.0.0", forRemoval = true)
     String NN_ATTRIBUTES = "attributes";
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.16.0")
+@Version("13.0.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Fixes #1234

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1234
| Patch: Bug Fix?          | x
| Minor: New Feature?      | :+1: 
| Major: Breaking Change?  | :+1: 
| Tests Added + Pass?      | x
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

This PR adds two new Context-aware configurations:
- `com.adobe.cq.wcm.core.components.config.HtmlPageItemConfig`
- `com.adobe.cq.wcm.core.components.config.AttributeConfig`

They are used as child configurations in the already existing `com.adobe.cq.wcm.core.components.config.HtmlPageItemsConfig`.

This unfortunately implies a change in the config's structure as child configs are now stored under one node called `items`, compared to how they were stored as immediate children of the parent config. (See the Javadoc inside `HtmlPageItemsConfig` for the diff).

It also adds [wcm.io Editor](https://github.com/wcm-io/wcm-io-caconfig) specific properties to allow the selection of e.g. an item's element as dropdown.

TODOs:
- [ ] Fix `PageImplTest`
  - I'm not quite sure how to test this, i.e., how to provide the UUT with a (proper) instance of `HtmlPageItemsConfig` based off of `bundles/core/src/test/resources/page/v2/test-sling-configs.json`
- [ ] Clarify if the version changes of `com.adobe.cq.wcm.core.components.config` (1.0.0 -> 2.0.0) and `com.adobe.cq.wcm.core.components.models` (12.16.0 -> 13.0.0) make sense
- [ ] Clarify if the deprecations of `HtmlPageItem#PN_ELEMENT`, `HtmlPageItem#PN_LOCATION` and `HtmlPageItem#NN_ATTRIBUTES` make sense