### PR TITLE
[Accessibility] css outline as a focus indicator (#1470)

### DIFF
--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/base/base.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/base/base.less
@@ -52,8 +52,4 @@ a {
     &:focus {
         text-decoration: underline;
     }
-
-    &:focus {
-        outline: none;
-    }
 }

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/accordion.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/accordion.less
@@ -52,10 +52,6 @@
             color: @cmp-examples-color-gray-900;
         }
 
-        &:focus {
-            outline: none;
-        }
-
         transition: background-color @cmp-examples-animation-duration-1 ease-in;
     }
 }

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/button.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/button.less
@@ -32,7 +32,6 @@
 
     cursor: pointer;
     .appearance(none);
-    outline: none;
 
     &[disabled] {
         display: none;

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/demo.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/demo.less
@@ -74,10 +74,6 @@
         &--active {
             color: @cmp-examples-color-gray-900;
         }
-
-        &:focus {
-            outline: none;
-        }
     }
 
     @media @cmp-examples-screen-s-min {

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/form-text.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/form-text.less
@@ -55,7 +55,6 @@
         }
 
         &:focus {
-            outline: none;
             border-color: @cmp-examples-color-blue-600;
         }
 

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/teaser.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/teaser.less
@@ -68,10 +68,6 @@
             flex-direction: column;
             width: 100%;
             height: 100%;
-
-            &:focus {
-                outline: none;
-            }
         }
 
         .cmp-image__image {
@@ -107,10 +103,6 @@
     .cmp-teaser__title-link {
         color: @cmp-examples-color-text;
         text-decoration: none;
-
-        &:focus {
-            outline: none;
-        }
     }
 
     .cmp-teaser__description {
@@ -179,10 +171,6 @@
             width: 100%;
             height: 100%;
             padding: (@cmp-examples-teaser-document-square-width - @cmp-examples-teaser-document-image-size) / 2;
-
-            &:focus {
-                outline: none;
-            }
         }
 
         .cmp-image__image {
@@ -211,7 +199,6 @@
         color: @cmp-examples-color-gray-900;
 
         &:focus {
-            outline: none;
             text-decoration: none;
         }
     }

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/carousel/base.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/carousel/base.less
@@ -69,10 +69,6 @@
         text-indent: -3000px;
 
         cursor: pointer;
-
-        &:focus {
-            outline: none;
-        }
     }
 
     .cmp-carousel__actions {
@@ -91,10 +87,6 @@
 
         &:first-child {
             margin-left: 0;
-        }
-
-        &:focus {
-            outline: none;
         }
 
         &--disabled {

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/tabs/base.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/tabs/base.less
@@ -33,10 +33,6 @@
             border-bottom: 2*@px solid;
             margin-bottom: -1*@px;
         }
-
-        &:focus {
-            outline: none;
-        }
     }
 
     .cmp-tabs__tabpanel {


### PR DESCRIPTION
- brings back focus indicator as a css outline in components library clientlibs (clientlib-site + core-components-clean)

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | fixes #1470
| Patch: Bug Fix?          | 
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   |
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

