### PR TITLE
[Carousel][Accessibility] Rotation control buttons are not the first …

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
@@ -85,7 +85,7 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
      */
     protected boolean autopauseDisabled;
 
-    private boolean prependControls = false;
+    private boolean controlsPrepended = false;
 
     /**
      * Initialize the model.
@@ -109,7 +109,7 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
             .orElseGet(() -> optionalStyle.map(style -> style.get(PN_AUTOPAUSE_DISABLED, Boolean.class))
                 .orElse(false));
 
-        prependControls = optionalStyle.map(style -> style.get(PN_PREPEND_CONTROLS, Boolean.class))
+        controlsPrepended = optionalStyle.map(style -> style.get(PN_PREPEND_CONTROLS, Boolean.class))
                 .orElse(false);
     }
 
@@ -135,8 +135,8 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
     }
 
     @Override
-    public boolean getPrependControls() {
-        return prependControls;
+    public boolean isControlsPrepended() {
+        return controlsPrepended;
     }
 
     /*

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
@@ -85,6 +85,8 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
      */
     protected boolean autopauseDisabled;
 
+    private boolean prependControls = false;
+
     /**
      * Initialize the model.
      */
@@ -106,6 +108,9 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
         autopauseDisabled = Optional.ofNullable(properties.get(PN_AUTOPAUSE_DISABLED, Boolean.class))
             .orElseGet(() -> optionalStyle.map(style -> style.get(PN_AUTOPAUSE_DISABLED, Boolean.class))
                 .orElse(false));
+
+        prependControls = optionalStyle.map(style -> style.get(PN_PREPEND_CONTROLS, Boolean.class))
+                .orElse(false);
     }
 
     @Override
