### PR TITLE
CIF-1942 - CIF components library can be removed by CORE components l…

### DIFF
--- a/examples/ui.content/src/content/META-INF/vault/filter.xml
+++ b/examples/ui.content/src/content/META-INF/vault/filter.xml
@@ -15,9 +15,23 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <workspaceFilter version="1.0">
-    <filter root="/conf/core-components-examples"/>
-    <filter root="/content/core-components-examples"/>
+
+    <!-- All the exclude rules are defined for Commerce content coming from https://github.com/adobe/aem-core-cif-components/tree/master/examples/ui.content -->
+
+    <filter root="/conf/core-components-examples">
+        <exclude pattern="/conf/core-components-examples/settings/cloudconfigs(/.*)?"/>
+        <exclude pattern="/conf/core-components-examples/settings/wcm/templates/content-page/structure/jcr:content/root/sidebar/accordion/item_1579021109269"/>
+    </filter>
+    <filter root="/content/core-components-examples">
+        <exclude pattern="/content/core-components-examples/library/jcr:content/root/responsivegrid/container_1589240807(/.*)?"/>
+        <exclude pattern="/content/core-components-examples/library/commerce(/.*)?"/>
+    </filter>
     <filter root="/content/cq:tags/core-components-examples"/>
-    <filter root="/content/dam/core-components-examples"/>
-    <filter root="/content/experience-fragments/core-components-examples"/>
+    <filter root="/content/dam/core-components-examples">
+        <exclude pattern="/content/dam/core-components-examples/library/cif-sample-assets(/.*)?"/>
+        <exclude pattern="/content/dam/core-components-examples/library/cif-components(/.*)?"/>
+    </filter>
+    <filter root="/content/experience-fragments/core-components-examples">
+        <exclude pattern="/content/experience-fragments/core-components-examples/library/commerce(/.*)?"/>
+    </filter>
 </workspaceFilter>

--- a/examples/ui.content/src/content/jcr_root/conf/core-components-examples/settings/wcm/templates/content-page/structure/.content.xml
+++ b/examples/ui.content/src/content/jcr_root/conf/core-components-examples/settings/wcm/templates/content-page/structure/.content.xml
@@ -62,7 +62,7 @@
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core-components-examples/components/accordion"
-                    expandedItems="[item_1579021121673,item_1579021131667,item_1579021109267,item_1579021109268]"
+                    expandedItems="[item_1579021121673,item_1579021131667,item_1579021109267,item_1579021109268,item_1579021109269]"
                     singleExpansion="false">
                     <item_1579021121673
                         cq:panelTitle="Templating"
@@ -104,6 +104,7 @@
                         navigationRoot="/content/core-components-examples/library/form"
                         structureDepth="1"
                         structureStart="1"/>
+                    <item_1579021109269/> <!-- Commerce menu items -->
                 </accordion>
             </sidebar>
             <responsivegrid

--- a/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/.content.xml
+++ b/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/.content.xml
@@ -840,6 +840,7 @@
                         </cq:responsive>
                     </teaser_1276818310>
                 </container_1589240806>
+                <container_1589240807/>
                 <text_557507476
                     cq:styleIds="[1550360114923]"
                     jcr:created="{Date}2019-02-17T01:01:23.716+01:00"
@@ -858,4 +859,5 @@
     <page-authoring/>
     <container/>
     <form/>
+    <commerce/> <!-- Commerce content coming from https://github.com/adobe/aem-core-cif-components/tree/master/examples/ui.content -->
 </jcr:root>

--- a/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/.content.xml
+++ b/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/.content.xml
@@ -840,7 +840,7 @@
                         </cq:responsive>
                     </teaser_1276818310>
                 </container_1589240806>
-                <container_1589240807/>
+                <container_1589240807/> <!-- Commerce components on main library page -->
                 <text_557507476
                     cq:styleIds="[1550360114923]"
                     jcr:created="{Date}2019-02-17T01:01:23.716+01:00"


### PR DESCRIPTION
…ibrary

- adds exclude rules to filter out commerce content locations
- adds placeholders and menu item placeholder

This PR ensures that installing the core components examples _**after**_ the cif components examples would not remove any Commerce content.