### PR TITLE
Add specific placeholder text for container component inside Panel Containers

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/accordion.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/accordion.html
@@ -18,7 +18,8 @@
      class="cmp-accordion"
      data-cmp-is="accordion"
      data-cmp-data-layer="${accordion.data.json}"
-     data-cmp-single-expansion="${accordion.singleExpansion}">
+     data-cmp-single-expansion="${accordion.singleExpansion}"
+     data-placeholder-text="${wcmmode.edit && 'Please drag Accordion item components here' @ i18n}">
     <div data-sly-test="${accordion.items.size > 0}"
          data-sly-repeat.item="${accordion.items}"
          class="cmp-accordion__item"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -25,7 +25,8 @@
      data-cmp-autoplay="${(wcmmode.edit || wcmmode.preview) ? '' : carousel.autoplay}"
      data-cmp-delay="${carousel.delay}"
      data-cmp-autopause-disabled="${carousel.autopauseDisabled}"
-     data-cmp-data-layer="${carousel.data.json}">
+     data-cmp-data-layer="${carousel.data.json}"
+     data-placeholder-text="${wcmmode.edit && 'Please add Carousel components here' @ i18n}">
     <div data-sly-test="${carousel.items && carousel.items.size > 0}"
          class="cmp-carousel__content"
          aria-atomic="false"

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/parsysplaceholder/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/parsysplaceholder/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[cq.authoring.editor.core]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/parsysplaceholder/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/parsysplaceholder/js.txt
@@ -1,0 +1,20 @@
+###############################################################################
+# Copyright 2020 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=js
+
+parsys-placeholder.js
+

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/parsysplaceholder/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/parsysplaceholder/js.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2020 Adobe
+# Copyright 2021 Adobe
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/parsysplaceholder/js/parsys-placeholder.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/parsysplaceholder/js/parsys-placeholder.js
@@ -1,0 +1,69 @@
+/*###############################################################################
+# Copyright 2020 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################*/
+
+(function ($, ns, channel, window) {
+    "use strict";
+    var placeholderClass = 'cq-placeholder';
+    var newComponentClass = 'new';
+    var newComponentPlaceholderText = Granite.I18n.get('Drag components here');
+
+    /**
+     * Indicates if the Inspectable has a placeholder element
+     * @returns {false|String} Returns the placeholder string or false if no placeholder exists
+     */
+    ns.Inspectable.prototype.hasPlaceholder = function() {
+        if( !this.onPage() ) {
+            return false;
+        }
+        // New component placeholder (drag components here)
+        if (this.dom.hasClass(newComponentClass)) {
+             //return newComponentPlaceholderText;
+            var editableEl = this.dom.parents(".cq-Editable-dom[data-placeholder-text],.cq-Editable-dom [data-placeholder-text]").first();
+        if(editableEl.length > 0) {
+            var placeholderHint = editableEl.data('placeholder-text');
+             if(placeholderHint) {
+                return Granite.I18n.get(placeholderHint);
+            }
+        }
+        return newComponentPlaceholderText;
+        }
+        // Placeholder for empty component
+        var placeholder;
+        if (this.dom.hasClass(placeholderClass)) {
+            /// The dom is directly marked as placeholder
+            placeholder = this.dom;
+        } else {
+            // The dom isn't marked as placeholder, but it might contain a nested placeholder
+            // when the inspectable is a drop target or is inplace editable
+            if (this.config.editConfig &&
+                (this.config.editConfig.dropTarget || this.config.editConfig.inplaceEditingConfig)) {
+                var inspectable = this;
+                placeholder = inspectable.dom
+                    .find(`.${placeholderClass}`)
+                    .filter(function() {
+                        // Filter out nested placeholders that are part of another inspectable
+                        return inspectable.dom.is($(this).closest(".cq-Editable-dom"));
+                    });
+            } else {
+                // The inspectable can have a direct child as placeholder to allow user interaction
+                // (e.g., "allowed components" in template editor)
+                placeholder = this.dom.find(`> .${placeholderClass}`);
+            }
+        }
+        return placeholder && placeholder.length ?
+            Granite.I18n.getVar(placeholder.data("emptytext")) : false;
+    };
+}(jQuery, Granite.author, jQuery(document)));

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/parsysplaceholder/js/parsys-placeholder.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/parsysplaceholder/js/parsys-placeholder.js
@@ -1,58 +1,61 @@
-/*###############################################################################
-# Copyright 2020 Adobe
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-###############################################################################*/
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
-(function ($, ns, channel, window) {
+(function($, ns, channel, window) {
     "use strict";
-    var placeholderClass = 'cq-placeholder';
-    var newComponentClass = 'new';
-    var newComponentPlaceholderText = Granite.I18n.get('Drag components here');
+    var placeholderClass = "cq-placeholder";
+    var newComponentClass = "new";
+    var newComponentPlaceholderText = Granite.I18n.get("Drag components here");
 
     /**
      * Indicates if the Inspectable has a placeholder element
-     * @returns {false|String} Returns the placeholder string or false if no placeholder exists
+     * @returns {*} Returns the placeholder string or false if no placeholder exists
      */
     ns.Inspectable.prototype.hasPlaceholder = function() {
-        if( !this.onPage() ) {
+        if (!this.onPage()) {
             return false;
         }
+
         // New component placeholder (drag components here)
         if (this.dom.hasClass(newComponentClass)) {
-             //return newComponentPlaceholderText;
+            // return newComponentPlaceholderText
             var editableEl = this.dom.parents(".cq-Editable-dom[data-placeholder-text],.cq-Editable-dom [data-placeholder-text]").first();
-        if(editableEl.length > 0) {
-            var placeholderHint = editableEl.data('placeholder-text');
-             if(placeholderHint) {
-                return Granite.I18n.get(placeholderHint);
+            if (editableEl.length > 0) {
+                var placeholderHint = editableEl.data("placeholder-text");
+                if (placeholderHint) {
+                    return Granite.I18n.get(placeholderHint);
+                }
             }
+            return newComponentPlaceholderText;
         }
-        return newComponentPlaceholderText;
-        }
+
         // Placeholder for empty component
         var placeholder;
         if (this.dom.hasClass(placeholderClass)) {
-            /// The dom is directly marked as placeholder
+            // The dom is directly marked as placeholder
             placeholder = this.dom;
         } else {
             // The dom isn't marked as placeholder, but it might contain a nested placeholder
             // when the inspectable is a drop target or is inplace editable
             if (this.config.editConfig &&
                 (this.config.editConfig.dropTarget || this.config.editConfig.inplaceEditingConfig)) {
+
                 var inspectable = this;
                 placeholder = inspectable.dom
-                    .find(`.${placeholderClass}`)
+                    .find("." + placeholderClass)
                     .filter(function() {
                         // Filter out nested placeholders that are part of another inspectable
                         return inspectable.dom.is($(this).closest(".cq-Editable-dom"));
@@ -60,10 +63,11 @@
             } else {
                 // The inspectable can have a direct child as placeholder to allow user interaction
                 // (e.g., "allowed components" in template editor)
-                placeholder = this.dom.find(`> .${placeholderClass}`);
+                placeholder = this.dom.find("> ." + placeholderClass);
             }
         }
-        return placeholder && placeholder.length ?
-            Granite.I18n.getVar(placeholder.data("emptytext")) : false;
+
+        return placeholder && placeholder.length ? Granite.I18n.getVar(placeholder.data("emptytext")) : false;
     };
+
 }(jQuery, Granite.author, jQuery(document)));

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
@@ -18,7 +18,8 @@
      id="${tabs.id}"
      class="cmp-tabs"
      data-cmp-is="tabs"
-     data-cmp-data-layer="${tabs.data.json}">
+     data-cmp-data-layer="${tabs.data.json}"
+     data-placeholder-text="${wcmmode.edit && 'Please drag Tab components here' @ i18n}">
     <ol data-sly-test="${tabs.items && tabs.items.size > 0}"
         data-sly-list.tab="${tabs.items}"
         role="tablist"


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1076
| Patch: Bug Fix?          | No
| Minor: New Feature?      | yes
| Major: Breaking Change?  | no
| Tests Added + Pass?      | no
| Documentation Provided   | no
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

Resubmitted PR (original #1099), fixed some linting and jquery issues. Tested against cloud ready and 6.5.7.

Makes the placeholder text for adding new components to a container that is inside a Carousel, Tab or Accordion more specific to improve author experiences. E.g. instead of `Drag component here `it will say `Please add Carousel Components here`, and the strings are i18n.