### PR TITLE
Creation of multiple items throw JS error

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/childreneditor/v1/childreneditor/clientlibs/js/childreneditor.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/childreneditor/v1/childreneditor/clientlibs/js/childreneditor.js
@@ -233,7 +233,7 @@
                                     });
                                 });
                                 // unbind events on dialog close
-                                channel.one("dialog-closed", function() {
+                                channel.one("coral-overlay:beforeclose", function() {
                                     selectList.off("coral-selectlist:change" + NS);
                                 });
                             }


### PR DESCRIPTION
- use correct event for unbinding select list changes
fixes #1489

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1489 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
