### PR TITLE
fix(page): skiptomain invalid markup

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/body.skiptomaincontent.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/body.skiptomaincontent.html
@@ -19,7 +19,6 @@
      data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
      data-sly-test="${page.mainContentSelector}">
     <a class="cmp-page__skiptomaincontent-link"
-       alt="${'Skip to main content link' @ i18n}"
        href="#${page.mainContentSelector}">${'Skip to main content' @ i18n}</a>
 </div>
 <sly data-sly-call="${clientlib.css @ categories='core.wcm.components.page.v2.skiptomaincontent'}"


### PR DESCRIPTION
Remove alt attribute on "skip to main content"-link since it's invalid HTML.

Using the [title attribute is discouraged](https://html.spec.whatwg.org/multipage/dom.html#attr-title). In my opinion, the link label should be sufficient, therefore I'd suggest to remove the alt-attribute without replacing it.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #1532
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | 👎
| Major: Breaking Change?  | 👎
| Tests Added + Pass?      | No tests required
| Documentation Provided   | No update needed
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

