### PR TITLE
[List] Correct sort ordering not matching list item title (#1269)

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageListItemImpl.java
@@ -36,22 +36,51 @@ import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.components.Component;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+/**
+ * List item implementation for a page-backed list item.
+ */
 public class PageListItemImpl extends AbstractListItemImpl implements ListItem {
 
+    /**
+     * Standard logger.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(PageListItemImpl.class);
 
     /**
      * Name of the resource property that for redirecting pages will indicate if original page or redirect target page should be returned.
-     * Dafault is `false`. If `true` - original page is returned. If `false` or not configured - redirect target page.
+     * Default is `false`. If `true` - original page is returned. If `false` or not configured - redirect target page.
      */
     static final String PN_DISABLE_SHADOWING = "disableShadowing";
+
+    /**
+     * Flag indicating if showing is disabled.
+     */
     public static final boolean PROP_DISABLE_SHADOWING_DEFAULT = false;
 
+    /**
+     * The current request.
+     */
     protected SlingHttpServletRequest request;
+
+    /**
+     * The page for this list item.
+     */
     protected Page page;
 
-    public PageListItemImpl(@NotNull SlingHttpServletRequest request, @NotNull Page page, String parentId, boolean isShadowingDisabled,
-                            Component component) {
+    /**
+     * Construct a list item for a given page.
+     *
+     * @param request The current request.
+     * @param page The current page.
+     * @param parentId The ID of the list containing this item.
+     * @param isShadowingDisabled Flag indicating if redirect shadowing should be disabled.
+     * @param component The component containing this list item.
+     */
+    public PageListItemImpl(@NotNull final SlingHttpServletRequest request,
+                            @NotNull final Page page,
+                            final String parentId,
+                            final boolean isShadowingDisabled,
+                            final Component component) {
         super(parentId, page.getContentResource(), component);
         this.request = request;
         this.page = page;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageListItemImpl.java
@@ -71,6 +71,24 @@ public class PageListItemImpl extends AbstractListItemImpl implements ListItem {
 
     @Override
     public String getTitle() {
+        return PageListItemImpl.getTitle(this.page);
+    }
+
+    /**
+     * Gets the title of a page list item from a given page.
+     * The list item title is derived from the page by selecting the first non-null value from the
+     * following:
+     * <ul>
+     *     <li>{@link Page#getNavigationTitle()}</li>
+     *     <li>{@link Page#getPageTitle()}</li>
+     *     <li>{@link Page#getTitle()}</li>
+     *     <li>{@link Page#getName()}</li>
+     * </ul>
+     *
+     * @param page The page for which to get the title.
+     * @return The list item title.
+     */
+    public static String getTitle(@NotNull final Page page) {
         String title = page.getNavigationTitle();
         if (title == null) {
             title = page.getPageTitle();

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
@@ -199,7 +199,8 @@ public class ListImplTest {
     @Test
     public void testOrderByTitleWithNoTitleForOneItem() {
         List list = getListUnderTest(LIST_15);
-        checkListConsistencyByPaths(list, new String[]{"/content/list/pages/page_1", "/content/list/pages/page_2", "/content/list/pages/page_4"});
+        list.getItems().stream().map(PageListItemImpl::getTitle).forEach(System.out::println);
+        checkListConsistencyByPaths(list, new String[]{"/content/list/pages/page_4", "/content/list/pages/page_1", "/content/list/pages/page_2" });
     }
 
     @Test


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1269 
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

- Changes the list item sorting of the `ListImpl` to match the titles produced by `PageListItemImpl` to ensure that the list items are sorted consistent with how they are presented.
- The comparator used for sorting the list pages is updated to prevent the construction of the title comparator unless sorting by titles is enabled.
- Additional JavaDoc comments are added to `PageListItemImpl`.