### PR TITLE
nullcheck to avoid 500 if asset does not exist #1414

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -873,7 +873,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
             String fileReference = component.getValueMap().get(DownloadResource.PN_REFERENCE, String.class);
             if (StringUtils.isNotEmpty(fileReference)) {
                 imageResource = component.getResourceResolver().getResource(fileReference);
-                if(imageResource != null) {
+                if (imageResource != null) {
                     source = Source.ASSET;
                 }
             } else {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -873,7 +873,9 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
             String fileReference = component.getValueMap().get(DownloadResource.PN_REFERENCE, String.class);
             if (StringUtils.isNotEmpty(fileReference)) {
                 imageResource = component.getResourceResolver().getResource(fileReference);
-                source = Source.ASSET;
+                if(imageResource != null) {
+                    source = Source.ASSET;
+                }
             } else {
                 Resource childFileNode = component.getChild(DownloadResource.NN_FILE);
                 if (childFileNode != null) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractImageTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractImageTest.java
@@ -74,6 +74,7 @@ public class AbstractImageTest {
     protected static final String IMAGE27_PATH = PAGE + "/jcr:content/root/image27";
     protected static final String IMAGE28_PATH = PAGE + "/jcr:content/root/image28";
     protected static final String IMAGE29_PATH = PAGE + "/jcr:content/root/image29";
+    protected static final String IMAGE30_PATH = PAGE + "/jcr:content/root/image30";
     protected static final String TEMPLATE_PATH = "/conf/coretest/settings/wcm/templates/testtemplate";
     protected static final String TEMPLATE_STRUCTURE_PATH = TEMPLATE_PATH + "/structure";
     protected static final String TEMPLATE_IMAGE_PATH = TEMPLATE_STRUCTURE_PATH + "/jcr:content/root/image_template";

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletTest.java
@@ -591,6 +591,16 @@ class AdaptiveImageServletTest extends AbstractImageTest {
     }
 
     @Test
+    void testFileReferenceNonexistingAsset() throws Exception {
+        Pair<MockSlingHttpServletRequest, MockSlingHttpServletResponse> requestResponsePair = prepareRequestResponsePair(IMAGE30_PATH,
+                "img", "png");
+        MockSlingHttpServletRequest request = requestResponsePair.getLeft();
+        MockSlingHttpServletResponse response = requestResponsePair.getRight();
+        servlet.doGet(request, response);
+        Assertions.assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+    }
+
+    @Test
     void testDifferentSuffixExtension() throws IOException {
         Pair<MockSlingHttpServletRequest, MockSlingHttpServletResponse> requestResponsePair =
                 prepareRequestResponsePair(IMAGE3_PATH, 1490005239000L, "img.600", "png", "jpeg");

--- a/bundles/core/src/test/resources/image/test-content.json
+++ b/bundles/core/src/test/resources/image/test-content.json
@@ -405,6 +405,14 @@
                     "fileReference"     : "/content/dam/core/images/transparent_hd.png",
                     "alt"               : "Transparent Image",
                     "jcr:title"         : "Transparent Image"
+                },
+                "image30"            : {
+                    "jcr:primaryType"   : "nt:unstructured",
+                    "jcr:createdBy"     : "admin",
+                    "sling:resourceType": "core/wcm/components/image/v1/image",
+                    "fileReference"     : "/content/dam/core/images/nonexisting.png",
+                    "alt"               : "Adobe Logo",
+                    "jcr:title"         : "Adobe Logo"
                 }
             },
             "cq:template": "/conf/coretest/settings/wcm/templates/testtemplate"


### PR DESCRIPTION
<!-- Describe your changes below in as much detail as possible -->

As described in the issue, requesting a core image component that has a file reference which points to a non existinga asset triggers several exceptions and results the request to be responded as a 500 instead of a 404.

I fixed this by simply null checking the imageResource before setting the source to Source.ASSET. The source will remain to be set to Source.NONEXISTING and the therefore correctly be treated as nonexisting (404)

There is a description on how to reproduce this as well as an example har file attached to the ticket. 

I added an unit-test to ensure the HttpServletResponse code to be correct.

Fixes #1414 