### PR TITLE
GH-1615 - [Image] a black background is added when uploading a PNG image

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
@@ -71,6 +71,9 @@ import com.day.cq.wcm.api.Template;
 import com.day.cq.wcm.api.designer.Style;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import static com.day.cq.commons.jcr.JcrConstants.JCR_CONTENT;
+import static com.day.cq.commons.jcr.JcrConstants.JCR_MIMETYPE;
+
 @Model(adaptables = SlingHttpServletRequest.class, adapters = {Image.class, ComponentExporter.class}, resourceType = ImageImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class ImageImpl extends AbstractComponentImpl implements Image {
@@ -171,7 +174,14 @@ public class ImageImpl extends AbstractComponentImpl implements Image {
             }
         } else {
             if (fileResource != null) {
-                mimeType = PropertiesUtil.toString(fileResource.getResourceMetadata().get(ResourceMetadata.CONTENT_TYPE), MIME_TYPE_IMAGE_JPEG);
+                mimeType = PropertiesUtil.toString(fileResource.getResourceMetadata().get(ResourceMetadata.CONTENT_TYPE), null);
+                if (StringUtils.isEmpty(mimeType)) {
+                    Resource fileResourceContent = fileResource.getChild(JCR_CONTENT);
+                    if (fileResourceContent != null) {
+                        ValueMap fileProperties = fileResourceContent.getValueMap();
+                        mimeType = fileProperties.get(JCR_MIMETYPE, MIME_TYPE_IMAGE_JPEG);
+                    }
+                }
                 String fileName = properties.get(ImageResource.PN_FILE_NAME, String.class);
                 imageName = StringUtils.isNotEmpty(fileName) ? getSeoFriendlyName(FilenameUtils.getBaseName(fileName)) : "";
                 hasContent = true;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -428,6 +428,12 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
                     if (flipVertically) {
                         layer.flipVertically();
                     }
+                    if (layer.getBackground().getTransparency() != Transparency.OPAQUE &&
+                            ("jpg".equalsIgnoreCase(mimeTypeService.getExtension(imageType))
+                                    || "jpeg".equalsIgnoreCase(mimeTypeService.getExtension(imageType)))) {
+                        LOGGER.debug("Adding default (white) background to a transparent JPG: {}", imageFile.getPath());
+                        layer.setBackground(Color.white);
+                    }
                     resizeAndStreamLayer(response, layer, imageType, resizeWidth, quality);
                 } else {
                     LOGGER.debug("No need to perform any processing on file {}; rendering.", imageFile.getPath());


### PR DESCRIPTION
- get the mime type of an uploaded image from its jcr:mimeType property
- uploaded image: add a default (white) background to a transparent JPG (same behaviour when the image is a DAM asset)

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1615
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | NA
| Documentation Provided   | NA
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0
