### PR TITLE
Add runtime statistics for the AdaptiveImageServlet (#1305)

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -506,6 +506,9 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
             if (dimension != null) {
                 if (dimension.getWidth() >= width) {
                     bestRendition = enhancedRendition;
+                    if (StringUtils.equals(bestRendition.getPath(), asset.getOriginal().getPath())) {
+                        metrics.markOriginalRenditionUsed();
+                    }
                     break;
                 }
             }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -136,13 +136,13 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
                 if (StringUtils.isNotEmpty(suffixExtension)) {
                     if (!suffixExtension.equals(requestPathInfo.getExtension())) {
                         LOGGER.error("The suffix part defines a different extension than the request: {}.", suffix);
-                        metrics.markImageError();
+                        metrics.markImageErrors();
                         response.sendError(HttpServletResponse.SC_NOT_FOUND);
                         return;
                     }
                 } else {
                     LOGGER.error("Invalid suffix: {}.", suffix);
-                    metrics.markImageError();
+                    metrics.markImageErrors();
                     response.sendError(HttpServletResponse.SC_NOT_FOUND);
                     return;
                 }
@@ -175,7 +175,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
                 }
                 if (componentCandidate == null) {
                     LOGGER.error("Unable to retrieve an image from this page's template.");
-                    metrics.markImageError();
+                    metrics.markImageErrors();
                     response.sendError(HttpServletResponse.SC_NOT_FOUND);
                     return;
                 }
@@ -186,7 +186,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
             ImageComponent imageComponent = new ImageComponent(component);
             if (imageComponent.source == Source.NONEXISTING) {
                 LOGGER.error("The image from {} does not have a valid file reference.", component.getPath());
-                metrics.markImageError();
+                metrics.markImageErrors();
                 response.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;
             }
@@ -206,7 +206,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
                 if (asset == null) {
                     LOGGER.error("Unable to adapt resource {} used by image {} to an asset.", imageComponent.imageResource.getPath(),
                             component.getPath());
-                    metrics.markImageError();
+                    metrics.markImageErrors();
                     response.sendError(HttpServletResponse.SC_NOT_FOUND);
                     return;
                 }
@@ -224,7 +224,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
                     return;
                 } else {
                     LOGGER.error("Unable to determine correct redirect location.");
-                    metrics.markImageError();
+                    metrics.markImageErrors();
                     response.setStatus(HttpServletResponse.SC_NOT_FOUND);
                     return;
                 }
@@ -248,7 +248,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
             }
         } catch (IllegalArgumentException e) {
             LOGGER.error("Invalid image request", e.getMessage());
-            metrics.markImageError();
+            metrics.markImageErrors();
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         } finally {
             requestDuration.stop();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -46,6 +46,7 @@ import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.commons.metrics.Timer;
 import org.apache.sling.commons.mime.MimeTypeService;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -102,6 +103,8 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
     private static final String SELECTOR_WIDTH_KEY = "width";
     private int defaultResizeWidth;
     private int maxInputWidth;
+    
+    private AdaptiveImageServletMetrics metrics;
 
     @SuppressFBWarnings(justification = "This field needs to be transient")
     private transient MimeTypeService mimeTypeService;
@@ -109,16 +112,20 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
     @SuppressFBWarnings(justification = "This field needs to be transient")
     private transient AssetStore assetStore;
 
-    public AdaptiveImageServlet(MimeTypeService mimeTypeService, AssetStore assetStore, int defaultResizeWidth, int maxInputWidth) {
+    public AdaptiveImageServlet(MimeTypeService mimeTypeService, AssetStore assetStore, AdaptiveImageServletMetrics metrics, 
+            int defaultResizeWidth, int maxInputWidth) {
         this.mimeTypeService = mimeTypeService;
         this.assetStore = assetStore;
+        this.metrics = metrics;
         this.defaultResizeWidth = defaultResizeWidth > 0 ? defaultResizeWidth : DEFAULT_RESIZE_WIDTH;
         this.maxInputWidth = maxInputWidth > 0 ? maxInputWidth : DEFAULT_MAX_SIZE;
     }
 
     @Override
     protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws IOException {
+        Timer.Context requestDuration = metrics.startDurationRecording();
         try {
+            metrics.markServletInvocation();
             RequestPathInfo requestPathInfo = request.getRequestPathInfo();
             List<String> selectorList = selectorToList(requestPathInfo.getSelectorString());
             String suffix = requestPathInfo.getSuffix();
@@ -231,10 +238,13 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
                     transformAndStreamAsset(response, componentProperties, resizeWidth, quality, asset, imageType,
                             imageName);
                 }
+                metrics.markRenditionRendered();
             }
         } catch (IllegalArgumentException e) {
             LOGGER.error("Invalid image request", e.getMessage());
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        } finally {
+            requestDuration.stop();
         }
 
     }
