### PR TITLE
[Experience Fragment] XF variantion is not loaded for localized content when the fragmentVariationPath is not accesible

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImpl.java
@@ -287,7 +287,6 @@ public class ExperienceFragmentImpl implements ExperienceFragment {
     @Nullable
     private String getXfLocalizationRoot(@Nullable final String xfPath, @Nullable final String currentPageRoot) {
         if (StringUtils.isNotEmpty(xfPath) && StringUtils.isNotEmpty(currentPageRoot)
-                && this.request.getResourceResolver().getResource(xfPath) != null
                 && this.request.getResourceResolver().getResource(currentPageRoot) != null) {
             String[] xfPathTokens = Text.explode(xfPath, PATH_DELIMITER_CHAR);
             int xfRootDepth = Text.explode(currentPageRoot, PATH_DELIMITER_CHAR).length + 1;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ExperienceFragmentImplTest.java
@@ -350,6 +350,20 @@ class ExperienceFragmentImplTest {
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf13"));
     }
 
+    /**
+     * Site with language localization
+     * XF component is defined in the template
+     * XF component points to a different language branch as the page.
+     * fragmentVariationPath is undefined, but it is defined in the page language branch
+     */
+    @Test
+    void testUndefinedXFInTemplateWithLocalizationDefinedInPageLanguageBranch() {
+        ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-14", EN_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
+        Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf14"));
+    }
+
 
     /* ------------------------------- Tests for a site with country/language localization (us/en) -----------------  */
 
@@ -430,6 +444,19 @@ class ExperienceFragmentImplTest {
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf22"));
     }
 
+    /**
+     * Site with country-language localization
+     * XF component is defined in the template
+     * XF component points to a different language branch as the page.
+     * fragmentVariationPath is undefined, but it is defined in the page language branch
+     */
+    @Test
+    void testUndefinedXFInTemplateWithLocalizationWithDifferentCountryLanguageDefinedInPageLanguageBranch() {
+        ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-23", US_EN_PAGE);
+        Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf23"));
+    }
+
 
     /* ----------------- Tests for a site with country-language localization (eu/mysite/en) -----------------------  */
 
@@ -508,6 +535,19 @@ class ExperienceFragmentImplTest {
         ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
             PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-32a", CH_MYSITE_FR_PAGE);
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf32"));
+    }
+
+    /**
+     * Site with country-language localization (optional): eu/mysite/en
+     * XF component is defined in the template
+     * XF component points to a different language branch as the page.
+     * fragmentVariationPath is undefined, but it is defined in the page language branch
+     */
+    @Test
+    void testUndefinedXFInTemplateWithLocalizationWithDifferentCountrySiteLanguageDefinedInPageLanguageBranch() {
+        ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-33", CH_MYSITE_FR_PAGE);
+        Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf33"));
     }
 
 
@@ -696,6 +736,20 @@ class ExperienceFragmentImplTest {
             PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-61a", LIVECOPY_PAGE);
         assertEquals(XF_NAME, experienceFragment.getName());
         Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf61a"));
+    }
+
+    /**
+     * Site with region localization (current page is a livecopy)
+     * XF component is defined in the template
+     * XF component points to a different region branch as the page
+     * fragmentVariationPath is undefined, but it is defined in the livecopy page
+     */
+    @Test
+    void testUndefinedXFInTemplateWithLocalizationWithDifferentLivecopyDefinedInLivecopyPage() {
+        ExperienceFragment experienceFragment = getExperienceFragmentUnderTest(
+            PRODUCT_PAGE_TEMPLATE + "/structure/jcr:content/xf-component-62", LIVECOPY_PAGE);
+        assertEquals(XF_NAME, experienceFragment.getName());
+        Utils.testJSONExport(experienceFragment, Utils.getTestExporterJSONPath(TEST_BASE, "xf62"));
     }
 
 

--- a/bundles/core/src/test/resources/experiencefragment/exporter-xf14.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-xf14.json
@@ -1,0 +1,8 @@
+{
+    "localizedFragmentVariationPath": "/content/experience-fragments/mysite/en/footer/definedInEn/jcr:content",
+    "configured": false,
+    ":itemsOrder": [],
+    ":items": {},
+    "classNames": "aem-xf empty",
+    ":type": "core/wcm/components/experiencefragment/v1/experiencefragment"
+}

--- a/bundles/core/src/test/resources/experiencefragment/exporter-xf23.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-xf23.json
@@ -1,0 +1,8 @@
+{
+    "localizedFragmentVariationPath": "/content/experience-fragments/mysite/us/en/footer/definedInUsEn/jcr:content",
+    "configured": false,
+    ":itemsOrder": [],
+    ":items": {},
+    "classNames": "aem-xf empty",
+    ":type": "core/wcm/components/experiencefragment/v1/experiencefragment"
+}

--- a/bundles/core/src/test/resources/experiencefragment/exporter-xf33.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-xf33.json
@@ -1,0 +1,8 @@
+{
+    "localizedFragmentVariationPath": "/content/experience-fragments/mysite/ch/mysite/fr/footer/definedInChMysiteFr/jcr:content",
+    "configured": false,
+    ":type": "core/wcm/components/experiencefragment/v1/experiencefragment",
+    "classNames": "aem-xf empty",
+    ":itemsOrder": [],
+    ":items": {}
+}

--- a/bundles/core/src/test/resources/experiencefragment/exporter-xf62.json
+++ b/bundles/core/src/test/resources/experiencefragment/exporter-xf62.json
@@ -1,0 +1,8 @@
+{
+    "localizedFragmentVariationPath": "/content/experience-fragments/mysite/livecopy/footer/definedInLiveCopy/jcr:content",
+    "configured": false,
+    ":type": "core/wcm/components/experiencefragment/v1/experiencefragment",
+    "classNames": "aem-xf empty",
+    ":itemsOrder": [],
+    ":items": {}
+}

--- a/bundles/core/src/test/resources/experiencefragment/test-conf.json
+++ b/bundles/core/src/test/resources/experiencefragment/test-conf.json
@@ -67,6 +67,11 @@
                             "jcr:primaryType": "nt:unstructured",
                             "sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment"
                         },
+                        "xf-component-14": {
+                            "jcr:primaryType": "nt:unstructured",
+                            "sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
+                            "fragmentVariationPath": "/content/experience-fragments/mysite/es/footer/definedInEn"
+                        },
                         "xf-component-20a": {
                             "jcr:primaryType": "nt:unstructured",
                             "sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
@@ -82,6 +87,11 @@
                             "sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
                             "fragmentVariationPath": "/content/experience-fragments/mysite/us/en/footer/master/undefined"
                         },
+                        "xf-component-23": {
+                            "jcr:primaryType": "nt:unstructured",
+                            "sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
+                            "fragmentVariationPath": "/content/experience-fragments/mysite/us/es/footer/definedInUsEn"
+                        },
                         "xf-component-30a": {
                             "jcr:primaryType": "nt:unstructured",
                             "sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
@@ -96,6 +106,11 @@
                             "jcr:primaryType": "nt:unstructured",
                             "sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
                             "fragmentVariationPath": "/content/experience-fragments/mysite/ch/mysite/en/footer/master/undefined"
+                        },
+                        "xf-component-33": {
+                            "jcr:primaryType": "nt:unstructured",
+                            "sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
+                            "fragmentVariationPath": "/content/experience-fragments/mysite/ch/mysite/de/footer/definedInChMysiteFr"
                         },
                         "xf-component-40a": {
                             "jcr:primaryType": "nt:unstructured",
@@ -131,6 +146,11 @@
                             "jcr:primaryType": "nt:unstructured",
                             "sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
                             "fragmentVariationPath": "/content/experience-fragments/mysite/blueprint/footer/master"
+                        },
+                        "xf-component-62": {
+                            "jcr:primaryType": "nt:unstructured",
+                            "sling:resourceType": "core/wcm/components/experiencefragment/v1/experiencefragment",
+                            "fragmentVariationPath": "/content/experience-fragments/mysite/blueprint/footer/definedInLiveCopy"
                         }
                     }
                 }

