### PR TITLE
Add runtime statistics for the AdaptiveImageServlet 

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -506,7 +506,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
         }
         // If no rendition was found, attempt to use original
         if (bestRendition == null) {
-            bestRendition = getOriginal(asset);
+            return getOriginal(asset);
         }
         return filter(bestRendition);
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumer.java
@@ -71,6 +71,9 @@ public class AdaptiveImageServletMappingConfigurationConsumer {
 
     @Reference
     private ConfigurationAdmin configurationAdmin;
+    
+    @Reference
+    AdaptiveImageServletMetrics metrics;
 
 
     /**
@@ -166,6 +169,7 @@ public class AdaptiveImageServletMappingConfigurationConsumer {
                                 new AdaptiveImageServlet(
                                         mimeTypeService,
                                         assetStore,
+                                        metrics,
                                         oldAISDefaultResizeWidth > 0 ? oldAISDefaultResizeWidth : config.getDefaultResizeWidth(),
                                         config.getMaxSize()),
                                 properties

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetrics.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetrics.java
@@ -1,0 +1,75 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.servlets;
+
+import org.apache.sling.commons.metrics.Counter;
+import org.apache.sling.commons.metrics.MetricsService;
+import org.apache.sling.commons.metrics.Timer;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(service=AdaptiveImageServletMetrics.class)
+public class AdaptiveImageServletMetrics {
+    
+    private static final String BASENAME = "com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServlet:";
+    
+    @Reference
+    MetricsService metricsService;
+    
+    // the total number of invocations of the servlet
+    private Counter invocations;
+    // how often the original rendition was used as basis for the rendition
+    private Counter originalRenditionUsed;
+    // how often a base rendition has been rejected because it exceeded the configured limits
+    private Counter baseRenditionRejected;
+    // how often a new rendition was actually created
+    private Counter renditionRendered;
+    // record the duration of the request
+    private Timer requestDuration;
+    
+    @Activate
+    public void activate() {
+        invocations = metricsService.counter(BASENAME + "invocations");
+        originalRenditionUsed = metricsService.counter(BASENAME + "original-rendition-used");
+        baseRenditionRejected = metricsService.counter(BASENAME + "base-rendition-rejected-because-of-size");
+        renditionRendered = metricsService.counter(BASENAME + "rendition-rendered");
+        requestDuration = metricsService.timer(BASENAME + "request-duration");
+        
+    }
+    
+    public void markServletInvocation() {
+        invocations.increment();
+    }
+    
+    public void markOriginalRenditionUsed() {
+        originalRenditionUsed.increment();
+    }
+    
+    public void markRejectedTooLargeRendition() {
+        baseRenditionRejected.increment();
+    }
+    
+    public void markRenditionRendered() {
+        renditionRendered.increment();
+    }
+    
+    public Timer.Context startDurationRecording() {
+        return requestDuration.time();
+    }
+    
+
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumerTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumerTest.java
@@ -53,6 +53,8 @@ public class AdaptiveImageServletMappingConfigurationConsumerTest {
     public void setUp() {
         AssetStore assetStore = mock(AssetStore.class);
         context.registerService(AssetStore.class, assetStore);
+        AdaptiveImageServletMetrics metrics = mock(AdaptiveImageServletMetrics.class);
+        context.registerService(AdaptiveImageServletMetrics.class, metrics);
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetricsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetricsTest.java
@@ -1,0 +1,72 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.servlets;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.sling.commons.metrics.Counter;
+import org.apache.sling.commons.metrics.MetricsService;
+import org.apache.sling.commons.metrics.Timer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+@ExtendWith(AemContextExtension.class)
+public class AdaptiveImageServletMetricsTest {
+    
+    
+    
+    /**
+     * Oh really, you want me to write unit tests for this class, which 
+     * actually does not have ANY logic?
+     * 
+     * Ok, here we go ... don't be disappointed.
+     */
+    
+    public final AemContext context = new AemContext();
+    
+    
+    @BeforeEach
+    public void setup() {
+        MetricsService s = mock (MetricsService.class);
+        Timer timer = mock(Timer.class);
+        when(timer.time()).thenReturn(mock(Timer.Context.class));
+        when(s.timer(Mockito.anyString())).thenReturn(timer);
+        when(s.counter(Mockito.anyString())).thenReturn(mock(Counter.class));
+        context.registerService(MetricsService.class, s);
+    }
+    
+    @Test
+    public void test() {
+        AdaptiveImageServletMetrics metrics = new AdaptiveImageServletMetrics();
+        context.registerInjectActivateService(metrics);
+        
+        metrics.markOriginalRenditionUsed();
+        metrics.markRejectedTooLargeRendition();
+        metrics.markServletInvocation();
+        Timer.Context c = metrics.startDurationRecording();
+        assertNotNull(c); // silly, as it is a mock ...
+      
+        
+    }
+
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletTest.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.api.servlets.HttpConstants;
+import org.apache.sling.commons.metrics.Timer;
 import org.apache.sling.testing.mock.sling.servlet.MockRequestPathInfo;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
@@ -87,12 +88,14 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         resourceResolver = context.resourceResolver();
         AssetHandler assetHandler = mock(AssetHandler.class);
         AssetStore assetStore = mock(AssetStore.class);
+        AdaptiveImageServletMetrics metrics = mock(AdaptiveImageServletMetrics.class);
+        when(metrics.startDurationRecording()).thenReturn(mock(Timer.Context.class));
         when(assetStore.getAssetHandler(anyString())).thenReturn(assetHandler);
         when(assetHandler.getImage(any(Rendition.class))).thenAnswer(invocation -> {
             Rendition rendition = invocation.getArgument(0);
             return ImageIO.read(rendition.getStream());
         });
-        servlet = new AdaptiveImageServlet(mockedMimeTypeService, assetStore, ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH, AdaptiveImageServlet.DEFAULT_MAX_SIZE);
+        servlet = new AdaptiveImageServlet(mockedMimeTypeService, assetStore, metrics, ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH, AdaptiveImageServlet.DEFAULT_MAX_SIZE);
         testLogger = TestLoggerFactory.getTestLogger(AdaptiveImageServlet.class);
     }
 


### PR DESCRIPTION

| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | Fixes #1292
| Patch: Bug Fix?          | 
| Minor: New Feature?      | Yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Inline
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

The AdaptiveImageServlet now maintains statistics as Sling Metrics, which you can check via /system/console/slingmetrics.

| Name | Description
|--------|--------
|sling:com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServlet:invocations| Number of total invocations of the AdaptiveImageSerlvet (Counter)
|sling:com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServlet:rendition-rendered | counts how often a rendition was rendered (in contrast to sending a 304 or 404)
|sling:com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServlet:original-rendition-used | counts how often the original rendition was used for rendering instead of any web rendition
| sling:com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServlet:base-rendition-rejected-because-of-size | counts how often the rendering was refused because the rendition to be used was larger than the configured maximum value
|sling:com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServlet:request-duration (timer)| a timer which collects the duration of the invocations of the AdaptiveImageServlet)