@@ -502,7 +512,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
         }
         // If no rendition was found, attempt to use original
         if (bestRendition == null) {
-            bestRendition = new EnhancedRendition(asset.getOriginal());
+            return getOriginal(asset);
         }
         return filter(bestRendition);
     }
@@ -517,7 +527,9 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
     @NotNull
     private EnhancedRendition getOriginal(@NotNull Asset asset) throws IOException {
         EnhancedRendition original = new EnhancedRendition(asset.getOriginal());
-        return filter(original);
+        EnhancedRendition filtered = filter(original);
+        metrics.markOriginalRenditionUsed();
+        return filtered;
     }
 
     /**
@@ -534,6 +546,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
         if (dimension != null && dimension.getWidth() <= maxInputWidth) {
             return rendition;
         }
+        metrics.markRejectedTooLargeRendition();
         throw new IOException(String.format("Cannot process rendition %s due to size %s", rendition.getName(), rendition.getDimension()));
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumer.java
@@ -71,6 +71,9 @@ public class AdaptiveImageServletMappingConfigurationConsumer {
 
     @Reference
     private ConfigurationAdmin configurationAdmin;
+    
+    @Reference
+    AdaptiveImageServletMetrics metrics;
 
 
     /**
@@ -166,6 +169,7 @@ public class AdaptiveImageServletMappingConfigurationConsumer {
                                 new AdaptiveImageServlet(
                                         mimeTypeService,
                                         assetStore,
+                                        metrics,
                                         oldAISDefaultResizeWidth > 0 ? oldAISDefaultResizeWidth : config.getDefaultResizeWidth(),
                                         config.getMaxSize()),
                                 properties

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetrics.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetrics.java
@@ -41,7 +41,7 @@ public class AdaptiveImageServletMetrics {
     // record the duration of the request
     private Timer requestDuration;
     // how often the image couldn't served
-    private Counter imageError;
+    private Counter imageErrors;
     
     @Activate
     public void activate() {
@@ -50,7 +50,7 @@ public class AdaptiveImageServletMetrics {
         baseRenditionRejected = metricsService.counter(BASENAME + "base-rendition-rejected-because-of-size");
         imageStreamed = metricsService.counter(BASENAME + "rendition-rendered");
         requestDuration = metricsService.timer(BASENAME + "request-duration");
-        
+        imageErrors = metricsService.counter(BASENAME + "image-errors");
     }
     
     public void markServletInvocation() {
@@ -69,8 +69,8 @@ public class AdaptiveImageServletMetrics {
         imageStreamed.increment();
     }
 
-    public void markImageError() {
-        imageError.increment();
+    public void markImageErrors() {
+        imageErrors.increment();
     }
     
     public Timer.Context startDurationRecording() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetrics.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetrics.java
@@ -1,0 +1,75 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.servlets;
+
+import org.apache.sling.commons.metrics.Counter;
+import org.apache.sling.commons.metrics.MetricsService;
+import org.apache.sling.commons.metrics.Timer;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(service=AdaptiveImageServletMetrics.class)
+public class AdaptiveImageServletMetrics {
+    
+    private static final String BASENAME = "com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServlet:";
+    
+    @Reference
+    MetricsService metricsService;
+    
+    // the total number of invocations of the servlet
+    private Counter invocations;
+    // how often the original rendition was used as basis for the rendition
+    private Counter originalRenditionUsed;
+    // how often a base rendition has been rejected because it exceeded the configured limits
+    private Counter baseRenditionRejected;
+    // how often a new rendition was actually created
+    private Counter renditionRendered;
+    // record the duration of the request
+    private Timer requestDuration;
+    
+    @Activate
+    public void activate() {
+        invocations = metricsService.counter(BASENAME + "invocations");
+        originalRenditionUsed = metricsService.counter(BASENAME + "original-rendition-used");
+        baseRenditionRejected = metricsService.counter(BASENAME + "base-rendition-rejected-because-of-size");
+        renditionRendered = metricsService.counter(BASENAME + "rendition-rendered");
+        requestDuration = metricsService.timer(BASENAME + "request-duration");
+        
+    }
+    
+    public void markServletInvocation() {
+        invocations.increment();
+    }
+    
+    public void markOriginalRenditionUsed() {
+        originalRenditionUsed.increment();
+    }
+    
+    public void markRejectedTooLargeRendition() {
+        baseRenditionRejected.increment();
+    }
+    
+    public void markRenditionRendered() {
+        renditionRendered.increment();
+    }
+    
+    public Timer.Context startDurationRecording() {
+        return requestDuration.time();
+    }
+    
+
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetrics.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetrics.java
@@ -37,16 +37,18 @@ public class AdaptiveImageServletMetrics {
     // how often a base rendition has been rejected because it exceeded the configured limits
     private Counter baseRenditionRejected;
     // how often a new rendition was actually created
-    private Counter renditionRendered;
+    private Counter imageStreamed;
     // record the duration of the request
     private Timer requestDuration;
+    // how often the image couldn't served
+    private Counter imageError;
     
     @Activate
     public void activate() {
         invocations = metricsService.counter(BASENAME + "invocations");
         originalRenditionUsed = metricsService.counter(BASENAME + "original-rendition-used");
         baseRenditionRejected = metricsService.counter(BASENAME + "base-rendition-rejected-because-of-size");
-        renditionRendered = metricsService.counter(BASENAME + "rendition-rendered");
+        imageStreamed = metricsService.counter(BASENAME + "rendition-rendered");
         requestDuration = metricsService.timer(BASENAME + "request-duration");
         
     }
@@ -63,8 +65,12 @@ public class AdaptiveImageServletMetrics {
         baseRenditionRejected.increment();
     }
     
-    public void markRenditionRendered() {
-        renditionRendered.increment();
+    public void markImageStreamed() {
+        imageStreamed.increment();
+    }
+
+    public void markImageError() {
+        imageError.increment();
     }
     
     public Timer.Context startDurationRecording() {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumerTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumerTest.java
@@ -53,6 +53,8 @@ public class AdaptiveImageServletMappingConfigurationConsumerTest {
     public void setUp() {
         AssetStore assetStore = mock(AssetStore.class);
         context.registerService(AssetStore.class, assetStore);
+        AdaptiveImageServletMetrics metrics = mock(AdaptiveImageServletMetrics.class);
+        context.registerService(AdaptiveImageServletMetrics.class, metrics);
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetricsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetricsTest.java
@@ -32,21 +32,12 @@ import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 @ExtendWith(AemContextExtension.class)
 public class AdaptiveImageServletMetricsTest {
-    
-    
-    
-    /**
-     * Oh really, you want me to write unit tests for this class, which 
-     * actually does not have ANY logic?
-     * 
-     * Ok, here we go ... don't be disappointed.
-     */
-    
+
     public final AemContext context = new AemContext();
     
     
     @BeforeEach