--- a/bundles/core/src/test/resources/experiencefragment/test-content.json
+++ b/bundles/core/src/test/resources/experiencefragment/test-content.json
@@ -310,8 +310,16 @@
                             "jcr:content": {
                                 "cq:xfVariantType": "web",
                                 "jcr:primaryType": "cq:PageContent",
-                                "jcr:title": "English Test Footer Variation"}
-
+                                "jcr:title": "English Test Footer Variation"
+                            }
+                        },
+                        "definedInUsEn": {
+                            "jcr:primaryType": "cq:Page",
+                            "jcr:content": {
+                                "cq:xfVariantType": "web",
+                                "jcr:primaryType": "cq:PageContent",
+                                "jcr:title": "English Test Footer Variation - Defined in us/en but not in us/es"
+                            }
                         }
                     }
                 },
@@ -365,8 +373,16 @@
                                 "jcr:content": {
                                     "cq:xfVariantType": "web",
                                     "jcr:primaryType": "cq:PageContent",
-                                    "jcr:title": "English Test Footer Variation"}
-
+                                    "jcr:title": "English Test Footer Variation"
+                                }
+                            },
+                            "definedInChMysiteFr": {
+                                "jcr:primaryType": "cq:Page",
+                                "jcr:content": {
+                                    "cq:xfVariantType": "web",
+                                    "jcr:primaryType": "cq:PageContent",
+                                    "jcr:title": "English Test Footer Variation - Defined in ch/mysite/fr but not in ch/mysite/de"
+                                }
                             }
                         }
                     },
@@ -509,8 +525,15 @@
                         "jcr:content": {
                             "cq:xfVariantType": "web",
                             "jcr:primaryType": "cq:PageContent",
-                            "jcr:title": "English Test Footer Variation"}
-
+                            "jcr:title": "English Test Footer Variation"
+                        }
+                    },
+                    "definedInEn": {
+                        "jcr:primaryType": "cq:Page",
+                        "jcr:content": {
+                            "cq:xfVariantType": "web",
+                            "jcr:primaryType": "cq:PageContent",
+                            "jcr:title": "English Test Footer Variation - Defined in en but not in es"}
                     }
                 }
             },
@@ -632,6 +655,14 @@
                             "cq:xfVariantType": "web",
                             "cq:xfMasterVariation": "true"
                         }
+                    },
+                    "definedInLiveCopy": {
+                        "jcr:primaryType": "cq:Page",
+                        "jcr:content": {
+                            "cq:xfVariantType": "web",
+                            "jcr:primaryType": "cq:PageContent",
+                            "jcr:title": "English Test Footer Variation - Defined in Livecopy"}
+
                     }
                 }
             }


### PR DESCRIPTION
- Avoid checking existence of the fragmentVariationPath to load the localized content even if the original path is not accessible 
 
Fixes #1516
