### PR TITLE
[Form Text & Form Options] Fixes #1259: Streamline form text

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/form/options/v2/options/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/options/v2/options/_cq_dialog/.content.xml
@@ -47,11 +47,6 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
-                                            <mainHeading
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/heading"
-                                                level="{Long}3"
-                                                text="Main"/>
                                             <optionTypes
                                                 granite:class="cmp-form-options__editor-type"
                                                 jcr:primaryType="nt:unstructured"
@@ -207,17 +202,6 @@
                                                     </options>
                                                 </items>
                                             </fromLocal>
-                                            <aboutHeading
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/heading"
-                                                level="{Long}3"
-                                                text="About"/>
-                                            <description
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="A hint for the user of what can be entered in the field."
-                                                fieldLabel="Help Message"
-                                                name="./helpMessage"/>
                                             <id
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
@@ -230,6 +214,33 @@
                             </columns>
                         </items>
                     </properties>
+                    <about
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="About"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <helpMessage
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="A hint to the user of what can be entered in the field"
+                                                fieldLabel="Help Message"
+                                                name="./helpMessage"/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </about>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/options/v2/options/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/options/v2/options/_cq_dialog/.content.xml
@@ -47,6 +47,11 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
+                                            <mainHeading
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/heading"
+                                                level="{Long}3"
+                                                text="Main"/>
                                             <optionTypes
                                                 granite:class="cmp-form-options__editor-type"
                                                 jcr:primaryType="nt:unstructured"
@@ -202,6 +207,17 @@
                                                     </options>
                                                 </items>
                                             </fromLocal>
+                                            <aboutHeading
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/heading"
+                                                level="{Long}3"
+                                                text="About"/>
+                                            <description
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="A hint for the user of what can be entered in the field."
+                                                fieldLabel="Help Message"
+                                                name="./helpMessage"/>
                                             <id
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
@@ -214,33 +230,6 @@
                             </columns>
                         </items>
                     </properties>
-                    <about
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="About"
-                        sling:resourceType="granite/ui/components/coral/foundation/container"
-                        margin="{Boolean}true">
-                        <items jcr:primaryType="nt:unstructured">
-                            <columns
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
-                                margin="{Boolean}true">
-                                <items jcr:primaryType="nt:unstructured">
-                                    <column
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/coral/foundation/container">
-                                        <items jcr:primaryType="nt:unstructured">
-                                            <helpMessage
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="A hint to the user of what can be entered in the field"
-                                                fieldLabel="Help Message"
-                                                name="./helpMessage"/>
-                                        </items>
-                                    </column>
-                                </items>
-                            </columns>
-                        </items>
-                    </about>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/_cq_dialog/.content.xml
@@ -110,9 +110,8 @@
                                             <name
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                emptyText="The name of the field which is submitted with the form data"
-                                                fieldDescription="The name of the field which is submitted with the form data"
-                                                fieldLabel="Element Name"
+                                                fieldDescription="The name of the field, which is submitted with the form data."
+                                                fieldLabel="Name"
                                                 name="./name"
                                                 required="{Boolean}true"/>
                                             <value


### PR DESCRIPTION
Follow up for #1260 

Changes applied to original PR:
* removed about section
* added main and about headings back

All changes that updated PR provides:
* Changes "Form Text Field"'s "Element Name" label to "Name" to be in line with "Form Options Text"