### PR TITLE
[Accordion] Style System selection is being ignored for accordion

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
@@ -249,7 +249,9 @@
 
         for (var i = 0; i < selects.length; i++) {
             var overlay = selects[i].querySelector("coral-overlay");
-            overlay.collision = Coral.Overlay.collision.NONE;
+            if (overlay) {
+                overlay.collision = Coral.Overlay.collision.NONE;
+            }
         }
 
         // adds a sufficient padding to the bottom of the wrapper such that selects


### PR DESCRIPTION
* Added check to prevent throwing an exception for undefined/null overlays.

Closes #1510
