### PR TITLE
feat: Init teaser dialog even if description field is not present (#1…

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/clientlibs/editor/js/teaser.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/clientlibs/editor/js/teaser.js
@@ -37,16 +37,21 @@
         var dialogContent = $dialogContent.length > 0 ? $dialogContent[0] : undefined;
 
         if (dialogContent) {
-
-            var rteInstance = $(descriptionTextfieldSelector).data("rteinstance");
-            // wait for the description textfield rich text editor to signal start before initializing.
-            // Ensures that any state adjustments made here will not be overridden.
-            if (rteInstance && rteInstance.isActive) {
-                init(e, $dialog, $dialogContent, dialogContent);
-            } else {
-                $(descriptionTextfieldSelector).on("editing-start", function() {
+            var $descriptionTextfield = $(descriptionTextfieldSelector);
+            if ($descriptionTextfield.length) {
+                var rteInstance = $descriptionTextfield.data("rteinstance");
+                // wait for the description textfield rich text editor to signal start before initializing.
+                // Ensures that any state adjustments made here will not be overridden.
+                if (rteInstance && rteInstance.isActive) {
                     init(e, $dialog, $dialogContent, dialogContent);
-                });
+                } else {
+                    $descriptionTextfield.on("editing-start", function() {
+                        init(e, $dialog, $dialogContent, dialogContent);
+                    });
+                }
+            } else {
+                // init without description field
+                init(e, $dialog, $dialogContent, dialogContent);
             }
         }
     });


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1384
| Patch: Bug Fix?          |
| Minor: New Feature?      | Yes, depending on whether or not the use case should have been supported previously.
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
We initialize the teaser's dialog logic regardless of whether `.cq-RichText-editable[name="./jcr:description"]` is available or not.