-    public void setup() {
+    void setup() {
         MetricsService s = mock (MetricsService.class);
         Timer timer = mock(Timer.class);
         when(timer.time()).thenReturn(mock(Timer.Context.class));
@@ -56,13 +47,14 @@ public class AdaptiveImageServletMetricsTest {
     }
     
     @Test
-    public void test() {
+    void test() {
         AdaptiveImageServletMetrics metrics = new AdaptiveImageServletMetrics();
         context.registerInjectActivateService(metrics);
         
         metrics.markOriginalRenditionUsed();
         metrics.markRejectedTooLargeRendition();
         metrics.markServletInvocation();
+        metrics.markRenditionRendered();
         Timer.Context c = metrics.startDurationRecording();
         assertNotNull(c); // silly, as it is a mock ...
       

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetricsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetricsTest.java
@@ -1,0 +1,72 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.servlets;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.sling.commons.metrics.Counter;
+import org.apache.sling.commons.metrics.MetricsService;
+import org.apache.sling.commons.metrics.Timer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+@ExtendWith(AemContextExtension.class)
+public class AdaptiveImageServletMetricsTest {
+    
+    
+    
+    /**
+     * Oh really, you want me to write unit tests for this class, which 
+     * actually does not have ANY logic?
+     * 
+     * Ok, here we go ... don't be disappointed.
+     */
+    
+    public final AemContext context = new AemContext();
+    
+    
+    @BeforeEach
+    public void setup() {
+        MetricsService s = mock (MetricsService.class);
+        Timer timer = mock(Timer.class);
+        when(timer.time()).thenReturn(mock(Timer.Context.class));
+        when(s.timer(Mockito.anyString())).thenReturn(timer);
+        when(s.counter(Mockito.anyString())).thenReturn(mock(Counter.class));
+        context.registerService(MetricsService.class, s);
+    }
+    
+    @Test
+    public void test() {
+        AdaptiveImageServletMetrics metrics = new AdaptiveImageServletMetrics();
+        context.registerInjectActivateService(metrics);
+        
+        metrics.markOriginalRenditionUsed();
+        metrics.markRejectedTooLargeRendition();
+        metrics.markServletInvocation();
+        Timer.Context c = metrics.startDurationRecording();
+        assertNotNull(c); // silly, as it is a mock ...
+      
+        
+    }
+
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetricsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetricsTest.java
@@ -54,7 +54,8 @@ public class AdaptiveImageServletMetricsTest {
         metrics.markOriginalRenditionUsed();
         metrics.markRejectedTooLargeRendition();
         metrics.markServletInvocation();
-        metrics.markRenditionRendered();
+        metrics.markImageStreamed();
+        metrics.markImageError();
         Timer.Context c = metrics.startDurationRecording();
         assertNotNull(c); // silly, as it is a mock ...
       

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetricsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetricsTest.java
@@ -55,7 +55,7 @@ public class AdaptiveImageServletMetricsTest {
         metrics.markRejectedTooLargeRendition();
         metrics.markServletInvocation();
         metrics.markImageStreamed();
-        metrics.markImageError();
+        metrics.markImageErrors();
         Timer.Context c = metrics.startDurationRecording();
         assertNotNull(c); // silly, as it is a mock ...
       

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletTest.java
@@ -31,6 +31,7 @@ import org.apache.http.HttpStatus;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.api.servlets.HttpConstants;
+import org.apache.sling.commons.metrics.Timer;
 import org.apache.sling.testing.mock.sling.servlet.MockRequestPathInfo;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
@@ -89,12 +90,14 @@ class AdaptiveImageServletTest extends AbstractImageTest {
         resourceResolver = context.resourceResolver();
         AssetHandler assetHandler = mock(AssetHandler.class);
         AssetStore assetStore = mock(AssetStore.class);
+        AdaptiveImageServletMetrics metrics = mock(AdaptiveImageServletMetrics.class);
+        when(metrics.startDurationRecording()).thenReturn(mock(Timer.Context.class));
         when(assetStore.getAssetHandler(anyString())).thenReturn(assetHandler);
         when(assetHandler.getImage(any(Rendition.class))).thenAnswer(invocation -> {
             Rendition rendition = invocation.getArgument(0);
             return ImageIO.read(rendition.getStream());
         });
-        servlet = new AdaptiveImageServlet(mockedMimeTypeService, assetStore, ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH, AdaptiveImageServlet.DEFAULT_MAX_SIZE);
+        servlet = new AdaptiveImageServlet(mockedMimeTypeService, assetStore, metrics, ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH, AdaptiveImageServlet.DEFAULT_MAX_SIZE);
         testLogger = TestLoggerFactory.getTestLogger(AdaptiveImageServlet.class);
     }
 


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | Fixes #1292
| Patch: Bug Fix?          | 
| Minor: New Feature?      | Yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Inline
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

The AdaptiveImageServlet now maintains statistics as Sling Metrics, which you can check via /system/console/slingmetrics.



<!-- Describe your changes below in as much detail as possible -->
