### PR TITLE
SITES-1051-Avoid page reload when hash location changes

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
@@ -460,11 +460,6 @@
                 if (that._properties.singleExpansion) {
                     button.classList.add(cssClasses.button.disabled);
                     button.setAttribute("aria-disabled", true);
-                    that._elements["item"].forEach(function(accordionItem, itemIndex) {
-                        if (index !== itemIndex) {
-                            collapseItem(accordionItem);
-                        }
-                    });
                 }
             }
         }
@@ -516,35 +511,10 @@
         if (location.hash && location.hash !== "#") {
             var anchorLocation = decodeURIComponent(location.hash);
             var anchorElement = document.querySelector(anchorLocation);
-            if (anchorElement && anchorElement.classList.contains("cmp-accordion__item")) {
+            if (anchorElement && anchorElement.classList.contains("cmp-accordion__item") && !anchorElement.hasAttribute("data-cmp-expanded")) {
                 var anchorElementButton = document.querySelector(anchorLocation + "-button");
-                var anchorElementPanel = document.querySelector(anchorLocation + "-panel");
-                anchorElementButton.classList.add(cssClasses.button.expanded);
-                anchorElementButton.setAttribute("aria-expanded", true);
-                anchorElementPanel.classList.add(cssClasses.panel.expanded);
-                anchorElementPanel.classList.remove(cssClasses.panel.hidden);
-                anchorElementPanel.setAttribute("aria-hidden", false);
-                var accordionContainer = anchorElement.parentElement;
-                var accordionChildrenItems = anchorElement.parentElement.children;
-                if (accordionContainer && accordionContainer.hasAttribute("data-cmp-single-expansion") && accordionChildrenItems) {
-                    if (Array.isArray(Array.prototype.slice.call(accordionChildrenItems))) {
-                        for (var i = 0; i < accordionChildrenItems.length; i++) {
-                            var itemButton = document.querySelector("#" + accordionChildrenItems[i].id + "-button");
-                            var itemPanel = document.querySelector("#" + accordionChildrenItems[i].id + "-panel");
-                            if (accordionChildrenItems[i].id !== anchorLocation.substring(1)) {
-                                itemButton.classList.remove(cssClasses.button.disabled);
-                                itemButton.classList.remove(cssClasses.button.expanded);
-                                itemButton.removeAttribute("aria-disabled");
-                                itemButton.setAttribute("aria-expanded", false);
-                                itemPanel.classList.add(cssClasses.panel.hidden);
-                                itemPanel.classList.remove(cssClasses.panel.expanded);
-                                itemPanel.setAttribute("aria-hidden", true);
-                            } else {
-                                itemButton.classList.add(cssClasses.button.disabled);
-                                itemButton.setAttribute("aria-disabled", true);
-                            }
-                        }
-                    }
+                if (anchorElementButton) {
+                    anchorElementButton.click();
                 }
             }
         }

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
@@ -460,6 +460,11 @@
                 if (that._properties.singleExpansion) {
                     button.classList.add(cssClasses.button.disabled);
                     button.setAttribute("aria-disabled", true);
+                    that._elements["item"].forEach(function(item, itemIndex) {
+                        if (index !== itemIndex) {
+                            collapseItem(item);
+                        }
+                    });
                 }
             }
         }
