### PR TITLE
Improve RTE usability in the Text Component

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/_cq_design_dialog/.content.xml
@@ -257,10 +257,10 @@
                                                         <items jcr:primaryType="nt:unstructured">
                                                             <links
                                                                 jcr:primaryType="nt:unstructured"
-                                                                jcr:title="Show link insertion options (link, unlink)"
+                                                                jcr:title="Show link insertion options (link, unlink, anchor)"
                                                                 sling:resourceType="cq/gui/components/authoring/dialog/inplaceediting/configuration/plugin"
                                                                 defaultEnabled="{Boolean}true"
-                                                                features="modifylink,unlink"
+                                                                features="modifylink,unlink,anchor"
                                                                 name="links"/>
                                                         </items>
                                                         <granite:data

--- a/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/_cq_dialog/.content.xml
@@ -149,7 +149,7 @@
                                                             <popovers jcr:primaryType="nt:unstructured">
                                                                 <justify
                                                                     jcr:primaryType="nt:unstructured"
-                                                                    items="[justify#justifyleft,justify#justifycenter,justify#justifyright]"
+                                                                    items="[justify#justifyleft,justify#justifycenter,justify#justifyright,justify#justifyjustify]"
                                                                     ref="justify"/>
                                                                 <lists
                                                                     jcr:primaryType="nt:unstructured"

--- a/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/_cq_editConfig.xml
@@ -94,6 +94,32 @@
                     jcr:primaryType="nt:unstructured"
                     features="bold,italic"/>
             </rtePlugins>
+            <uiSettings jcr:primaryType="nt:unstructured">
+                <cui jcr:primaryType="nt:unstructured">
+                    <inline
+                        jcr:primaryType="nt:unstructured"
+                        toolbar="[#format,#justify,#lists,links#modifylink,links#unlink,#paraformat,fullscreen#start,control#close,control#save]">
+                        <popovers jcr:primaryType="nt:unstructured">
+                            <format
+                                jcr:primaryType="nt:unstructured"
+                                items="[format#bold,format#italic,format#underline]"
+                                ref="format"/>
+                            <justify
+                                jcr:primaryType="nt:unstructured"
+                                items="[justify#justifyleft,justify#justifycenter,justify#justifyright,justify#justifyjustify]"
+                                ref="justify"/>
+                            <lists
+                                jcr:primaryType="nt:unstructured"
+                                items="[lists#unordered,lists#ordered,lists#outdent,lists#indent]"
+                                ref="lists"/>
+                            <paraformat
+                                jcr:primaryType="nt:unstructured"
+                                items="paraformat:getFormats:paraformat-pulldown"
+                                ref="paraformat"/>
+                        </popovers>
+                    </inline>
+                </cui>
+            </uiSettings>
         </inplaceEditingConfig>
     </cq:inplaceEditing>
 </jcr:root>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1293 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | No
| Documentation Provided   | No (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
In order to improve RTE usability in the Text Component the following changes are included:
1. Providing the possibility to enable anchor links via policies.
2. Adding the missed "justifyjustify" feature of the "justify" RTE plugin to the dialog compact toolbar.
3. Making RTE plugins/features set in the inline compact toolbar the same as in the dialog compact toolbar.
