### PR TITLE
IT HTTP tests fail when defined to run with random AEM Ports

### DIFF
--- a/testing/it/http/pom.xml
+++ b/testing/it/http/pom.xml
@@ -198,10 +198,6 @@
                                     <goal>integration-test</goal>
                                 </goals>
                                 <configuration>
-                                    <systemPropertyVariables>
-                                        <granite.it.author.url>${granite.it.author.url}</granite.it.author.url>
-                                        <granite.it.publish.url>${granite.it.publish.url}</granite.it.publish.url>
-                                    </systemPropertyVariables>
                                     <includes>
                                         <include>**/*IT.java</include>
                                         <include>**/*SST.java</include>


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1438
| Patch: Bug Fix?          | bug
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | Yes
| Documentation Provided   | not needed
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

removed `<systemPropertyVariables>` set for `granite.it.author.url` and `granite.it.publish.url` as this can lead to miss-configured instances if used together with `sling.it.instances.*` properties