@@ -499,6 +504,48 @@
         function focusButton(index) {
             var button = that._elements["button"][index];
             button.focus();
+        }
+    }
+
+    /**
+     * Scrolls the browser when the URI fragment is changed to the item of the container Accordion component that corresponds to the deep link in the URL fragment, and displays its content.
+     * This method fixes the issue existent with Chrome and related browsers, which are just scrolling to the item without displaying its content.
+     */
+    function onHashChange() {
+        if (location.hash && location.hash !== "#") {
+            var anchorLocation = decodeURIComponent(location.hash);
+            var anchorElement = document.querySelector(anchorLocation);
+            if (anchorElement && anchorElement.classList.contains("cmp-accordion__item")) {
+                var anchorElementButton = document.querySelector(anchorLocation + "-button");
+                var anchorElementPanel = document.querySelector(anchorLocation + "-panel");
+                anchorElementButton.classList.add(cssClasses.button.expanded);
+                anchorElementButton.setAttribute("aria-expanded", true);
+                anchorElementPanel.classList.add(cssClasses.panel.expanded);
+                anchorElementPanel.classList.remove(cssClasses.panel.hidden);
+                anchorElementPanel.setAttribute("aria-hidden", false);
+                var accordionContainer = anchorElement.parentElement;
+                var accordionChildrenItems = anchorElement.parentElement.children;
+                if (accordionContainer && accordionContainer.hasAttribute("data-cmp-single-expansion") && accordionChildrenItems) {
+                    if (Array.isArray(Array.prototype.slice.call(accordionChildrenItems))) {
+                        for (var i = 0; i < accordionChildrenItems.length; i++) {
+                            var itemButton = document.querySelector("#" + accordionChildrenItems[i].id + "-button");
+                            var itemPanel = document.querySelector("#" + accordionChildrenItems[i].id + "-panel");
+                            if (accordionChildrenItems[i].id !== anchorLocation.substring(1)) {
+                                itemButton.classList.remove(cssClasses.button.disabled);
+                                itemButton.classList.remove(cssClasses.button.expanded);
+                                itemButton.removeAttribute("aria-disabled");
+                                itemButton.setAttribute("aria-expanded", false);
+                                itemPanel.classList.add(cssClasses.panel.hidden);
+                                itemPanel.classList.remove(cssClasses.panel.expanded);
+                                itemPanel.setAttribute("aria-hidden", true);
+                            } else {
+                                itemButton.classList.add(cssClasses.button.disabled);
+                                itemButton.setAttribute("aria-disabled", true);
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -595,5 +642,7 @@
         document.addEventListener("DOMContentLoaded", onDocumentReady);
     }
 
-    window.addEventListener("hashchange", window.CQ.CoreComponents.container.utils.locationHashChanged, false);
+    window.addEventListener("load", window.CQ.CoreComponents.container.utils.scrollToAnchor, false);
+    window.addEventListener("hashchange", onHashChange, false);
+
 }());

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
@@ -460,9 +460,9 @@
                 if (that._properties.singleExpansion) {
                     button.classList.add(cssClasses.button.disabled);
                     button.setAttribute("aria-disabled", true);
-                    that._elements["item"].forEach(function(item, itemIndex) {
+                    that._elements["item"].forEach(function(accordionItem, itemIndex) {
                         if (index !== itemIndex) {
-                            collapseItem(item);
+                            collapseItem(accordionItem);
                         }
                     });
                 }
@@ -508,7 +508,8 @@
     }
 
     /**
-     * Scrolls the browser when the URI fragment is changed to the item of the container Accordion component that corresponds to the deep link in the URL fragment, and displays its content.
+     * Scrolls the browser when the URI fragment is changed to the item of the container Accordion component that corresponds to the deep link in the URL fragment,
+       and displays its content.
      * This method fixes the issue existent with Chrome and related browsers, which are just scrolling to the item without displaying its content.
      */
     function onHashChange() {

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/site/clientlibs/container/js/containerUtils.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/site/clientlibs/container/js/containerUtils.js
@@ -71,8 +71,10 @@
         },
 
         /**
-         * Scrolls the browser on page reload (if URL contains URI fragment) to the item of the container component (accordion, tabs) that corresponds to the deep link in the URL fragment.
-         * This method fixes the issue existent with Chrome and related browsers, which are not scrolling on page reload (if URL contains URI fragment) to the element that corresponds to the deep link in the URL fragment.
+         * Scrolls the browser on page reload (if URL contains URI fragment) to the item of the container component (accordion, tabs)
+           that corresponds to the deep link in the URL fragment.
+         * This method fixes the issue existent with Chrome and related browsers, which are not scrolling on page reload (if URL contains URI fragment)
+           to the element that corresponds to the deep link in the URL fragment.
          * Small setTimeout is needed, otherwise the scrolling will not work on Chrome.
          */
         scrollToAnchor: function() {

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/site/clientlibs/container/js/containerUtils.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/site/clientlibs/container/js/containerUtils.js
@@ -71,11 +71,20 @@
         },
 
         /**
-         * Refreshes the page when the hash location has been changed.
+         * Scrolls the browser on page reload (if URL contains URI fragment) to the item of the container component (accordion, tabs) that corresponds to the deep link in the URL fragment.
+         * This method fixes the issue existent with Chrome and related browsers, which are not scrolling on page reload (if URL contains URI fragment) to the element that corresponds to the deep link in the URL fragment.
+         * Small setTimeout is needed, otherwise the scrolling will not work on Chrome.
          */
-        locationHashChanged: function() {
-            window.location.reload();
+        scrollToAnchor: function() {
+            setTimeout(function() {
+                if (location.hash && location.hash !== "#") {
+                    var anchorLocation = decodeURIComponent(location.hash);
+                    var anchorElement = document.querySelector(anchorLocation);
+                    if (anchorElement && anchorElement.offsetTop) {
+                        anchorElement.scrollIntoView();
+                    }
+                }
+            }, 100);
         }
-
     };
 }());

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
@@ -326,43 +326,8 @@
         if (location.hash && location.hash !== "#") {
             var anchorLocation = decodeURIComponent(location.hash);
             var anchorElement = document.querySelector(anchorLocation);
-            if (anchorElement && anchorElement.classList.contains("cmp-tabs__tab")) {
-                anchorElement.classList.add(selectors.active.tab);
-                anchorElement.setAttribute("aria-selected", true);
-                anchorElement.setAttribute("tabindex", "0");
-                var childrenTabsOfTheSameParent = anchorElement.parentElement.children;
-                if (childrenTabsOfTheSameParent) {
-                    if (Array.isArray(Array.prototype.slice.call(childrenTabsOfTheSameParent))) {
-                        for (var i = 0; i < childrenTabsOfTheSameParent.length; i++) {
-                            if (childrenTabsOfTheSameParent[i].id !== anchorLocation.substring(1)) {
-                                if (childrenTabsOfTheSameParent[i].classList.contains(selectors.active.tab)) {
-                                    childrenTabsOfTheSameParent[i].classList.remove(selectors.active.tab);
-                                    childrenTabsOfTheSameParent[i].setAttribute("aria-selected", false);
-                                    childrenTabsOfTheSameParent[i].setAttribute("tabindex", "-1");
-                                }
-                            }
-                        }
-                    }
-                }
-
-                var correspondingPanel = document.querySelector(anchorLocation + "panel");
-                if (correspondingPanel) {
-                    correspondingPanel.classList.add(selectors.active.tabpanel);
-                    correspondingPanel.removeAttribute("aria-hidden");
-                    var childrenPanelsOfTheSameParent = correspondingPanel.parentElement.children;
-                    if (childrenPanelsOfTheSameParent) {
-                        if (Array.isArray(Array.prototype.slice.call(childrenPanelsOfTheSameParent))) {
-                            for (var j = 0; j < childrenPanelsOfTheSameParent.length; j++) {
-                                if (childrenPanelsOfTheSameParent[j].id !== (anchorLocation + "panel").substring(1)) {
-                                    if (childrenPanelsOfTheSameParent[j].classList.contains(selectors.active.tabpanel)) {
-                                        childrenPanelsOfTheSameParent[j].classList.remove(selectors.active.tabpanel);
-                                        childrenPanelsOfTheSameParent[j].setAttribute("aria-hidden", true);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+            if (anchorElement && anchorElement.classList.contains("cmp-tabs__tab") && !anchorElement.classList.contains("cmp-tabs__tab--active")) {
+                anchorElement.click();
             }
         }
     }

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
@@ -318,7 +318,8 @@
     }
 
     /**
-     * Scrolls the browser when the URI fragment is changed to the item of the container Tab component that corresponds to the deep link in the URI fragment, and displays its content.
+     * Scrolls the browser when the URI fragment is changed to the item of the container Tab component that corresponds to the deep link in the URI fragment,
+       and displays its content.
      * This method fixes the issue existent with Chrome and related browsers, which are just scrolling to the item without displaying its content.
      */
     function onHashChange() {


### PR DESCRIPTION
- fixes the issue existent with Chrome and related browsers, which are not implementing as expected the deep linking for the item of the container (Tabs, Accordion) component, when the URI fragment is changed. In the current behaviour, the browser scrolls to the item, but don't expand its content. This behaviour is fixed in this PR and the content is also displayed, without having to reload the page.
- fixes the issue existent with Chrome and related browsers, which are not scrolling on page reload (if URL contains URI fragment) to the item of the container component (Tabs, Accordion) component that corresponds to the deep link in the URL fragment.

Fixes #1614, #1432
