### PR TITLE
[Accessibility][Container] Allow to define ARIA labels on the container 

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImpl.java
@@ -24,8 +24,11 @@ import javax.annotation.PostConstruct;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.wcm.core.components.models.LayoutContainer;
 
@@ -50,6 +53,13 @@ public class LayoutContainerImpl extends AbstractContainerImpl implements Layout
      * The layout type.
      */
     private LayoutType layout;
+
+    /**
+     * The accessibility label.
+     */
+    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
+    private String accessibilityLabel;
 
     /**
      * Initialize the model.
@@ -83,5 +93,11 @@ public class LayoutContainerImpl extends AbstractContainerImpl implements Layout
     @Override
     public @NotNull LayoutType getLayout() {
         return layout;
+    }
+
+    @Override
+    @Nullable
+    public String getAccessibilityLabel() {
+        return accessibilityLabel;
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/LayoutContainer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/LayoutContainer.java
@@ -71,4 +71,14 @@ public interface LayoutContainer extends Container {
     default LayoutType getLayout() {
         return LayoutType.SIMPLE;
     }
+
+    /**
+     * Returns an accessibility label that describes the container.
+     *
+     * @return an accessibility label for the container
+     * @since com.adobe.cq.wcm.core.components.models 12.20.0
+     */
+    default String getAccessibilityLabel() {
+        return null;
+    }
 }

--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/_cq_dialog/.content.xml
@@ -123,6 +123,13 @@
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
                                                 name="./id"/>
+                                            <accessibilityLabel
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="Value of an aria-label attribute for the container, which describes the container content."
+                                                fieldLabel="Label"
+                                                name="./accessibilityLabel"
+                                                value=""/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/responsiveGrid.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/responsiveGrid.html
@@ -16,6 +16,7 @@
 <template data-sly-template.responsiveGrid="${ @ container}">
     <div id="${container.id}"
          class="cmp-container"
+         aria-label="${container.accessibilityLabel}"
          style="${container.backgroundStyle @ context='styleString'}">
         <sly data-sly-resource="${resource @ resourceType='wcm/foundation/components/responsivegrid'}"></sly>
     </div>

--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/simple.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/simple.html
@@ -18,6 +18,7 @@
     <div data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
          id="${container.id}"
          class="cmp-container${wcmmode.edit ? ' {0}': '' @ format=[allowed.cssClass]}"
+         aria-label="${container.accessibilityLabel}"
          style="${container.backgroundStyle @ context='styleString'}">
         <sly data-sly-test.isAllowedApplicable="${allowed.isApplicable}"
              data-sly-test="${isAllowedApplicable}"


### PR DESCRIPTION
- allow authors to define the aria-label attribute on the same tab of the edit dialog, for the container component.
Fixes #1469 
