### PR TITLE
Specify "cq:Component" as model resource type for `ComponentImpl`

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentImpl.java
@@ -15,11 +15,18 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
+import com.day.cq.wcm.api.NameConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
 import com.adobe.cq.wcm.core.components.models.Component;
 
-@Model(adaptables = SlingHttpServletRequest.class, adapters = Component.class)
-public class ComponentImpl extends AbstractComponentImpl {
+/**
+ * Default component model implementation.
+ *
+ * This component model implementations allows resource whose component does not have a model, or whose model
+ * does not list {@link Component} as an adapter, to be adapted to {@link Component}.
+ */
+@Model(adaptables = SlingHttpServletRequest.class, adapters = Component.class, resourceType = NameConstants.NT_COMPONENT)
+public final class ComponentImpl extends AbstractComponentImpl {
 }


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #1447 
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | N/A
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Adds the resource type "cq:Component" to the model definition for
the default Component implementation (`ComponentImpl`).

This change allows other models to indicate `Component.class` as an
adapter, and have those models take precedence based on resource type
hierarchy, without interfering with `ComponentImpl` being used as the
default fallback for any component that does not have a model with
a more specific resource type defined.
