### PR TITLE
[Container] Background image with whitespace do not work

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
@@ -160,7 +160,22 @@ public class LinkHandler {
     private String getLinkURL(@NotNull String path) {
         return getPage(path)
                 .map(page -> getPageLinkURL(page))
-                .orElse(path);
+                .orElse(map(path));
+    }
+
+    /**
+     * Tries to map the provided {@code path}.
+     *
+     * @param path the path to map
+     * @return the mapped path or the original one, in case mapping fails.
+     */
+    @NotNull
+    private String map(@NotNull String path) {
+        try {
+            return StringUtils.defaultString(request.getResourceResolver().map(request, path), path);
+        } catch (Exception e) {
+            return path;
+        }
     }
 
     /**
@@ -179,7 +194,7 @@ public class LinkHandler {
         } else {
             pageLinkURL = vanityURL;
         }
-        return StringUtils.defaultString(request.getResourceResolver().map(request, pageLinkURL));
+        return map(pageLinkURL);
     }
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.SlingModelFilter;
+import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.Container;
 import com.adobe.cq.wcm.core.components.models.ListItem;
@@ -177,7 +178,7 @@ public abstract class AbstractContainerImpl extends AbstractComponentImpl implem
     private Optional<String> getBackgroundImage() {
         return Optional.ofNullable(this.currentStyle)
             .filter(style -> style.get(PN_BACKGROUND_IMAGE_ENABLED, Boolean.FALSE))
-            .flatMap(style -> Optional.ofNullable(this.resource.getValueMap().get(PN_BACKGROUND_IMAGE_REFERENCE, String.class)))
+            .flatMap(style -> linkHandler.getLink(resource, PN_BACKGROUND_IMAGE_REFERENCE).map(Link::getURL))
             .filter(StringUtils::isNotEmpty);
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImplTest.java
@@ -45,7 +45,7 @@ class DownloadImplTest {
     private static final String PDF_ASSET_WITHOUT_SIZE_PROP_PATH = "/content/dam/core/documents_without_size/" + PDF_BINARY_NAME;
     private static final String PDF_FILE_PATH = "/content/downloads/jcr:content/root/responsivegrid/download-3/file";
     private static final String PDF_ASSET_DOWNLOAD_PATH = PDF_ASSET_PATH + "." + DownloadServlet.SELECTOR + ".pdf";
-    private static final String PDF_FILE_DOWNLOAD_PATH = PDF_FILE_PATH + "." + DownloadServlet.SELECTOR + ".inline.pdf/" + PDF_BINARY_NAME;
+    private static final String PDF_FILE_DOWNLOAD_PATH = PDF_FILE_PATH.replace("jcr:content", "_jcr_content") + "." + DownloadServlet.SELECTOR + ".inline.pdf/" + PDF_BINARY_NAME;
     private static final String TEST_CONTENT_DAM_JSON = "/test-content-dam.json";
     private static final String TEST_CONTENT_DAM_WITHOUT_SIZE_PROP_JSON = "/test-content-dam-without-size-prop.json";
     private static final String CONTEXT_PATH = "/core";
@@ -84,7 +84,7 @@ class DownloadImplTest {
         Download download = getDownloadUnderTest(DOWNLOAD_1);
         assertEquals(TITLE, download.getTitle());
         assertEquals(DESCRIPTION, download.getDescription());
-        assertEquals(PDF_ASSET_DOWNLOAD_PATH, download.getUrl());
+        assertEquals(CONTEXT_PATH + PDF_ASSET_DOWNLOAD_PATH, download.getUrl());
         assertEquals(PDF_FILENAME, download.getFilename());
         assertEquals(PDF_EXTENSION, download.getExtension());
         assertEquals(PDF_FILESIZE_STRING, download.getSize());
@@ -101,7 +101,7 @@ class DownloadImplTest {
         Download download = getDownloadUnderTest(DOWNLOAD_4);
         assertEquals(TITLE, download.getTitle());
         assertEquals(DESCRIPTION, download.getDescription());
-        assertEquals(PDF_ASSET_WITHOUT_SIZE_PROP_PATH + "." + DownloadServlet.SELECTOR + ".pdf", download.getUrl());
+        assertEquals(CONTEXT_PATH + PDF_ASSET_WITHOUT_SIZE_PROP_PATH + "." + DownloadServlet.SELECTOR + ".pdf", download.getUrl());
         assertEquals(PDF_FILENAME, download.getFilename());
         assertEquals(PDF_EXTENSION, download.getExtension());
         assertEquals(PDF_FILESIZE_STRING, download.getSize());
@@ -114,7 +114,7 @@ class DownloadImplTest {
         Download download = getDownloadUnderTest(DOWNLOAD_3);
         assertEquals(TITLE, download.getTitle());
         assertEquals(DESCRIPTION, download.getDescription());
-        assertEquals(PDF_FILE_DOWNLOAD_PATH, download.getUrl());
+        assertEquals(CONTEXT_PATH + PDF_FILE_DOWNLOAD_PATH, download.getUrl());
         assertEquals(PDF_FILENAME, download.getFilename());
         assertEquals(PDF_EXTENSION, download.getExtension());
         assertEquals(PDF_FORMAT_STRING, download.getFormat());
@@ -127,7 +127,7 @@ class DownloadImplTest {
         Download download = getDownloadUnderTest(DOWNLOAD_2);
         assertEquals(DAM_TITLE, download.getTitle());
         assertEquals(DAM_DESCRIPTION, download.getDescription());
-        assertEquals(PDF_ASSET_DOWNLOAD_PATH, download.getUrl());
+        assertEquals(CONTEXT_PATH + PDF_ASSET_DOWNLOAD_PATH, download.getUrl());
         assertEquals(PDF_FILENAME, download.getFilename());
         assertEquals(PDF_EXTENSION, download.getExtension());
         assertEquals(PDF_FILESIZE_STRING, download.getSize());

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImplTest.java
@@ -44,6 +44,7 @@ public class LayoutContainerImplTest {
     private static final String CONTAINER_1 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/container-1";
     private static final String CONTAINER_2 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/container-2";
     private static final String CONTAINER_3 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/container-3";
+    private static final String CONTAINER_4 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/container-4";
     private static final String TEST_APPS_ROOT = "/apps/core/wcm/components";
 
     public final AemContext context = CoreComponentTestContext.newAemContext();
@@ -105,6 +106,18 @@ public class LayoutContainerImplTest {
         LayoutContainer container = getContainerUnderTest(CONTAINER_3);
         assertEquals("container-d7eba9c61f", container.getId(), "ID mismatch");
         assertNull(container.getBackgroundStyle(), "Style");
+    }
+
+    @Test
+    public void testSpaceEscapingInBackgroundImage() {
+        context.contentPolicyMapping(LayoutContainerImpl.RESOURCE_TYPE_V1, new HashMap<String, Object>() {{
+            put(Container.PN_BACKGROUND_IMAGE_ENABLED, true);
+            put(Container.PN_BACKGROUND_COLOR_ENABLED, true);
+            put(LayoutContainer.PN_LAYOUT, "simple");
+        }});
+        LayoutContainer container = getContainerUnderTest(CONTAINER_4);
+        assertEquals("container-ece469fc8b", container.getId(), "ID mismatch");
+        assertEquals("background-image:url(/content/dam/core-components-examples/library/sample-assets/mountain%20range.jpg);background-size:cover;background-repeat:no-repeat;background-color:#000000;", container.getBackgroundStyle(), "Style mismatch");
     }
 
     private void verifyContainerItems(Object[][] expectedItems, List<ListItem> items) {

--- a/bundles/core/src/test/resources/container/test-content.json
+++ b/bundles/core/src/test/resources/container/test-content.json
@@ -44,6 +44,13 @@
                         "sling:resourceType": "core/wcm/components/container/v1/container",
                         "backgroundColor": "#000000",
                         "backgroundImageReference": "/content/dam/core-components-examples/library/sample-assets/mountain-range.jpg"
+                    },
+                    "container-4"       : {
+                        "jcr:primaryType"   : "nt:unstructured",
+                        "jcr:title"         : "Container 4",
+                        "sling:resourceType": "core/wcm/components/container/v1/container",
+                        "backgroundColor": "#000000",
+                        "backgroundImageReference": "/content/dam/core-components-examples/library/sample-assets/mountain range.jpg"
                     }
                 }
             }

--- a/bundles/core/src/test/resources/download/exporter-download-fully-configured-file.json
+++ b/bundles/core/src/test/resources/download/exporter-download-fully-configured-file.json
@@ -1,5 +1,5 @@
 {
-  "url": "/content/downloads/jcr:content/root/responsivegrid/download-3/file.coredownload.inline.pdf/Download_Test_PDF.pdf",
+  "url": "/core/content/downloads/_jcr_content/root/responsivegrid/download-3/file.coredownload.inline.pdf/Download_Test_PDF.pdf",
   "title": "Download",
   "description": "Description",
   "actionText": "Click",

--- a/bundles/core/src/test/resources/download/exporter-download-fully-configured.json
+++ b/bundles/core/src/test/resources/download/exporter-download-fully-configured.json
@@ -1,5 +1,5 @@
 {
-  "url": "/content/dam/core/documents/Download_Test_PDF.pdf.coredownload.pdf",
+  "url": "/core/content/dam/core/documents/Download_Test_PDF.pdf.coredownload.pdf",
   "title": "Download",
   "description": "Description",
   "actionText": "Click",

--- a/bundles/core/src/test/resources/download/exporter-download-with-dam-properties.json
+++ b/bundles/core/src/test/resources/download/exporter-download-with-dam-properties.json
@@ -1,5 +1,5 @@
 {
-  "url": "/content/dam/core/documents/Download_Test_PDF.pdf.coredownload.pdf",
+  "url": "/core/content/dam/core/documents/Download_Test_PDF.pdf.coredownload.pdf",
   "title": "This is the title from the PDF.",
   "description": "This is the description from the PDF.",
   "filename": "Download_Test_PDF.pdf",

--- a/bundles/core/src/test/resources/download/exporter-download-with-title-type.json
+++ b/bundles/core/src/test/resources/download/exporter-download-with-title-type.json
@@ -1,5 +1,5 @@
 {
-  "url": "/content/dam/core/documents/Download_Test_PDF.pdf.coredownload.pdf",
+  "url": "/core/content/dam/core/documents/Download_Test_PDF.pdf.coredownload.pdf",
   "title": "Download",
   "description": "Description",
   "actionText": "Click",

--- a/bundles/core/src/test/resources/download/exporter-download-without-action-text.json
+++ b/bundles/core/src/test/resources/download/exporter-download-without-action-text.json
@@ -1,5 +1,5 @@
 {
-  "url": "/content/dam/core/documents/Download_Test_PDF.pdf.coredownload.pdf",
+  "url": "/core/content/dam/core/documents/Download_Test_PDF.pdf.coredownload.pdf",
   "title": "This is the title from the PDF.",
   "description": "Description",
   "filename": "Download_Test_PDF.pdf",


### PR DESCRIPTION
* Updated background image URL to use LinkHandler logic
* Updated LinkHandler to also try to map non-page links
* Updated Download component tests and test content to account for the fact that now asset links get mapped

Fixes #1468 
