### PR TITLE
[Accessibility][Panel] Aria controls don't match the element ID

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -34,7 +34,7 @@
          aria-live="${carousel.autoplay ? 'off' : 'polite'}">
         <div data-sly-repeat.item="${carousel.items}"
              data-sly-resource="${item.name @ decorationTagName='div'}"
-             id="${item.id}"
+             id="${item.id}-tabpanel"
              class="cmp-carousel__item${itemList.first ? ' cmp-carousel__item--active' : ''}"
              role="tabpanel"
              aria-roledescription="slide"
@@ -80,7 +80,7 @@
             <li data-sly-repeat.item="${carousel.items}"
                 class="cmp-carousel__indicator${itemList.first ? ' cmp-carousel__indicator--active' : ''}"
                 role="tab"
-                aria-controls="${carousel.id}-item-${itemList.index}"
+                aria-controls="${item.id}-tabpanel"
                 aria-label="${'Slide {0}' @ format=[itemList.count], i18n}"
                 data-cmp-hook-carousel="indicator">${item.title}</li>
         </ol>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
@@ -37,9 +37,9 @@
     </ol>
     <div data-sly-repeat.item="${tabs.items}"
          data-sly-resource="${item.name @ decorationTagName='div'}"
-         id="${item.id}"
+         id="${item.id}-tabpanel"
          role="tabpanel"
-         aria-labelledby="${item.id}"
+         aria-labelledby="${item.id}-tab"
          tabindex="0"
          class="cmp-tabs__tabpanel${item.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
          data-cmp-hook-tabs="tabpanel"


### PR DESCRIPTION
- Did the updates for Tabs and Carousel, to fix the accessibility errors found with AXE Monitor
- Checked Accordion Component, it has the attributes set correctly
Fixes #1208
