### PR TITLE
[Container] Background image with whitespace do not work

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
@@ -196,7 +196,11 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
     public String getBackgroundStyle() {
         if (this.backgroundStyle == null) {
             StringBuilder styleBuilder = new StringBuilder();
-            getBackgroundImage().ifPresent(image -> styleBuilder.append("background-image:url(").append(image).append(");background-size:cover;background-repeat:no-repeat;"));
+            getBackgroundImage().ifPresent(image -> {
+                styleBuilder.append("background-image:url(")
+                    .append(image.replace(" ","%20"))
+                    .append(");background-size:cover;background-repeat:no-repeat;");
+            });
             getBackgroundColor().ifPresent(color -> styleBuilder.append("background-color:").append(color).append(";"));
             this.backgroundStyle = styleBuilder.toString();
         }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1468
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | Yes
| Documentation Provided   | no
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

Images with whitespace in the name should work. Can be reproduced by uploading an asset with spaces as an background image. According to [W3C Standard](https://www.w3.org/TR/2011/REC-CSS2-20110607/syndata.html#uri) the URI values should either be in single or double quotes or special characters like whitespace should be escaped.

Can't use quotes, since this gets escaped in the output by the `@context` setting:

`style="${container.backgroundStyle @ context='styleString'}"`

in [responsive grid](https://github.com/adobe/aem-core-wcm-components/blob/master/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/responsiveGrid.html#L19) and [simple](https://github.com/adobe/aem-core-wcm-components/blob/master/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/simple.html#L21) container as `\27`:

`url(\27\2f content\2f dam\2fname with space.jpg\27)`

Can't use [URL.Encoder](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/URLEncoder.html) to encode special characters either as as it encodes whitespace as `+` instead of `%20`. For now  its implemented as a simple search replace  which seems a bit hacky, any suggestions welcome.
