### PR TITLE
Fix/1390 panelselect should ignore wrapper divs

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/accordion.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/accordion.html
@@ -14,6 +14,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.accordion="com.adobe.cq.wcm.core.components.models.Accordion"
+     data-panelcontainer="${wcmmode.edit && 'accordion'}"
      id="${accordion.id}"
      class="cmp-accordion"
      data-cmp-is="accordion"

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editorhook/js/panelcontainer.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editorhook/js/panelcontainer.js
@@ -22,6 +22,7 @@
             window.CQ.CoreComponents.panelcontainer.v1.registry.register({
                 name: "cmp-accordion",
                 selector: ".cmp-accordion",
+                wrapperSelector: '[data-panelcontainer="accordion"]',
                 itemSelector: "[data-cmp-hook-accordion='panel']",
                 itemActiveSelector: "[data-cmp-hook-accordion='item'][data-cmp-expanded] [data-cmp-hook-accordion='panel']"
             });

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -15,6 +15,7 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.carousel="com.adobe.cq.wcm.core.components.models.Carousel"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+     data-panelcontainer="${wcmmode.edit && 'carousel'}"
      id="${carousel.id}"
      class="cmp-carousel"
      role="group"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/editorhook/js/panelcontainer.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/editorhook/js/panelcontainer.js
@@ -22,6 +22,7 @@
             window.CQ.CoreComponents.panelcontainer.v1.registry.register({
                 name: "cmp-carousel",
                 selector: ".cmp-carousel",
+                wrapperSelector: '[data-panelcontainer="carousel"]',
                 itemSelector: "[data-cmp-hook-carousel='item']",
                 itemActiveSelector: ".cmp-carousel__item--active"
             });

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/panelContainerUtils.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/panelContainerUtils.js
@@ -58,7 +58,7 @@
             var element;
 
             if (container) {
-                element = editable.dom.find(container.selector)[0];
+                element = editable.dom.filter(container.selector)[0] || editable.dom.find(container.selector)[0];
             }
 
             return element;
@@ -96,7 +96,7 @@
             for (var i = 0; i < panelContainerTypes.length; i++) {
                 var container = panelContainerTypes[i];
 
-                if (editable.dom.find(container.selector)) {
+                if (editable.dom.is(container.selector) || editable.dom.find(container.selector).length) {
                     panelContainerType = container;
                     break;
                 }

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/panelContainerUtils.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/panelContainerUtils.js
@@ -55,13 +55,10 @@
          */
         getPanelContainerHTMLElement: function(editable) {
             var container = getPanelContainerType(editable);
-            var element;
 
             if (container) {
-                element = editable.dom.filter(container.selector)[0] || editable.dom.find(container.selector)[0];
+                return editable.dom.filter(container.selector)[0] || editable.dom.find(container.selector)[0];
             }
-
-            return element;
         },
 
         /**
@@ -95,8 +92,22 @@
         if (editable && editable.dom) {
             for (var i = 0; i < panelContainerTypes.length; i++) {
                 var container = panelContainerTypes[i];
+                var selector = container.wrapperSelector || container.selector;
 
-                if (editable.dom.is(container.selector) || editable.dom.find(container.selector).length) {
+                var match = $(editable.dom[0]).is(selector);
+
+                // look for a match at the editable DOM wrapper, if none is found, try its children.
+                if (!match) {
+                    var children = editable.dom[0].children;
+                    for (var j = 0; j < children.length; j++) {
+                        var child = children[j];
+                        match = $(child).is(selector);
+                        if (match) {
+                            break;
+                        }
+                    }
+                }
+                if (match) {
                     panelContainerType = container;
                     break;
                 }

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/panelContainerUtils.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/panelContainerUtils.js
@@ -58,18 +58,7 @@
             var element;
 
             if (container) {
-                if ($(editable.dom[0]).is(container.selector)) {
-                    element = editable.dom[0];
-                } else {
-                    var children = editable.dom[0].children;
-                    for (var i = 0; i < children.length; i++) {
-                        var child = children[i];
-                        if ($(child).is(container.selector)) {
-                            element = child;
-                            break;
-                        }
-                    }
-                }
+                element = editable.dom.find(container.selector)[0];
             }
 
             return element;
@@ -106,20 +95,8 @@
         if (editable && editable.dom) {
             for (var i = 0; i < panelContainerTypes.length; i++) {
                 var container = panelContainerTypes[i];
-                var match = $(editable.dom[0]).is(container.selector);
 
-                // look for a match at the editable DOM wrapper, if none is found, try its children.
-                if (!match) {
-                    var children = editable.dom[0].children;
-                    for (var j = 0; j < children.length; j++) {
-                        var child = children[j];
-                        match = $(child).is(container.selector);
-                        if (match) {
-                            break;
-                        }
-                    }
-                }
-                if (match) {
+                if (editable.dom.find(container.selector)) {
                     panelContainerType = container;
                     break;
                 }

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/panelContainerUtils.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/panelContainerUtils.js
@@ -55,10 +55,13 @@
          */
         getPanelContainerHTMLElement: function(editable) {
             var container = getPanelContainerType(editable);
+            var element;
 
             if (container) {
-                return editable.dom.filter(container.selector)[0] || editable.dom.find(container.selector)[0];
+                element = editable.dom.filter(container.selector)[0] || editable.dom.find(container.selector)[0];
             }
+
+            return element;
         },
 
         /**

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/editorhook/js/panelcontainer.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/editorhook/js/panelcontainer.js
@@ -22,6 +22,7 @@
             window.CQ.CoreComponents.panelcontainer.v1.registry.register({
                 name: "cmp-tabs",
                 selector: ".cmp-tabs",
+                wrapperSelector: '[data-panelcontainer="tabs"]',
                 itemSelector: "[data-cmp-hook-tabs='tabpanel']",
                 itemActiveSelector: ".cmp-tabs__tabpanel--active"
             });

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
@@ -15,6 +15,7 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.tabs="com.adobe.cq.wcm.core.components.models.Tabs"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+     data-panelcontainer="${wcmmode.edit && 'tabs'}"
      id="${tabs.id}"
      class="cmp-tabs"
      data-cmp-is="tabs"


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1390
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | We don't have FE tests for editor clientlibs
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Looking for the panel container recursively (by using jQuery.find()) allows us to ignore arbitrary wrapper elements and makes us much more flexible in terms of how the proxy component is structured.