### PR TITLE
CaConfigReferenceProvider hardcodes references to specific Core Components context-aware configs #1393

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider.java
@@ -21,12 +21,10 @@ import java.util.List;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.caconfig.management.ConfigurationManager;
 import org.apache.sling.caconfig.resource.ConfigurationResourceResolver;
 import org.osgi.service.component.annotations.Component;
 
-import com.adobe.cq.wcm.core.components.config.HtmlPageItemsConfig;
-import com.adobe.cq.wcm.core.components.internal.DataLayerConfig;
-import com.adobe.cq.wcm.core.components.internal.services.pdfviewer.PdfViewerCaConfig;
 import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
@@ -46,6 +44,12 @@ public class CaConfigReferenceProvider implements ReferenceProvider {
     private static final String CA_CONFIG_REFERENCE_TYPE = "caconfig";
 
     /**
+     * The {@link ConfigurationManager} service;
+     */
+    @org.osgi.service.component.annotations.Reference
+    private ConfigurationManager configurationManager;
+
+    /**
      * The @{@link ConfigurationResourceResolver} service.
      */
     @org.osgi.service.component.annotations.Reference
@@ -63,9 +67,9 @@ public class CaConfigReferenceProvider implements ReferenceProvider {
         if (page == null) {
             return references;
         }
-        addCaConfigReference(HtmlPageItemsConfig.class.getName(), resource, references);
-        addCaConfigReference(DataLayerConfig.class.getName(), resource, references);
-        addCaConfigReference(PdfViewerCaConfig.class.getName(), resource, references);
+        for (String config : configurationManager.getConfigurationNames()) {
+            addCaConfigReference(config, resource, references);
+        }
         return references;
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProviderTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProviderTest.java
@@ -16,15 +16,20 @@
 package com.adobe.cq.wcm.core.components.internal.services;
 
 import java.util.List;
+import java.util.TreeSet;
 
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.caconfig.management.ConfigurationManager;
 import org.apache.sling.testing.mock.caconfig.MockContextAwareConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 
 import com.adobe.cq.wcm.core.components.config.HtmlPageItemsConfig;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
+import com.adobe.cq.wcm.core.components.internal.DataLayerConfig;
+import com.adobe.cq.wcm.core.components.internal.services.pdfviewer.PdfViewerCaConfig;
 import com.day.cq.wcm.api.reference.Reference;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
@@ -49,6 +54,13 @@ class CaConfigReferenceProviderTest {
         context.load().json(TEST_BASE + "/test-content.json", TEST_PAGE);
         context.load().json(TEST_BASE + "/test-sling-configs.json", SLING_CONFIGS_ROOT);
         MockContextAwareConfig.registerAnnotationClasses(context, HtmlPageItemsConfig.class);
+        ConfigurationManager mockConfigurationManager = Mockito.mock(ConfigurationManager.class);
+        Mockito.when(mockConfigurationManager.getConfigurationNames()).thenReturn(new TreeSet<String>() {{
+            add(HtmlPageItemsConfig.class.getName());
+            add(DataLayerConfig.class.getName());
+            add(PdfViewerCaConfig.class.getName());
+        }});
+        context.registerService(ConfigurationManager.class, mockConfigurationManager);
         caConfigReferenceProvider = context.registerInjectActivateService(new CaConfigReferenceProvider());
     }
 


### PR DESCRIPTION
* Update reference provider to pick configurations dinamically
* Updated test

Fixes #1393
