### PR TITLE
Avoid swapping image back on scroll event

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -232,7 +232,7 @@
             }
             var url = that._properties.src.replace(SRC_URI_TEMPLATE_WIDTH_VAR, replacement);
 
-            if (that._elements.image.getAttribute("src") !== url) {
+            if (that._elements.image.getAttribute("src") == EMPTY_PIXEL) {
                 that._elements.image.setAttribute("src", url);
                 if (!hasWidths) {
                     window.removeEventListener("scroll", that.update);

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -232,7 +232,7 @@
             }
             var url = that._properties.src.replace(SRC_URI_TEMPLATE_WIDTH_VAR, replacement);
 
-            if (that._elements.image.getAttribute("src") == EMPTY_PIXEL) {
+            if (that._elements.image.getAttribute("src") === EMPTY_PIXEL) {
                 that._elements.image.setAttribute("src", url);
                 if (!hasWidths) {
                     window.removeEventListener("scroll", that.update);

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -232,7 +232,8 @@
             }
             var url = that._properties.src.replace(SRC_URI_TEMPLATE_WIDTH_VAR, replacement);
 
-            if (that._elements.image.getAttribute("src") === EMPTY_PIXEL) {
+            var imgSrcAttribute = that._elements.image.getAttribute("src");
+            if (imgSrcAttribute === null || imgSrcAttribute === EMPTY_PIXEL) {
                 that._elements.image.setAttribute("src", url);
                 if (!hasWidths) {
                     window.removeEventListener("scroll", that.update);


### PR DESCRIPTION
Fixed image lazy loading loadImage so it doesn't replace dynamically swapped images on scroll event.  When custom javascript does an intentional swap on the img src attribute of a lazyloaded image, it swaps back to the original when the user scrolls the browser window.  Instead it should be compared to the placeholder.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1330
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  | 
| Tests Added + Pass?      | 
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

Instead of comparing to URL of src, compare against EMPTY_PIXEL placeholder:
Before:
```
            if (that._elements.image.getAttribute("src") !== url) {
```
After:
```
            if (that._elements.image.getAttribute("src") == EMPTY_PIXEL) {
```