@@ -127,6 +132,11 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
     @Nullable
     public String getAccessibilityLabel() {
         return accessibilityLabel;
+    }
+
+    @Override
+    public boolean getPrependControls() {
+        return prependControls;
     }
 
     /*

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImpl.java
@@ -109,7 +109,7 @@ public class CarouselImpl extends PanelContainerImpl implements Carousel {
             .orElseGet(() -> optionalStyle.map(style -> style.get(PN_AUTOPAUSE_DISABLED, Boolean.class))
                 .orElse(false));
 
-        controlsPrepended = optionalStyle.map(style -> style.get(PN_PREPEND_CONTROLS, Boolean.class))
+        controlsPrepended = optionalStyle.map(style -> style.get(PN_CONTROLS_PREPENDED, Boolean.class))
                 .orElse(false);
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
@@ -47,6 +47,13 @@ public interface Carousel extends Container {
     String PN_AUTOPAUSE_DISABLED = "autopauseDisabled";
 
     /**
+     * Name of the policy property that defines whether the control elements should be placed in front of the carousel items.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.20.0
+     */
+    String PN_PREPEND_CONTROLS = "prependControls";
+
+    /**
      * Indicates whether the carousel should automatically transition between slides or not.
      *
      * @return {@code true} if the carousel should automatically transition slides; {@code false} otherwise
@@ -84,5 +91,15 @@ public interface Carousel extends Container {
      */
     default String getAccessibilityLabel() {
         return null;
+    }
+
+    /**
+     * Checks if the control elements should be placed in front of the carousel items.
+     *
+     * @return {@code true} if the control elements should be placed in front of the items, {@code false} if they should be appended
+     * @since com.adobe.cq.wcm.core.components.models 12.20.0
+     */
+    default boolean getPrependControls() {
+        return false;
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Carousel.java
@@ -51,7 +51,7 @@ public interface Carousel extends Container {
      *
      * @since com.adobe.cq.wcm.core.components.models 12.20.0
      */
-    String PN_PREPEND_CONTROLS = "prependControls";
+    String PN_CONTROLS_PREPENDED = "controlsPrepended";
 
     /**
      * Indicates whether the carousel should automatically transition between slides or not.
@@ -99,7 +99,7 @@ public interface Carousel extends Container {
      * @return {@code true} if the control elements should be placed in front of the items, {@code false} if they should be appended
      * @since com.adobe.cq.wcm.core.components.models 12.20.0
      */
-    default boolean getPrependControls() {
+    default boolean isControlsPrepended() {
         return false;
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImplTest.java
@@ -49,6 +49,7 @@ class CarouselImplTest {
     private static final String TEST_ROOT_PAGE = "/content/carousel";
     private static final String TEST_ROOT_PAGE_GRID = "/jcr:content/root/responsivegrid";
     private static final String CAROUSEL_1 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/carousel-1";
+    private static final String CAROUSEL_2 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/carousel-2";
     private static final String CAROUSEL_EMPTY = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/carousel-empty";
     private static final String TEST_APPS_ROOT = "/apps/core/wcm/components";
 
@@ -85,6 +86,14 @@ class CarouselImplTest {
         assertTrue(carousel.getAutoplay());
         assertEquals(Long.valueOf(7000), carousel.getDelay());
         assertTrue(carousel.getAutopauseDisabled());
+    }
+
+    @Test
+    void testControlsPrepended() {
+        context.contentPolicyMapping(CarouselImpl.RESOURCE_TYPE, "controlsPrepended", true);
+        Carousel carousel = getCarouselUnderTest(CAROUSEL_1);
+        assertTrue(carousel.isControlsPrepended());
+        Utils.testJSONExport(carousel, Utils.getTestExporterJSONPath(TEST_BASE, "carousel1a"));
     }
 
     private Carousel getCarouselUnderTest(@NotNull final String resourcePath) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/CarouselImplTest.java
@@ -49,7 +49,6 @@ class CarouselImplTest {
     private static final String TEST_ROOT_PAGE = "/content/carousel";
     private static final String TEST_ROOT_PAGE_GRID = "/jcr:content/root/responsivegrid";
     private static final String CAROUSEL_1 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/carousel-1";
-    private static final String CAROUSEL_2 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/carousel-2";
     private static final String CAROUSEL_EMPTY = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/carousel-empty";
     private static final String TEST_APPS_ROOT = "/apps/core/wcm/components";
 

--- a/bundles/core/src/test/resources/accordion/exporter-accordion2.json
+++ b/bundles/core/src/test/resources/accordion/exporter-accordion2.json
@@ -131,6 +131,7 @@
                                 "item_1_2_2_2": {
                                     "id": "carousel-8c88179066",
                                     "autoplay": true,
+                                    "controlsPrepended": false,
                                     "delay": 7000,
                                     "autopauseDisabled": false,
                                     "dataLayer": {

--- a/bundles/core/src/test/resources/carousel/exporter-carousel1.json
+++ b/bundles/core/src/test/resources/carousel/exporter-carousel1.json
@@ -3,6 +3,7 @@
     "autoplay": true,
     "delay": 7000,
     "autopauseDisabled": true,
+    "prependControls": false,
     "dataLayer": {
         "carousel-c39ba25916": {
             "@type": "core/wcm/components/carousel/v1/carousel",

--- a/bundles/core/src/test/resources/carousel/exporter-carousel1.json
+++ b/bundles/core/src/test/resources/carousel/exporter-carousel1.json
@@ -3,7 +3,7 @@
     "autoplay": true,
     "delay": 7000,
     "autopauseDisabled": true,
-    "prependControls": false,
+    "controlsPrepended": false,
     "dataLayer": {
         "carousel-c39ba25916": {
             "@type": "core/wcm/components/carousel/v1/carousel",

--- a/bundles/core/src/test/resources/carousel/exporter-carousel1a.json
+++ b/bundles/core/src/test/resources/carousel/exporter-carousel1a.json
@@ -1,0 +1,77 @@
+{
+    "id": "carousel-c39ba25916",
+    "autoplay": true,
+    "delay": 7000,
+    "autopauseDisabled": true,
+    "controlsPrepended": true,
+    "dataLayer": {
+        "carousel-c39ba25916": {
+            "@type": "core/wcm/components/carousel/v1/carousel",
+            "shownItems": [
+                "carousel-c39ba25916-item-6204f971ea"
+            ]
+        }
+    },
+    ":itemsOrder": [
+        "item_1",
+        "item_2",
+        "item_3"
+    ],
+    ":items": {
+        "item_1": {
+            "title": "Teaser 1",
+            "description": "Teaser 1 description",
+            "actionsEnabled": false,
+            "imageLinkHidden": false,
+            "titleLinkHidden": false,
+            "actions": [],
+            "id": "teaser-6204f971ea",
+            "dataLayer": {
+                "teaser-6204f971ea": {
+                    "dc:description": "Teaser 1 description",
+                    "@type": "core/wcm/components/teaser/v1/teaser",
+                    "dc:title": "Teaser 1"
+                }
+            },
+            ":type": "core/wcm/components/teaser/v1/teaser",
+            "cq:panelTitle": "Teaser 1"
+        },
+        "item_2": {
+            "title": "Teaser 2",
+            "description": "Teaser 2 description",
+            "actionsEnabled": false,
+            "imageLinkHidden": false,
+            "titleLinkHidden": false,
+            "actions": [],
+            "id": "teaser-7d7da28085",
+            "dataLayer": {
+                "teaser-7d7da28085": {
+                    "dc:description": "Teaser 2 description",
+                    "@type": "core/wcm/components/teaser/v1/teaser",
+                    "dc:title": "Teaser 2"
+                }
+            },
+            ":type": "core/wcm/components/teaser/v1/teaser",
+            "cq:panelTitle": "Teaser 2"
+        },
+        "item_3": {
+            "title": "Teaser 3",
+            "description": "Teaser 3 description",
+            "actionsEnabled": false,
+            "imageLinkHidden": false,
+            "titleLinkHidden": false,
+            "actions": [],
+            "id": "teaser-aeaad4f462",
+            "dataLayer": {
+                "teaser-aeaad4f462": {
+                    "dc:description": "Teaser 3 description",
+                    "@type": "core/wcm/components/teaser/v1/teaser",
+                    "dc:title": "Teaser 3"
+                }
+            },
+            ":type": "core/wcm/components/teaser/v1/teaser",
+            "cq:panelTitle": "Carousel Panel 3"
+        }
+    },
+    ":type": "core/wcm/components/carousel/v1/carousel"
+}

--- a/bundles/core/src/test/resources/tabs/exporter-tabs2.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs2.json
@@ -125,6 +125,7 @@
                                 "item_1_2_2_2": {
                                     "id": "carousel-21953a9100",
                                     "autoplay": true,
+                                    "controlsPrepended": false,
                                     "delay": 7000,
                                     "autopauseDisabled": false,
                                     "dataLayer": {

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
@@ -38,6 +38,7 @@ The following configuration properties are used:
 1. `./autoplay` - defines whether or not the carousel should automatically transition between slides.
 2. `./delay` - defines the delay (in milliseconds) when automatically transitioning between slides.
 3. `./autopauseDisabled` - defines whether or not automatic pause when hovering the carousel is disabled.
+4. `./controlsPrepended` - defines whether the carousel controls should be arranged before the carousel items or not.
 
 It is also possible to define the allowed components for the Carousel.
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
@@ -87,6 +87,15 @@
                                     jcr:primaryType="nt:unstructured"
                                     cmp-carousel-v1-dialog-hook="autoplayGroup"/>
                             </autoplayGroup>
+                            <prependControls
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                fieldDescription="When checked, the control elements will be places in front of the carousel items to improve accessibility."
+                                name="./prependControls"
+                                checked="{Boolean}false"
+                                text="Prepend control elements"
+                                uncheckedValue="false"
+                                value="{Boolean}true"/>
                         </items>
                     </properties>
                     <allowedcomponents

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
@@ -87,11 +87,11 @@
                                     jcr:primaryType="nt:unstructured"
                                     cmp-carousel-v1-dialog-hook="autoplayGroup"/>
                             </autoplayGroup>
-                            <prependControls
+                            <controlsPrepended
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                fieldDescription="When checked, the control elements will be places in front of the carousel items to improve accessibility."
-                                name="./prependControls"
+                                fieldDescription="When checked, the control elements will be placed in front of the carousel items to improve accessibility."
+                                name="./controlsPrepended"
                                 checked="{Boolean}false"
                                 text="Prepend control elements"
                                 uncheckedValue="false"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -15,6 +15,7 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.carousel="com.adobe.cq.wcm.core.components.models.Carousel"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+     data-sly-use.controlsTemplate="controls.html"
      data-panelcontainer="${wcmmode.edit && 'carousel'}"
      id="${carousel.id}"
      class="cmp-carousel"
@@ -28,6 +29,7 @@
      data-cmp-autopause-disabled="${carousel.autopauseDisabled}"
      data-cmp-data-layer="${carousel.data.json}"
      data-placeholder-text="${wcmmode.edit && 'Please add Carousel components here' @ i18n}">
+    <sly data-sly-call="${controlsTemplate.controls @ carousel=carousel}" data-sly-test="${carousel.prependControls}"></sly>
     <div data-sly-test="${carousel.items && carousel.items.size > 0}"
          class="cmp-carousel__content"
          aria-atomic="false"
@@ -42,40 +44,7 @@
              aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.items.size], i18n}"
              data-cmp-data-layer="${item.data.json}"
              data-cmp-hook-carousel="item"></div>
-        <div class="cmp-carousel__actions">
-            <button class="cmp-carousel__action cmp-carousel__action--previous"
-                    type="button"
-                    aria-label="${'Previous' @ i18n}"
-                    data-cmp-hook-carousel="previous"
-                    tabindex="-1">
-                <span class="cmp-carousel__action-icon"></span>
-                <span class="cmp-carousel__action-text">${'Previous' @ i18n}</span>
-            </button>
-            <button class="cmp-carousel__action cmp-carousel__action--next"
-                    type="button"
-                    aria-label="${'Next' @ i18n}"
-                    data-cmp-hook-carousel="next"
-                    tabindex="-1">
-                <span class="cmp-carousel__action-icon"></span>
-                <span class="cmp-carousel__action-text">${'Next' @ i18n}</span>
-            </button>
-            <button data-sly-test="${carousel.autoplay}"
-                    class="cmp-carousel__action cmp-carousel__action--pause"
-                    type="button"
-                    aria-label="${'Pause' @ i18n}"
-                    data-cmp-hook-carousel="pause">
-                <span class="cmp-carousel__action-icon"></span>
-                <span class="cmp-carousel__action-text">${'Pause' @ i18n}</span>
-            </button>
-            <button data-sly-test="${carousel.autoplay}"
-                    class="cmp-carousel__action cmp-carousel__action--play cmp-carousel__action--disabled"
-                    type="button"
-                    aria-label="${'Play' @ i18n}"
-                    data-cmp-hook-carousel="play">
-                <span class="cmp-carousel__action-icon"></span>
-                <span class="cmp-carousel__action-text">${'Play' @ i18n}</span>
-            </button>
-        </div>
+        <sly data-sly-call="${controlsTemplate.controls @ carousel=carousel}" data-sly-test="${!carousel.prependControls}"></sly>
         <ol class="cmp-carousel__indicators"
             role="tablist"
             aria-label="${'Choose a slide to display' @ i18n}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -46,14 +46,16 @@
             <button class="cmp-carousel__action cmp-carousel__action--previous"
                     type="button"
                     aria-label="${'Previous' @ i18n}"
-                    data-cmp-hook-carousel="previous">
+                    data-cmp-hook-carousel="previous"
+                    tabindex="-1">
                 <span class="cmp-carousel__action-icon"></span>
                 <span class="cmp-carousel__action-text">${'Previous' @ i18n}</span>
             </button>
             <button class="cmp-carousel__action cmp-carousel__action--next"
                     type="button"
                     aria-label="${'Next' @ i18n}"
-                    data-cmp-hook-carousel="next">
+                    data-cmp-hook-carousel="next"
+                    tabindex="-1">
                 <span class="cmp-carousel__action-icon"></span>
                 <span class="cmp-carousel__action-text">${'Next' @ i18n}</span>
             </button>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -29,7 +29,7 @@
      data-cmp-autopause-disabled="${carousel.autopauseDisabled}"
      data-cmp-data-layer="${carousel.data.json}"
      data-placeholder-text="${wcmmode.edit && 'Please add Carousel components here' @ i18n}">
-    <sly data-sly-call="${controlsTemplate.controls @ carousel=carousel}" data-sly-test="${carousel.prependControls}"></sly>
+    <sly data-sly-call="${controlsTemplate.controls @ carousel=carousel}" data-sly-test="${carousel.controlsPrepended}"></sly>
     <div data-sly-test="${carousel.items && carousel.items.size > 0}"
          class="cmp-carousel__content"
          aria-atomic="false"
@@ -44,7 +44,7 @@
              aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.items.size], i18n}"
              data-cmp-data-layer="${item.data.json}"
              data-cmp-hook-carousel="item"></div>
-        <sly data-sly-call="${controlsTemplate.controls @ carousel=carousel}" data-sly-test="${!carousel.prependControls}"></sly>
+        <sly data-sly-call="${controlsTemplate.controls @ carousel=carousel}" data-sly-test="${!carousel.controlsPrepended}"></sly>
         <ol class="cmp-carousel__indicators"
             role="tablist"
             aria-label="${'Choose a slide to display' @ i18n}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -271,6 +271,9 @@
                 that._elements.self.addEventListener("mouseenter", onMouseEnter);
                 that._elements.self.addEventListener("mouseleave", onMouseLeave);
             }
+            // for accessibility we pause animation when a element get focused
+            that._elements.self.addEventListener("focusin", onMouseEnter);
+            that._elements.self.addEventListener("focusout", onMouseLeave);
         }
 
         /**

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -271,9 +271,15 @@
                 that._elements.self.addEventListener("mouseenter", onMouseEnter);
                 that._elements.self.addEventListener("mouseleave", onMouseLeave);
             }
+
             // for accessibility we pause animation when a element get focused
-            that._elements.self.addEventListener("focusin", onMouseEnter);
-            that._elements.self.addEventListener("focusout", onMouseLeave);
+            var items = that._elements["item"];
+            if (items) {
+                for (var i = 0; i < items.length; i++) {
+                    items[i].addEventListener("focusin", onMouseEnter);
+                    items[i].addEventListener("focusout", onMouseLeave);
+                }
+            }
         }
 
         /**

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -275,9 +275,9 @@
             // for accessibility we pause animation when a element get focused
             var items = that._elements["item"];
             if (items) {
-                for (var i = 0; i < items.length; i++) {
-                    items[i].addEventListener("focusin", onMouseEnter);
-                    items[i].addEventListener("focusout", onMouseLeave);
+                for (var j = 0; j < items.length; j++) {
+                    items[j].addEventListener("focusin", onMouseEnter);
+                    items[j].addEventListener("focusout", onMouseLeave);
                 }
             }
         }

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/controls.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/controls.html
@@ -1,0 +1,49 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2021 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<sly data-sly-template.controls="${@ carousel}">
+    <div class="cmp-carousel__actions">
+    <button class="cmp-carousel__action cmp-carousel__action--previous"
+            type="button"
+            aria-label="${'Previous' @ i18n}"
+            data-cmp-hook-carousel="previous">
+        <span class="cmp-carousel__action-icon"></span>
+        <span class="cmp-carousel__action-text">${'Previous' @ i18n}</span>
+    </button>
+    <button class="cmp-carousel__action cmp-carousel__action--next"
+            type="button"
+            aria-label="${'Next' @ i18n}"
+            data-cmp-hook-carousel="next">
+        <span class="cmp-carousel__action-icon"></span>
+        <span class="cmp-carousel__action-text">${'Next' @ i18n}</span>
+    </button>
+    <button data-sly-test="${carousel.autoplay}"
+            class="cmp-carousel__action cmp-carousel__action--pause"
+            type="button"
+            aria-label="${'Pause' @ i18n}"
+            data-cmp-hook-carousel="pause">
+        <span class="cmp-carousel__action-icon"></span>
+        <span class="cmp-carousel__action-text">${'Pause' @ i18n}</span>
+    </button>
+    <button data-sly-test="${carousel.autoplay}"
+            class="cmp-carousel__action cmp-carousel__action--play cmp-carousel__action--disabled"
+            type="button"
+            aria-label="${'Play' @ i18n}"
+            data-cmp-hook-carousel="play">
+        <span class="cmp-carousel__action-icon"></span>
+        <span class="cmp-carousel__action-text">${'Play' @ i18n}</span>
+    </button>
+</div>
+</sly>


### PR DESCRIPTION
…element in carousel and pause on focus issue

- add animation pause on focusin
- set negative tabindex to next and previous so that pause and play button can be focused first.

fixes #681

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #681 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
