### PR TITLE
CIF-2100 Sitemap Generation

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -73,6 +73,11 @@
                                     <artifactId>org.apache.sling.models.impl</artifactId>
                                     <target>/apps/core/wcm/install</target>
                                 </embedded>
+                                <embedded>
+                                    <groupId>org.apache.sling</groupId>
+                                    <artifactId>org.apache.sling.sitemap</artifactId>
+                                    <target>/apps/core/wcm/install</target>
+                                </embedded>
                             </embeddeds>
                             <subPackages>
                                 <subPackage>
@@ -316,6 +321,11 @@
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.models.impl</artifactId>
             <version>1.4.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.sitemap</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -376,6 +376,10 @@
             <artifactId>org.apache.sling.commons.johnzon</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.sitemap</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/SitemapDetailsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/SitemapDetailsImpl.java
@@ -1,0 +1,135 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2017 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v2;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.apache.sling.models.annotations.injectorspecific.RequestAttribute;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.sitemap.SitemapInfo;
+import org.apache.sling.sitemap.SitemapService;
+
+import com.adobe.cq.wcm.core.components.models.SitemapDetails;
+import com.adobe.granite.ui.components.Value;
+
+/**
+ * This model is used by the sitemap root dialog field in order to provide additional information for the UI.
+ */
+@Model(adaptables = SlingHttpServletRequest.class, adapters = { SitemapDetails.class })
+public class SitemapDetailsImpl implements SitemapDetails {
+
+    private static final String ONE_DECIMAL_FORMAT = "%.1f";
+    private static final String ONE_DECIMAL_W_UNIT_FORMAT = ONE_DECIMAL_FORMAT + " %s";
+
+    private final boolean isSitemapRoot;
+    private final boolean beingGenerated;
+    private final boolean hasWarning;
+    private final List<Detail> details;
+
+    @Inject
+    public SitemapDetailsImpl(
+        @RequestAttribute(name = Value.CONTENTPATH_ATTRIBUTE, injectionStrategy = InjectionStrategy.OPTIONAL) String contentPath,
+        @Self SlingHttpServletRequest request,
+        @OSGiService SitemapService sitemapService
+    ) {
+        Resource resource = Optional.ofNullable(request.getResourceResolver().getResource(contentPath))
+            .orElseGet(request::getResource);
+        isSitemapRoot = resource.getValueMap().get(SitemapService.PROPERTY_SITEMAP_ROOT, Boolean.FALSE);
+        if (isSitemapRoot) {
+            beingGenerated = sitemapService.isSitemapGenerationPending(resource);
+            Collection<SitemapInfo> infos = sitemapService.getSitemapInfo(resource);
+            details = infos.stream().map(SitemapDetailsImpl::newDetail).collect(Collectors.toList());
+            hasWarning = !infos.stream().map(SitemapInfo::isWithinLimits).reduce(Boolean::logicalAnd).orElse(Boolean.TRUE);
+        } else {
+            details = Collections.emptyList();
+            hasWarning = false;
+            beingGenerated = false;
+        }
+    }
+
+    @Override public List<Detail> getDetails() {
+        return Collections.unmodifiableList(details);
+    }
+
+    @Override public boolean isSitemapRoot() {
+        return isSitemapRoot;
+    }
+
+    @Override public boolean isGenerationPending() {
+        return beingGenerated;
+    }
+
+    @Override public boolean hasWarning() {
+        return hasWarning;
+    }
+
+    private static Detail newDetail(SitemapInfo info) {
+        int lastDot = info.getUrl().lastIndexOf('.');
+        int prevDot = info.getUrl().substring(0, lastDot).lastIndexOf('.');
+        String name = info.getUrl().substring(prevDot + 1, lastDot);
+        return new Detail() {
+            @Override public String getName() {
+                return name;
+            }
+
+            @Override public String getUrl() {
+                return info.getUrl();
+            }
+
+            @Override public String getSize() {
+                return formatFileSize(info.getSize());
+            }
+
+            @Override public String getEntries() {
+                return formatNumber(info.getEntries());
+            }
+        };
+    }
+
+    private static String formatFileSize(int bytes) {
+        if (bytes > 1024 * 1024) {
+            // mb
+            return String.format(ONE_DECIMAL_W_UNIT_FORMAT, (float) bytes / (1024 * 1024), "MB");
+        } else if (bytes > 1024) {
+            return String.format(ONE_DECIMAL_W_UNIT_FORMAT, (float) bytes / 1024, "KB");
+        } else if (bytes < 0) {
+            return "-";
+        } else {
+            return String.format("%.1f %s", (float) bytes, "Byte");
+        }
+    }
+
+    private static String formatNumber(int number) {
+        if (number > 1000) {
+            return String.format(ONE_DECIMAL_FORMAT, (float) number / 1000);
+        } else if (number < 0) {
+            return "-";
+        } else {
+            return String.valueOf(number);
+        }
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/SitemapDetailsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/SitemapDetailsImpl.java
@@ -1,5 +1,5 @@
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- ~ Copyright 2017 Adobe
+ ~ Copyright 2021 Adobe
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/sitemap/PageTreeSitemapGeneratorImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/sitemap/PageTreeSitemapGeneratorImpl.java
@@ -26,7 +26,7 @@ import org.apache.sling.sitemap.SitemapException;
 import org.apache.sling.sitemap.builder.Sitemap;
 import org.apache.sling.sitemap.builder.Url;
 import org.apache.sling.sitemap.builder.extensions.AlternateLanguageExtension;
-import org.apache.sling.sitemap.common.Externalizer;
+import org.apache.sling.sitemap.common.SitemapLinkExternalizer;
 import org.apache.sling.sitemap.generator.ResourceTreeSitemapGenerator;
 import org.apache.sling.sitemap.generator.SitemapGenerator;
 import org.jetbrains.annotations.NotNull;
@@ -53,7 +53,7 @@ public class PageTreeSitemapGeneratorImpl extends ResourceTreeSitemapGenerator i
     private final Logger LOG = LoggerFactory.getLogger(PageTreeSitemapGeneratorImpl.class);
 
     @Reference(policyOption = ReferencePolicyOption.GREEDY)
-    private Externalizer externalizer;
+    private SitemapLinkExternalizer externalizer;
     @Reference
     private SlingSettingsService slingSettingsService;
     @Reference

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/sitemap/PageTreeSitemapGeneratorImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/sitemap/PageTreeSitemapGeneratorImpl.java
@@ -1,0 +1,196 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.sitemap;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.settings.SlingSettingsService;
+import org.apache.sling.sitemap.SitemapException;
+import org.apache.sling.sitemap.builder.Sitemap;
+import org.apache.sling.sitemap.builder.Url;
+import org.apache.sling.sitemap.builder.extensions.AlternateLanguageExtension;
+import org.apache.sling.sitemap.common.Externalizer;
+import org.apache.sling.sitemap.generator.ResourceTreeSitemapGenerator;
+import org.apache.sling.sitemap.generator.SitemapGenerator;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.wcm.core.components.internal.models.v2.PageImpl;
+import com.adobe.cq.wcm.core.components.services.sitemap.PageTreeSitemapGenerator;
+import com.day.cq.replication.ReplicationActionType;
+import com.day.cq.replication.ReplicationStatus;
+import com.day.cq.wcm.api.LanguageManager;
+import com.day.cq.wcm.api.Page;
+import com.day.text.Text;
+
+/**
+ * The main {@link SitemapGenerator} for AEM pages.
+ */
+@Component(service = { SitemapGenerator.class, PageTreeSitemapGenerator.class })
+public class PageTreeSitemapGeneratorImpl extends ResourceTreeSitemapGenerator implements PageTreeSitemapGenerator {
+
+    private final Logger LOG = LoggerFactory.getLogger(PageTreeSitemapGeneratorImpl.class);
+
+    @Reference(policyOption = ReferencePolicyOption.GREEDY)
+    private Externalizer externalizer;
+    @Reference
+    private SlingSettingsService slingSettingsService;
+    @Reference
+    private LanguageManager languageManager;
+
+    @Override
+    @NotNull
+    public Set<String> getNames(@NotNull Resource sitemapRoot) {
+        return Collections.singleton(SitemapGenerator.DEFAULT_SITEMAP);
+    }
+
+    @Override
+    protected void addResource(@NotNull String name, @NotNull Sitemap sitemap, @NotNull Resource resource)
+        throws SitemapException {
+        Page page = resource.adaptTo(Page.class);
+
+        if (page == null) {
+            LOG.debug("Skipping resource at {}: not a page", resource.getPath());
+            return;
+        }
+
+        String location = externalizer.externalize(resource);
+
+        if (location == null) {
+            LOG.debug("Skipping resource at {}: externalised location is null", resource.getPath());
+            return;
+        }
+
+        Url url = sitemap.addUrl(location + ".html");
+        // last modified
+        ReplicationStatus replicationStatus = page.getContentResource().adaptTo(ReplicationStatus.class);
+        if (replicationStatus != null) {
+            url.setLastModified(replicationStatus.getLastPublished().toInstant());
+        }
+        // alternate languages
+        Map<Locale, String> languageAlternatives = getLanguageAlternatives(page);
+        if (languageAlternatives.size() > 0) {
+            AlternateLanguageExtension alternateLanguages = url.addExtension(AlternateLanguageExtension.class);
+            if (alternateLanguages != null) {
+                for (Map.Entry<Locale, String> entry : languageAlternatives.entrySet()) {
+                    alternateLanguages.setLocale(entry.getKey());
+                    alternateLanguages.setHref(entry.getValue());
+                }
+            }
+        }
+    }
+
+    @Override
+    protected final boolean shouldFollow(@NotNull Resource resource) {
+        return super.shouldFollow(resource) && !isProtected(resource);
+    }
+
+    @Override
+    protected final boolean shouldInclude(@NotNull Resource resource) {
+        return super.shouldInclude(resource) && Optional.ofNullable(resource.adaptTo(Page.class))
+            .map(this::shouldInclude).orElse(Boolean.FALSE);
+    }
+
+    /**
+     * Include only pages that are published, exclude pages that have noindex set, are CUG protected or are redirects.
+     * <p>
+     * Redirects are filtered explicitly because they either point to another page in the same site, which if it makes the same filter will
+     * anyway be in the sitemap, or they will point to a url outside of the current site.
+     *
+     * @param page
+     * @return
+     */
+    private boolean shouldInclude(@NotNull Page page) {
+        return isPublished(page) && !isNoIndex(page) && !isRedirect(page) && !isProtected(page);
+    }
+
+    @Override
+    public Map<Locale, String> getLanguageAlternatives(Page page) {
+        ResourceResolver resolver = page.getContentResource().getResourceResolver();
+        Collection<Resource> languageRoots = languageManager.getLanguageRootResources(resolver, page.getPath(), true);
+
+        Resource pageLanguageRoot = languageRoots.stream()
+            .filter(languageRoot -> Text.isDescendantOrEqual(languageRoot.getPath(), page.getPath()))
+            .findFirst()
+            .orElse(null);
+
+        if (pageLanguageRoot == null) {
+            return Collections.emptyMap();
+        }
+
+        Stream<Resource> alternativesCandidates = languageRoots.stream()
+            .filter(resource -> !Text.isDescendantOrEqual(resource.getPath(), page.getPath()));
+
+        if (Text.isDescendant(pageLanguageRoot.getPath(), page.getPath())) {
+            String childPath = page.getPath().substring(pageLanguageRoot.getPath().length() + 1);
+            alternativesCandidates = alternativesCandidates.map(resource -> resource.getChild(childPath));
+        }
+
+        Map<Locale, String> alternatives = new HashMap<>(languageRoots.size());
+        for (Resource resource : (Iterable<Resource>) alternativesCandidates.filter(Objects::nonNull)::iterator) {
+            Locale key = languageManager.getLanguage(resource, true);
+            String location = externalizer.externalize(resource);
+            if (key != null && location != null && shouldInclude(resource)) {
+                alternatives.putIfAbsent(key, location);
+            }
+        }
+        return Collections.unmodifiableMap(alternatives);
+    }
+
+    @Override
+    public boolean isPublished(@NotNull Page page) {
+        if (slingSettingsService.getRunModes().contains("publish")) {
+            // for publishers, pages are always published
+            return true;
+        }
+
+        ReplicationStatus replicationStatus = page.getContentResource().adaptTo(ReplicationStatus.class);
+        return replicationStatus != null && replicationStatus.getLastReplicationAction() == ReplicationActionType.ACTIVATE;
+    }
+
+    @Override
+    public boolean isNoIndex(@NotNull Page page) {
+        return false;
+    }
+
+    @Override
+    public boolean isRedirect(@NotNull Page page) {
+        return page.getContentResource().getValueMap().get(PageImpl.PN_REDIRECT_TARGET, String.class) != null;
+    }
+
+    @Override
+    public boolean isProtected(@NotNull Page page) {
+        return Optional.ofNullable(page.adaptTo(Resource.class)).map(this::isProtected).orElse(Boolean.FALSE);
+    }
+
+    @Override
+    public boolean isProtected(@NotNull Resource resource) {
+        return Optional.of(resource)
+            .map(Resource::getValueMap)
+            .map(properties -> properties.get(JcrConstants.JCR_MIXINTYPES, String[].class))
+            .map(Arrays::asList)
+            .map(mixins -> mixins.contains("granite:AuthenticationRequired"))
+            .orElse(Boolean.FALSE);
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/sitemap/SitemapDispatcherFlushImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/sitemap/SitemapDispatcherFlushImpl.java
@@ -1,0 +1,120 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.sitemap;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import javax.jcr.Session;
+
+import org.apache.sling.api.resource.ResourceUtil;
+import org.apache.sling.jcr.api.SlingRepository;
+import org.apache.sling.sitemap.generator.SitemapGenerator;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventConstants;
+import org.osgi.service.event.EventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.wcm.core.components.internal.Utils;
+import com.day.cq.replication.*;
+
+@Component(
+    service = EventHandler.class,
+    property = {
+        EventConstants.EVENT_TOPIC + "=" + SitemapGenerator.EVENT_TOPIC_SITEMAP_UPDATED,
+        EventConstants.EVENT_TOPIC + "=" + SitemapGenerator.EVENT_TOPIC_SITEMAP_PURGED,
+        EventConstants.EVENT_TOPIC + "=" + ReplicationEvent.EVENT_TOPIC
+    },
+    configurationPolicy = ConfigurationPolicy.REQUIRE
+)
+public class SitemapDispatcherFlushImpl implements EventHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SitemapDispatcherFlushImpl.class);
+    private static final AgentFilter FLUSH_AGENT_FILTER = agent -> agent.getConfiguration().isSpecific() &&
+        agent.getConfiguration().isTriggeredOnReceive();
+    private static final String SITEMAP_STORAGE_ROOT = "/var/sitemaps";
+
+    @Reference
+    private SlingRepository repository;
+    @Reference
+    private Replicator replicator;
+
+    @Override
+    public void handleEvent(Event event) {
+        String[] paths = getFlushPaths(event).toArray(String[]::new);
+        if (paths.length == 0) {
+            return;
+        }
+
+        Session session = null;
+        try {
+            session = repository.loginService(Utils.COMPONENTS_SERVICE, repository.getDefaultWorkspace());
+
+            ReplicationOptions opts = new ReplicationOptions();
+            opts.setSuppressStatusUpdate(true);
+            opts.setSuppressVersions(true);
+            opts.setUpdateAlias(false);
+            opts.setFilter(FLUSH_AGENT_FILTER);
+
+            replicator.replicate(session, ReplicationActionType.DELETE, paths, opts);
+        } catch (Exception ex) {
+            LOG.warn("Failed to queue flush of sitemap: {}", ex.getMessage(), ex);
+        } finally {
+            if (session != null) {
+                session.logout();
+            }
+        }
+    }
+
+    private Stream<String> getFlushPaths(Event event) {
+        Stream<String> storagePaths;
+
+        if (event.getTopic().equals(SitemapGenerator.EVENT_TOPIC_SITEMAP_UPDATED)
+            || event.getTopic().equals(SitemapGenerator.EVENT_TOPIC_SITEMAP_PURGED)) {
+            storagePaths = Stream.of((String) event.getProperty(SitemapGenerator.EVENT_PROPERTY_SITEMAP_STORAGE_PATH));
+        } else if (event.getTopic().equals(ReplicationEvent.EVENT_TOPIC) && !event.containsProperty("event.application")) {
+            // non-distributed replication events, inspired by the configuration of the ChainReplicationProcessor
+            storagePaths = Arrays.stream(ReplicationEvent.fromEvent(event).getReplicationAction().getPaths());
+        } else {
+            storagePaths = Stream.empty();
+        }
+
+        return storagePaths.flatMap(this::getFlushPathsForStoragePath);
+    }
+
+    private Stream<String> getFlushPathsForStoragePath(String storagePath) {
+        String name = ResourceUtil.getName(storagePath);
+        String parentPath = ResourceUtil.getParent(storagePath);
+        if (parentPath == null || parentPath.length() < SITEMAP_STORAGE_ROOT.length()) {
+            // handle corner cases to prevent any runtime exceptions
+            return Stream.empty();
+        }
+
+        String sitemapContentRoot = parentPath.substring(SITEMAP_STORAGE_ROOT.length());
+        String sitemapContentPath = name.equals("sitemap.xml")
+            // for the default name, no selector is added to avoid redundancy
+            ? sitemapContentRoot + '.' + name
+            // for named sitemaps a sitemap selector is added
+            : sitemapContentRoot + ".sitemap." + name;
+
+        // map the storage path to all applicable content paths, that includes the sitemap-index potentially
+        return Stream.of(sitemapContentPath, sitemapContentRoot + ".sitemap-index.xml");
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/sitemap/SitemapExternalizerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/sitemap/SitemapExternalizerImpl.java
@@ -1,0 +1,46 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.sitemap;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.sitemap.common.Externalizer;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * An {@link Externalizer} to be used for sitemaps.
+ */
+@Component(property = Constants.SERVICE_RANKING + "=I\"100\"")
+public class SitemapExternalizerImpl implements Externalizer {
+
+    @Reference
+    private com.day.cq.commons.Externalizer externalizer;
+
+    @Override
+    @Nullable
+    public String externalize(SlingHttpServletRequest request, String path) {
+        return externalizer.absoluteLink(request, request.getScheme(), path);
+    }
+
+    @Override
+    @Nullable
+    public String externalize(Resource resource) {
+        return externalizer.publishLink(resource.getResourceResolver(), resource.getPath());
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/sitemap/SitemapLinkExternalizerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/sitemap/SitemapLinkExternalizerImpl.java
@@ -17,20 +17,22 @@ package com.adobe.cq.wcm.core.components.internal.services.sitemap;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.sitemap.common.Externalizer;
+import org.apache.sling.sitemap.common.SitemapLinkExternalizer;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import com.day.cq.commons.Externalizer;
+
 /**
- * An {@link Externalizer} to be used for sitemaps.
+ * An {@link SitemapLinkExternalizer} to be used for sitemaps.
  */
-@Component(property = Constants.SERVICE_RANKING + "=I\"100\"")
-public class SitemapExternalizerImpl implements Externalizer {
+@Component(property = Constants.SERVICE_RANKING + ":Integer=100")
+public class SitemapLinkExternalizerImpl implements SitemapLinkExternalizer {
 
     @Reference
-    private com.day.cq.commons.Externalizer externalizer;
+    private Externalizer externalizer;
 
     @Override
     @Nullable

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/sitemap/SitemapReplicatorImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/sitemap/SitemapReplicatorImpl.java
@@ -1,0 +1,74 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.sitemap;
+
+import javax.jcr.Session;
+
+import org.apache.sling.jcr.api.SlingRepository;
+import org.apache.sling.serviceusermapping.ServiceUserMapped;
+import org.apache.sling.sitemap.generator.SitemapGenerator;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventConstants;
+import org.osgi.service.event.EventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.wcm.core.components.internal.Utils;
+import com.day.cq.replication.AgentFilter;
+import com.day.cq.replication.ReplicationActionType;
+import com.day.cq.replication.ReplicationOptions;
+import com.day.cq.replication.Replicator;
+
+/**
+ * An {@link EventHandler} that schedules updated sitemaps for replication.
+ */
+@Component(
+    service = EventHandler.class,
+    property = {
+        EventConstants.EVENT_TOPIC + "=" + SitemapGenerator.EVENT_TOPIC_SITEMAP_UPDATED
+    }
+)
+public class SitemapReplicatorImpl implements EventHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SitemapReplicatorImpl.class);
+
+    @Reference(target = "(subServiceName=" + Utils.COMPONENTS_SERVICE + ")")
+    private ServiceUserMapped serviceUser;
+    @Reference
+    private Replicator replicator;
+    @Reference
+    private SlingRepository repository;
+
+    @Override
+    public void handleEvent(Event event) {
+        Session session = null;
+        try {
+            session = repository.loginService(Utils.COMPONENTS_SERVICE, repository.getDefaultWorkspace());
+            String storagePath = (String) event.getProperty(SitemapGenerator.EVENT_PROPERTY_SITEMAP_STORAGE_PATH);
+            ReplicationOptions opts = new ReplicationOptions();
+            opts.setFilter(AgentFilter.DEFAULT);
+            replicator.replicate(session, ReplicationActionType.ACTIVATE, storagePath, opts);
+        } catch (Exception ex) {
+            LOG.warn("Failed to queue replication of sitemap: {}", ex.getMessage(), ex);
+        } finally {
+            if (session != null) {
+                session.logout();
+            }
+        }
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/SitemapDetails.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/SitemapDetails.java
@@ -1,0 +1,64 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2017 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.models;
+
+import java.util.List;
+
+/**
+ * Describes the details that can be returned for a sitemap root.
+ */
+public interface SitemapDetails {
+
+    /**
+     * Returns a list of details about the sitemaps of the current resource if it is a sitemap root.
+     *
+     * @return
+     */
+    List<Detail> getDetails();
+
+    /**
+     * Returns true when the current resource is a sitemap root.
+     *
+     * @return
+     */
+    boolean isSitemapRoot();
+
+    /**
+     * Returns true when the at least one of the current resource's sitemaps is currently being generated.
+     *
+     * @return
+     */
+    boolean isGenerationPending();
+
+    /**
+     * Returns true when at least one of the current resource's sitemaps exceeds the configured limits.
+     *
+     * @return
+     */
+    boolean hasWarning();
+
+    interface Detail {
+
+        String getName();
+
+        String getUrl();
+
+        String getSize();
+
+        String getEntries();
+
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/SitemapDetails.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/SitemapDetails.java
@@ -1,5 +1,5 @@
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- ~ Copyright 2017 Adobe
+ ~ Copyright 2021 Adobe
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
@@ -15,10 +15,11 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.models;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
- * Describes the details that can be returned for a sitemap root.
+ * Describes the details that can be returned for a sitemap root Resource.
  */
 public interface SitemapDetails {
 
@@ -27,38 +28,56 @@ public interface SitemapDetails {
      *
      * @return
      */
-    List<Detail> getDetails();
+    default List<Detail> getDetails() {
+        return Collections.emptyList();
+    }
 
     /**
      * Returns true when the current resource is a sitemap root.
      *
      * @return
      */
-    boolean isSitemapRoot();
+    default boolean isSitemapRoot() {
+        return false;
+    }
 
     /**
      * Returns true when the at least one of the current resource's sitemaps is currently being generated.
      *
      * @return
      */
-    boolean isGenerationPending();
+    default boolean isGenerationPending() {
+        return false;
+    }
 
     /**
      * Returns true when at least one of the current resource's sitemaps exceeds the configured limits.
      *
      * @return
      */
-    boolean hasWarning();
+    default boolean hasWarning() {
+        return false;
+    }
 
+    /**
+     * A Detail describing a sitemap for the model's Resource.
+     */
     interface Detail {
 
-        String getName();
+        default String getName() {
+            return null;
+        }
 
-        String getUrl();
+        default String getUrl() {
+            return null;
+        }
 
-        String getSize();
+        default String getSize() {
+            return null;
+        }
 
-        String getEntries();
-
+        default String getEntries() {
+            return null;
+        }
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.20.0")
+@Version("12.21.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/sitemap/PageTreeSitemapGenerator.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/sitemap/PageTreeSitemapGenerator.java
@@ -1,0 +1,86 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.services.sitemap;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.sitemap.generator.SitemapGenerator;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.annotation.versioning.ProviderType;
+
+import com.day.cq.wcm.api.Page;
+
+/**
+ * A service that exposes the filters and utility methods the default {@link SitemapGenerator} of the WCM Core Components uses.
+ * <p>
+ * It acts as extension point for a delegation pattern implementation, where another {@link SitemapGenerator} replaces the default one but
+ * needs to use some of its functionality anyway.
+ */
+@ProviderType
+public interface PageTreeSitemapGenerator extends SitemapGenerator {
+
+    /**
+     * Returns a mapping from {@link Locale} to {@link Page} for the language alternatives of the given {@link Page}.
+     *
+     * @return
+     */
+    Map<Locale, String> getLanguageAlternatives(Page page);
+
+    /**
+     * Returns true when the {@link Page} is published.
+     * <p>
+     * When called on publishers, this is always true.
+     *
+     * @param page
+     * @return
+     */
+    boolean isPublished(@NotNull Page page);
+
+    /**
+     * Returns true when the {@link Page} is set to be not indexed by search engines.
+     *
+     * @param page
+     * @return
+     */
+    boolean isNoIndex(@NotNull Page page);
+
+    /**
+     * Returns true when the {@link Page} has a redirect target.
+     *
+     * @param page
+     * @return
+     */
+    boolean isRedirect(@NotNull Page page);
+
+    /**
+     * Returns true when the {@link Page} requires authentication.
+     *
+     * @param page
+     * @return
+     */
+    boolean isProtected(@NotNull Page page);
+
+    /**
+     * Returns true when the {@link Resource} requires authentication.
+     *
+     * @param resource
+     * @return
+     */
+    boolean isProtected(@NotNull Resource resource);
+
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/sitemap/PageTreeSitemapGenerator.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/sitemap/PageTreeSitemapGenerator.java
@@ -36,6 +36,8 @@ public interface PageTreeSitemapGenerator extends SitemapGenerator {
 
     /**
      * Returns a mapping from {@link Locale} to {@link Page} for the language alternatives of the given {@link Page}.
+     * <p>
+     * Each path is checked with {@link SitemapGenerator#shouldInclude(Resource)} before being returned.
      *
      * @return
      */

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/sitemap/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/sitemap/package-info.java
@@ -1,0 +1,19 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+@Version("1.0.0")
+package com.adobe.cq.wcm.core.components.services.sitemap;
+
+import org.osgi.annotation.versioning.Version;

--- a/config/src/content/META-INF/vault/filter.xml
+++ b/config/src/content/META-INF/vault/filter.xml
@@ -17,4 +17,5 @@
 <workspaceFilter version="1.0">
     <filter root="/apps/core/wcm/config"/>
     <filter root="/apps/core/wcm/config.author"/>
+    <filter root="/apps/core/wcm/config.publish"/>
 </workspaceFilter>

--- a/config/src/content/jcr_root/apps/core/wcm/config.author/com.adobe.cq.wcm.core.components.internal.services.sitemap.SitemapReplicatorImpl.config
+++ b/config/src/content/jcr_root/apps/core/wcm/config.author/com.adobe.cq.wcm.core.components.internal.services.sitemap.SitemapReplicatorImpl.config
@@ -1,4 +1,4 @@
-# Copyright 2019 Adobe
+# Copyright 2021 Adobe
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-user.mapping=[
-    "com.adobe.cq.core.wcm.components.core:components-service\=[clientlibs-service,sling-scripting,replication-service]",
-    "org.apache.sling.sitemap:sitemap-reader\=[content-reader-service]",
-    "org.apache.sling.sitemap:sitemap-writer\=[sling-sitemap-writer,content-reader-service]"
+event.topics=[
+    "org/apache/sling/sitemap/UPDATED",
+    "org/apache/sling/sitemap/PURGED"
 ]

--- a/config/src/content/jcr_root/apps/core/wcm/config.author/org.apache.sling.event.jobs.QueueConfiguration-slingsitemap.config
+++ b/config/src/content/jcr_root/apps/core/wcm/config.author/org.apache.sling.event.jobs.QueueConfiguration-slingsitemap.config
@@ -1,4 +1,4 @@
-# Copyright 2019 Adobe
+# Copyright 2021 Adobe
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-user.mapping=[
-    "com.adobe.cq.core.wcm.components.core:components-service\=[clientlibs-service,sling-scripting,replication-service]",
-    "org.apache.sling.sitemap:sitemap-reader\=[content-reader-service]",
-    "org.apache.sling.sitemap:sitemap-writer\=[sling-sitemap-writer,content-reader-service]"
-]
+queue.name="Background Sitemap Generation Queue Config"
+queue.topics=["org/apache/sling/sitemap/build"]
+queue.type="UNORDERED"
+queue.priority="MIN"
+queue.maxparallel=I"1"

--- a/config/src/content/jcr_root/apps/core/wcm/config.author/org.apache.sling.sitemap.impl.SitemapScheduler-default.config
+++ b/config/src/content/jcr_root/apps/core/wcm/config.author/org.apache.sling.sitemap.impl.SitemapScheduler-default.config
@@ -1,4 +1,4 @@
-# Copyright 2019 Adobe
+# Copyright 2021 Adobe
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-user.mapping=[
-    "com.adobe.cq.core.wcm.components.core:components-service\=[clientlibs-service,sling-scripting,replication-service]",
-    "org.apache.sling.sitemap:sitemap-reader\=[content-reader-service]",
-    "org.apache.sling.sitemap:sitemap-writer\=[sling-sitemap-writer]"
-]
+scheduler.name="default-sitemaps"
+scheduler.expression="0 0 */4 * * ?"
+scheduler.runOn="LEADER"
+scheduler.concurrent=B"false"
+names=["<default>"]

--- a/config/src/content/jcr_root/apps/core/wcm/config.publish/com.adobe.cq.wcm.core.components.internal.services.sitemap.SitemapDispatcherFlushImpl.config
+++ b/config/src/content/jcr_root/apps/core/wcm/config.publish/com.adobe.cq.wcm.core.components.internal.services.sitemap.SitemapDispatcherFlushImpl.config
@@ -1,4 +1,4 @@
-# Copyright 2019 Adobe
+# Copyright 2021 Adobe
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-user.mapping=[
-    "com.adobe.cq.core.wcm.components.core:components-service\=[clientlibs-service,sling-scripting,replication-service]",
-    "org.apache.sling.sitemap:sitemap-reader\=[content-reader-service]",
-    "org.apache.sling.sitemap:sitemap-writer\=[sling-sitemap-writer,content-reader-service]"
+event.topics=[
+    "org/apache/sling/sitemap/UPDATED",
+    "org/apache/sling/sitemap/PURGED",
+    "com/adobe/granite/replication"
 ]

--- a/config/src/content/jcr_root/apps/core/wcm/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-slingsitemap.config
+++ b/config/src/content/jcr_root/apps/core/wcm/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-slingsitemap.config
@@ -1,4 +1,4 @@
-# Copyright 2019 Adobe
+# Copyright 2021 Adobe
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-user.mapping=[
-    "com.adobe.cq.core.wcm.components.core:components-service\=[clientlibs-service,sling-scripting,replication-service]",
-    "org.apache.sling.sitemap:sitemap-reader\=[content-reader-service]",
-    "org.apache.sling.sitemap:sitemap-writer\=[sling-sitemap-writer]"
-]
+scripts=["
+create path (sling:Folder) /var/sitemaps (sling:Folder mixin rep:AccessControllable)
+create service user sling-sitemap-writer with forced path system/cq:services
+set principal ACL for sling-sitemap-writer
+    allow jcr:read,rep:write on /var/sitemaps
+end"]

--- a/config/src/content/jcr_root/apps/core/wcm/config/org.apache.sling.sitemap.impl.SitemapServlet.config
+++ b/config/src/content/jcr_root/apps/core/wcm/config/org.apache.sling.sitemap.impl.SitemapServlet.config
@@ -1,4 +1,4 @@
-# Copyright 2019 Adobe
+# Copyright 2021 Adobe
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-user.mapping=[
-    "com.adobe.cq.core.wcm.components.core:components-service\=[clientlibs-service,sling-scripting,replication-service]",
-    "org.apache.sling.sitemap:sitemap-reader\=[content-reader-service]",
-    "org.apache.sling.sitemap:sitemap-writer\=[sling-sitemap-writer]"
-]
+sling.servlet.resourceTypes=["core/wcm/components/page/v2/page"]
+sling.servlet.selectors=["sitemap","sitemap-index"]
+sling.servlet.extensions=["xml"]

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -61,6 +61,9 @@
                         <filter>
                             <root>/apps/core/wcm/components</root>
                         </filter>
+                        <filter>
+                            <root>/apps/cq</root>
+                        </filter>
                     </filters>
                     <packageType>application</packageType>
                     <dependencies>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_dialog/.content.xml
@@ -91,6 +91,63 @@
                             </column>
                         </items>
                     </basic>
+                    <advanced
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Advanced"
+                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
+                        <items jcr:primaryType="nt:unstructured">
+                            <column
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <section1
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                                        path="/mnt/overlay/wcm/foundation/components/basicpage/v1/basicpage/tabs/advanced/items/column/items/section1"/>
+                                    <configuration
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                                        path="/mnt/overlay/wcm/foundation/components/basicpage/v1/basicpage/tabs/advanced/items/column/items/configuration"/>
+                                    <spa
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                                        path="/mnt/overlay/wcm/foundation/components/basicpage/v1/basicpage/tabs/advanced/items/column/items/spa"/>
+                                    <templates
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                                        path="/mnt/overlay/wcm/foundation/components/basicpage/v1/basicpage/tabs/advanced/items/column/items/templates"/>
+                                    <authenticationrequirement
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                                        path="/mnt/overlay/wcm/foundation/components/basicpage/v1/basicpage/tabs/advanced/items/column/items/authenticationrequirement"/>
+                                    <export
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                                        path="/mnt/overlay/wcm/foundation/components/basicpage/v1/basicpage/tabs/advanced/items/column/items/export"/>
+                                    <seo
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="SEO"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <sitemapRoot
+                                                jcr:primaryType="nt:unstructured"
+                                                text="Generate Sitemap"
+                                                value="true"
+                                                name="./sitemapRoot"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox">
+                                                <granite:data
+                                                    cq-msm-lockable="./sitemapRoot"
+                                                    jcr:primaryType="nt:unstructured"/>
+                                            </sitemapRoot>
+                                            <sitemapDetailsPanel
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/siteadmin/admin/properties/sitemapdetails"/>
+                                        </items>
+                                    </seo>
+                                </items>
+                            </column>
+                        </items>
+                    </advanced>
                     <socialmedia
                         cq:showOnCreate="{Boolean}true"
                         jcr:primaryType="nt:unstructured"

--- a/content/src/content/jcr_root/apps/cq/gui/components/siteadmin/admin/properties/sitemapdetails/sitemapdetails.html
+++ b/content/src/content/jcr_root/apps/cq/gui/components/siteadmin/admin/properties/sitemapdetails/sitemapdetails.html
@@ -24,7 +24,9 @@
         <coral-alert variant="warning" data-sly-test.warning="${sitemapDetails.hasWarning}">
             <coral-alert-header>${ 'Warning' @ i18n }</coral-alert-header>
             <coral-alert-content>
-                ${ 'At least one of the sitemaps exceeds the configured limits. Please consider splitting the sitemap(s) by making any of the descendant pages a sitemap root. Please refer to the documentation for more details.' @ i18n }
+                ${ 'At least one of the sitemaps exceeds the configured limits. Please consider splitting the sitemap(s) by making any of the descendant pages a sitemap root.' @ i18n }
+                <br/>
+                ${ 'Please refer to the documentation for more details.' @ i18n}
             </coral-alert-content>
         </coral-alert>
         <sly data-sly-test="${!warning}">
@@ -32,18 +34,18 @@
         </sly>
         <table is="coral-table">
             <thead is="coral-table-head">
-            <tr is="coral-table-row">
-                <th is="coral-table-headercell">${ 'Link' @ i18n }</th>
-                <th is="coral-table-headercell">${ 'Size' @ i18n }</th>
-                <th is="coral-table-headercell">${ 'URLs' @ i18n }</th>
-            </tr>
+                <tr is="coral-table-row">
+                    <th is="coral-table-headercell">${ 'Link' @ i18n }</th>
+                    <th is="coral-table-headercell">${ 'Size' @ i18n }</th>
+                    <th is="coral-table-headercell">${ 'URLs' @ i18n }</th>
+                </tr>
             </thead>
             <tbody is="coral-table-body" divider="cell">
-            <tr is="coral-table-row" data-sly-repeat="${sitemapDetails.details}">
-                <td is="coral-table-cell"><a href="${item.url}">${item.name}</a></td>
-                <td is="coral-table-cell">${item.size}</td>
-                <td is="coral-table-cell">${item.entries}</td>
-            </tr>
+                <tr is="coral-table-row" data-sly-repeat="${sitemapDetails.details}">
+                    <td is="coral-table-cell"><a href="${item.url}">${item.name}</a></td>
+                    <td is="coral-table-cell">${item.size}</td>
+                    <td is="coral-table-cell">${item.entries}</td>
+                </tr>
             </tbody>
         </table>
     </coral-panel>

--- a/content/src/content/jcr_root/apps/cq/gui/components/siteadmin/admin/properties/sitemapdetails/sitemapdetails.html
+++ b/content/src/content/jcr_root/apps/cq/gui/components/siteadmin/admin/properties/sitemapdetails/sitemapdetails.html
@@ -1,0 +1,50 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2019 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+
+<coral-panelstack class="coral-Well" id="panelListPreselectedItem"
+                  data-sly-use.sitemapDetails="com.adobe.cq.wcm.core.components.models.SitemapDetails"
+                  data-sly-test="${sitemapDetails.isSitemapRoot && sitemapDetails.details.size > 0}">
+    <coral-panel selected data-sly-test.generating="${sitemapDetails.generationPending}">
+        ${ 'Sitemap(s) are currently being generated. This may take a while.' @ i18n }
+    </coral-panel>
+    <coral-panel selected data-sly-test="${!generating}">
+        <coral-alert variant="warning" data-sly-test.warning="${sitemapDetails.hasWarning}">
+            <coral-alert-header>${ 'Warning' @ i18n }</coral-alert-header>
+            <coral-alert-content>
+                ${ 'At least one of the sitemaps exceeds the configured limits. Please consider splitting the sitemap(s) by making any of the descendant pages a sitemap root. Please refer to the documentation for more details.' @ i18n }
+            </coral-alert-content>
+        </coral-alert>
+        <sly data-sly-test="${!warning}">
+            ${ 'Sitemap generation completed. Please copy the link to the sitemap to your site\'s Search Administration Console(s) and/or add it to your site\'s robots.txt.' @ i18n }
+        </sly>
+        <table is="coral-table">
+            <thead is="coral-table-head">
+            <tr is="coral-table-row">
+                <th is="coral-table-headercell">${ 'Link' @ i18n }</th>
+                <th is="coral-table-headercell">${ 'Size' @ i18n }</th>
+                <th is="coral-table-headercell">${ 'URLs' @ i18n }</th>
+            </tr>
+            </thead>
+            <tbody is="coral-table-body" divider="cell">
+            <tr is="coral-table-row" data-sly-repeat="${sitemapDetails.details}">
+                <td is="coral-table-cell"><a href="${item.url}">${item.name}</a></td>
+                <td is="coral-table-cell">${item.size}</td>
+                <td is="coral-table-cell">${item.entries}</td>
+            </tr>
+            </tbody>
+        </table>
+    </coral-panel>
+</coral-panelstack>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -676,6 +676,12 @@
                 <version>1.0.0</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.sitemap</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+                <scope>provided</scope>
+            </dependency>
 
             <!-- javax.inject 1 -->
             <dependency>


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | CIF-2100, CIF-2101
| Patch: Bug Fix?          |  No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      |  Not yet
| Documentation Provided   | Not yet
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

The proposed changes implement XML sitemap generation based on https://github.com/apache/sling-whiteboard/tree/master/sitemap.

There are a couple of points to be discussed

- [ ] Should the SEO dialog section better be put in /libs/wcm/foundation?
- [ ] Should the Sitemap specific dialog components used in the page properties dialog better be in /libs/cq (incl. the Models used)?
- [ ] Should the repoinit (service user, service user mapping) and maybe other configurations better be put in the product? 

