### PR TITLE
Add support for CA configs stored as Pages

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
@@ -45,7 +45,7 @@ import com.day.cq.wcm.api.PageManager;
            service = PathProcessor.class)
 public class DefaultPathProcessor implements PathProcessor {
     @ObjectClassDefinition(
-            name = "Default path processor configuration"
+            name = "Core Components Default Path Processor"
     )
     @interface Config {
         @AttributeDefinition(

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider.java
@@ -17,15 +17,19 @@ package com.adobe.cq.wcm.core.components.internal.services;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.caconfig.management.ConfigurationManager;
 import org.apache.sling.caconfig.resource.ConfigurationResourceResolver;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
-import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.reference.Reference;
@@ -36,11 +40,21 @@ import static com.adobe.cq.wcm.core.components.util.ComponentUtils.NN_SLING_CONF
 /**
  * Provides Context Aware Configuration references for a given resource.
  */
+@Designate(ocd = CaConfigReferenceProvider.Config.class)
 @Component(
         service = ReferenceProvider.class
 )
 public class CaConfigReferenceProvider implements ReferenceProvider {
-
+    @ObjectClassDefinition(
+            name = "Core Components Context-Aware Configuration Reference Provider"
+    )
+    @interface Config {
+        @AttributeDefinition(
+                name = "Enabled",
+                description = "Enable this reference provider"
+        )
+        boolean enabled() default true;
+    }
     private static final String CA_CONFIG_REFERENCE_TYPE = "caconfig";
 
     /**
@@ -55,8 +69,24 @@ public class CaConfigReferenceProvider implements ReferenceProvider {
     @org.osgi.service.component.annotations.Reference
     private ConfigurationResourceResolver configurationResourceResolver;
 
+    private boolean enabled;
+
+    @Activate
+    protected void activate(Config config) {
+        enabled = config.enabled();
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        enabled = false;
+    }
+
     @Override
     public List<Reference> findReferences(Resource resource) {
+        if (!enabled) {
+            return Collections.emptyList();
+        }
+
         List<Reference> references = new ArrayList<>();
         // If the resource is not part of a page: stop the processing
         PageManager pageManager = resource.getResourceResolver().adaptTo(PageManager.class);
@@ -76,9 +106,17 @@ public class CaConfigReferenceProvider implements ReferenceProvider {
     private void addCaConfigReference(String configName, Resource resource, List<Reference> references) {
         Resource configResource = configurationResourceResolver.getResource(resource, NN_SLING_CONFIGS, configName);
         if (configResource != null) {
-            ValueMap properties = configResource.getValueMap();
-            Calendar lastModified = properties.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class);
-            references.add(new Reference(CA_CONFIG_REFERENCE_TYPE, configName, configResource, (lastModified != null) ? lastModified.getTimeInMillis() : -1));
+            references.add(new Reference(CA_CONFIG_REFERENCE_TYPE, configName, configResource, getLastModificationTime(configResource)));
+        }
+    }
+
+    private long getLastModificationTime(Resource configResource) {
+        Page configPage = configResource.adaptTo(Page.class);
+        if (configPage != null) {
+            Calendar lastModified = configPage.getLastModified();
+            return lastModified != null ? lastModified.getTimeInMillis() : -1L;
+        } else {
+            return configResource.getResourceMetadata().getModificationTime();
         }
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProviderTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProviderTest.java
@@ -16,25 +16,21 @@
 package com.adobe.cq.wcm.core.components.internal.services;
 
 import java.util.List;
-import java.util.TreeSet;
 
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.caconfig.management.ConfigurationManager;
 import org.apache.sling.testing.mock.caconfig.MockContextAwareConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
 
 import com.adobe.cq.wcm.core.components.config.HtmlPageItemsConfig;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.internal.DataLayerConfig;
-import com.adobe.cq.wcm.core.components.internal.services.pdfviewer.PdfViewerCaConfig;
 import com.day.cq.wcm.api.reference.Reference;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(AemContextExtension.class)
 class CaConfigReferenceProviderTest {
@@ -53,36 +49,52 @@ class CaConfigReferenceProviderTest {
     void setUp() {
         context.load().json(TEST_BASE + "/test-content.json", TEST_PAGE);
         context.load().json(TEST_BASE + "/test-sling-configs.json", SLING_CONFIGS_ROOT);
-        MockContextAwareConfig.registerAnnotationClasses(context, HtmlPageItemsConfig.class);
-        ConfigurationManager mockConfigurationManager = Mockito.mock(ConfigurationManager.class);
-        Mockito.when(mockConfigurationManager.getConfigurationNames()).thenReturn(new TreeSet<String>() {{
-            add(HtmlPageItemsConfig.class.getName());
-            add(DataLayerConfig.class.getName());
-            add(PdfViewerCaConfig.class.getName());
-        }});
-        context.registerService(ConfigurationManager.class, mockConfigurationManager);
+        MockContextAwareConfig.registerAnnotationClasses(context, HtmlPageItemsConfig.class, DataLayerConfig.class);
         caConfigReferenceProvider = context.registerInjectActivateService(new CaConfigReferenceProvider());
     }
 
     @Test
     void testFindReferences() {
         Resource resource = context.resourceResolver().getResource(TEST_CA_COMPONENT);
+        assertNotNull(resource);
         List<Reference> references = caConfigReferenceProvider.findReferences(resource);
-        assertEquals(1, references.size());
-        Reference reference = references.get(0);
+        assertEquals(2, references.size());
+        Reference reference = getReference(references, HtmlPageItemsConfig.class);
+        assertNotNull(reference);
         Resource expectedReferenceRes = context.resourceResolver().getResource(SLING_CONFIGS_ROOT + "/" + HtmlPageItemsConfig.class.getName());
         assertEquals("caconfig", reference.getType());
-        assertEquals(HtmlPageItemsConfig.class.getName(), reference.getName());
         if (expectedReferenceRes != null) {
             assertEquals(expectedReferenceRes.getPath(), reference.getResource().getPath());
         }
         assertEquals(1602683813696L, reference.getLastModified());
+        reference = getReference(references, DataLayerConfig.class);
+        assertNotNull(reference);
+        assertEquals(1623074213696L, reference.getLastModified());
+    }
+
+    private Reference getReference(List<Reference> references, Class<?> clazz) {
+        for (Reference refItem: references) {
+            if (refItem.getName().equals(clazz.getName())) {
+                return refItem;
+            }
+        }
+        return null;
     }
 
     @Test
     void testNoReferences() {
         Resource resource = context.resourceResolver().getResource(TEST_NO_CA_COMPONENT);
+        assertNotNull(resource);
         List<Reference> references = caConfigReferenceProvider.findReferences(resource);
         assertEquals(0, references.size());
+    }
+
+    @Test
+    void testDisabled() {
+        Resource resource = context.resourceResolver().getResource(TEST_CA_COMPONENT);
+        CaConfigReferenceProvider referenceProvider = context.registerInjectActivateService(new CaConfigReferenceProvider(), "enabled", false);
+        List<Reference> references = referenceProvider.findReferences(resource);
+        assertTrue(references.isEmpty());
+
     }
 }

--- a/bundles/core/src/test/resources/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider/test-sling-configs.json
+++ b/bundles/core/src/test/resources/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider/test-sling-configs.json
@@ -1,4 +1,13 @@
 {
+    "com.adobe.cq.wcm.core.components.internal.DataLayerConfig": {
+        "jcr:primaryType"                                            : "cq:Page",
+        "jcr:content"                                                : {
+            "jcr:primaryType" : "cq:PageContent",
+            "cq:lastModified": "2021-06-07T15:56:53.696+02:00",
+            "enabled"         : true
+        }
+    },
+
     "com.adobe.cq.wcm.core.components.config.HtmlPageItemsConfig": {
         "jcr:primaryType": "nt:unstructured",
         "jcr:lastModified": "2020-10-14T15:56:53.696+02:00",

--- a/testing/it/e2e-selenium/pom.xml
+++ b/testing/it/e2e-selenium/pom.xml
@@ -53,6 +53,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.0</version>
                     <configuration>
                         <classesDirectory>${project.build.testOutputDirectory}</classesDirectory>
                     </configuration>

--- a/testing/it/http/pom.xml
+++ b/testing/it/http/pom.xml
@@ -53,6 +53,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.0</version>
                     <configuration>
                         <classesDirectory>${project.build.testOutputDirectory}</classesDirectory>
                     </configuration>


### PR DESCRIPTION
- check last modified time of page content if config is a Page
- provide OSGi config to disable reference provider, default is enabled
- adapt unit tests
fixes #1558

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1558 
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | 👍
| Major: Breaking Change?  | 👎
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | 👎
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
