### PR TITLE
[Embed] Add Data Layer support

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/datalayer/EmbeddableDataImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/datalayer/EmbeddableDataImpl.java
@@ -1,0 +1,44 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1.datalayer;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.adobe.cq.wcm.core.components.models.datalayer.EmbeddableData;
+import com.adobe.cq.wcm.core.components.models.datalayer.builder.DataLayerSupplier;
+
+public class EmbeddableDataImpl extends ComponentDataImpl implements EmbeddableData {
+
+    private Map<String, Object> embeddableDetails;
+
+    public EmbeddableDataImpl(@NotNull final DataLayerSupplier supplier) {
+        super(supplier);
+    }
+
+    @Override
+    public Map<String, Object> getEmbeddableDetails() {
+        if (this.embeddableDetails == null) {
+            this.embeddableDetails = this.getDataLayerSupplier()
+                    .getEmbeddableDetails()
+                    .map(Supplier::get)
+                    .orElse(null);
+        }
+        return this.embeddableDetails;
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/datalayer/builder/DataLayerSupplierImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/datalayer/builder/DataLayerSupplierImpl.java
@@ -501,7 +501,7 @@ public final class DataLayerSupplierImpl implements DataLayerSupplier {
     }
 
     /**
-     * Set the embeddable details value supplier.
+     * Sets the embeddable details value supplier.
      *
      * @param supplier The embeddable details value supplier.
      * @return This.
@@ -521,7 +521,7 @@ public final class DataLayerSupplierImpl implements DataLayerSupplier {
     }
 
     /**
-     * Set the template path field value supplier.
+     * Sets the template path field value supplier.
      *
      * @param supplier The template path field value supplier.
      * @return This.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/datalayer/builder/DataLayerSupplierImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/datalayer/builder/DataLayerSupplierImpl.java
@@ -145,6 +145,12 @@ public final class DataLayerSupplierImpl implements DataLayerSupplier {
     private Supplier<ContentFragmentData.ElementData[]> contentFragmentElementsSupplier;
 
     /**
+     * The embeddable value supplier;
+     */
+    @Nullable
+    private Supplier<Map<String, Object>> embeddableSupplier;
+
+    /**
      * Construct a wrapper for a {@link DataLayerSupplier}.
      *
      * @param dataLayerSupplier The data layer supply to wrap.
@@ -482,6 +488,26 @@ public final class DataLayerSupplierImpl implements DataLayerSupplier {
      */
     public DataLayerSupplierImpl setSmartTags(@NotNull final Supplier<Map<String, Object>> supplier) {
         this.smartTagsSupplier = supplier;
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public Optional<Supplier<Map<String, Object>>> getEmbeddableDetails() {
+        if (this.embeddableSupplier != null) {
+            return Optional.of(this.embeddableSupplier);
+        }
+        return this.wrappedSupplier.getEmbeddableDetails();
+    }
+
+    /**
+     * Set the embeddable details value supplier.
+     *
+     * @param supplier The embeddable details value supplier.
+     * @return This.
+     */
+    public DataLayerSupplierImpl setEmbeddableDetails(@NotNull final Supplier<Map<String, Object>> supplier) {
+        this.embeddableSupplier = supplier;
         return this;
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/EmbeddableData.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/EmbeddableData.java
@@ -20,6 +20,11 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Interface defining data for embeddables.
+ *
+ * @since com.adobe.cq.wcm.core.components.models.datalayer 1.3.0
+ */
 public interface EmbeddableData extends ComponentData {
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/EmbeddableData.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/EmbeddableData.java
@@ -1,5 +1,5 @@
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- ~ Copyright 2020 Adobe
+ ~ Copyright 2021 Adobe
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
@@ -13,11 +13,24 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-/**
- * This packages defines models for integration with
- * <a href="https://github.com/adobe/adobe-client-data-layer">Adobe Client Data Layer</a>
- */
-@Version("1.3.0")
 package com.adobe.cq.wcm.core.components.models.datalayer;
 
-import org.osgi.annotation.versioning.Version;
+import java.util.Collections;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public interface EmbeddableData extends ComponentData {
+
+    /**
+     * Returns the embeddable properties.
+     *
+     * @return Map of embeddable properties
+     *
+     * @since com.adobe.cq.wcm.core.components.models.datalayer 1.3.0
+     */
+    @JsonProperty("embeddableProperties")
+    default Map<String, Object> getEmbeddableDetails() {
+        return Collections.emptyMap();
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/ComponentDataLayerExtender.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/ComponentDataLayerExtender.java
@@ -90,7 +90,7 @@ public final class ComponentDataLayerExtender {
     }
 
     /**
-     * Get a EmbeddableDataBuilder that extends existing component data.
+     * Gets a EmbeddableDataBuilder that extends existing component data.
      *
      * @return A new EmbeddableDataBuilder pre-initialized with the existing component data.
      */

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/ComponentDataLayerExtender.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/ComponentDataLayerExtender.java
@@ -89,4 +89,14 @@ public final class ComponentDataLayerExtender {
         return new ContentFragmentDataBuilder(DataLayerSupplierImpl.extend(this.componentData));
     }
 
+    /**
+     * Get a EmbeddableDataBuilder that extends existing component data.
+     *
+     * @return A new EmbeddableDataBuilder pre-initialized with the existing component data.
+     */
+    @NotNull
+    public EmbeddableDataBuilder asEmbeddable() {
+        return new EmbeddableDataBuilder(DataLayerSupplierImpl.extend(this.componentData));
+    }
+
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/DataLayerBuilder.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/DataLayerBuilder.java
@@ -16,9 +16,11 @@
 package com.adobe.cq.wcm.core.components.models.datalayer.builder;
 
 import com.adobe.cq.wcm.core.components.internal.models.v1.datalayer.builder.DataLayerSupplierImpl;
+import com.adobe.cq.wcm.core.components.models.Image;
 import com.adobe.cq.wcm.core.components.models.datalayer.AssetData;
 import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import com.adobe.cq.wcm.core.components.models.datalayer.ContainerData;
+import com.adobe.cq.wcm.core.components.models.datalayer.EmbeddableData;
 import com.adobe.cq.wcm.core.components.models.datalayer.ImageData;
 import com.adobe.cq.wcm.core.components.models.datalayer.PageData;
 import com.day.cq.dam.api.Asset;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/DataLayerBuilder.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/DataLayerBuilder.java
@@ -15,30 +15,29 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.models.datalayer.builder;
 
-import com.adobe.cq.wcm.core.components.internal.models.v1.datalayer.builder.DataLayerSupplierImpl;
-import com.adobe.cq.wcm.core.components.models.Image;
-import com.adobe.cq.wcm.core.components.models.datalayer.AssetData;
-import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
-import com.adobe.cq.wcm.core.components.models.datalayer.ContainerData;
-import com.adobe.cq.wcm.core.components.models.datalayer.EmbeddableData;
-import com.adobe.cq.wcm.core.components.models.datalayer.ImageData;
-import com.adobe.cq.wcm.core.components.models.datalayer.PageData;
-import com.day.cq.dam.api.Asset;
-import com.day.cq.dam.api.DamConstants;
-import com.day.cq.tagging.TagConstants;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Optional;
-import java.util.stream.Stream;
+import com.adobe.cq.wcm.core.components.internal.models.v1.datalayer.builder.DataLayerSupplierImpl;
+import com.adobe.cq.wcm.core.components.models.datalayer.AssetData;
+import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
+import com.adobe.cq.wcm.core.components.models.datalayer.ContainerData;
+import com.adobe.cq.wcm.core.components.models.datalayer.ImageData;
+import com.adobe.cq.wcm.core.components.models.datalayer.PageData;
+import com.day.cq.dam.api.Asset;
+import com.day.cq.dam.api.DamConstants;
+import com.day.cq.tagging.TagConstants;
 
 import static com.adobe.cq.wcm.core.components.models.datalayer.builder.DataLayerSupplier.EMPTY_SUPPLIER;
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/DataLayerSupplier.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/DataLayerSupplier.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.wcm.core.components.models.datalayer.AssetData;
 import com.adobe.cq.wcm.core.components.models.datalayer.ContentFragmentData;
+import com.adobe.cq.wcm.core.components.models.datalayer.EmbeddableData;
 
 /**
  * Data layer field value supplier.
@@ -163,6 +164,16 @@ public interface DataLayerSupplier {
      */
     @NotNull
     default Optional<Supplier<Map<String, Object>>> getSmartTags() {
+        return Optional.empty();
+    }
+
+    /**
+     * Get the embeddable details value supplier.
+     *
+     * @return The embeddable details value supplier, or empty if not set.
+     */
+    @NotNull
+    default Optional<Supplier<Map<String, Object>>> getEmbeddableDetails() {
         return Optional.empty();
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/EmbeddableDataBuilder.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/EmbeddableDataBuilder.java
@@ -25,8 +25,8 @@ import com.adobe.cq.wcm.core.components.internal.models.v1.datalayer.builder.Dat
 import com.adobe.cq.wcm.core.components.models.datalayer.EmbeddableData;
 
 /**
- * Data builder for a Embeddable.
- * This builder will produce a valid {@link EmbeddableData} object.
+ * Data builder for an Embeddable.
+ * This builder produces a valid {@link EmbeddableData} object.
  *
  * @since com.adobe.cq.wcm.core.components.models.datalayer.builder 1.2.0
  */

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/EmbeddableDataBuilder.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/EmbeddableDataBuilder.java
@@ -38,7 +38,7 @@ public class EmbeddableDataBuilder extends GenericDataBuilder<EmbeddableDataBuil
     }
 
     /**
-     * Set the supplier that supplies the content fragment data.
+     * Sets the supplier that supplies the content fragment data.
      *
      * @param supplier The content fragment data value supplier.
      * @return A new {@link ContentFragmentDataBuilder}.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/EmbeddableDataBuilder.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/EmbeddableDataBuilder.java
@@ -1,0 +1,60 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.models.datalayer.builder;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.adobe.cq.wcm.core.components.internal.models.v1.datalayer.EmbeddableDataImpl;
+import com.adobe.cq.wcm.core.components.internal.models.v1.datalayer.builder.DataLayerSupplierImpl;
+import com.adobe.cq.wcm.core.components.models.datalayer.EmbeddableData;
+
+/**
+ * Data builder for a Embeddable.
+ * This builder will produce a valid {@link EmbeddableData} object.
+ *
+ * @since com.adobe.cq.wcm.core.components.models.datalayer.builder 1.2.0
+ */
+public class EmbeddableDataBuilder extends GenericDataBuilder<EmbeddableDataBuilder, EmbeddableData> {
+
+    public EmbeddableDataBuilder(
+            @NotNull DataLayerSupplier supplier) {
+        super(supplier);
+    }
+
+    /**
+     * Set the supplier that supplies the content fragment data.
+     *
+     * @param supplier The content fragment data value supplier.
+     * @return A new {@link ContentFragmentDataBuilder}.
+     */
+    @NotNull
+    public EmbeddableDataBuilder withEmbeddableDetails(@NotNull final Supplier<Map<String, Object>> supplier) {
+        return this.createInstance(new DataLayerSupplierImpl(this.getDataLayerSupplier()).setEmbeddableDetails(supplier));
+    }
+
+    @Override
+    @NotNull EmbeddableDataBuilder createInstance(@NotNull DataLayerSupplier supplier) {
+        return new EmbeddableDataBuilder(supplier);
+    }
+
+    @Override
+    public @NotNull EmbeddableData build() {
+        return new EmbeddableDataImpl(this.getDataLayerSupplier());
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/package-info.java
@@ -19,7 +19,7 @@
  *
  * All models can be built from {@link com.adobe.cq.wcm.core.components.models.datalayer.builder.DataLayerBuilder}.
  */
-@Version("1.1.0")
+@Version("1.2.0")
 package com.adobe.cq.wcm.core.components.models.datalayer.builder;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/embeddable/Embeddable.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/embeddable/Embeddable.java
@@ -1,0 +1,46 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.models.embeddable;
+
+import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ConsumerType;
+
+import com.adobe.cq.wcm.core.components.internal.jackson.ComponentDataModelSerializer;
+import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * A base interface to be extended by embeddable
+ *
+ * @since com.adobe.cq.wcm.core.components.models.embeddable 1.1.0
+ */
+@ConsumerType
+public interface Embeddable {
+    /**
+     * Returns the data layer information associated with the embeddable
+     *
+     * @return {@link ComponentData} object associated with the embeddable
+     *
+     * @since com.adobe.cq.wcm.core.components.models.embeddable 1.1.0
+     */
+    @Nullable
+    @JsonProperty("dataLayer")
+    @JsonSerialize(using = ComponentDataModelSerializer.class)
+    default ComponentData getData() {
+        return null;
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/embeddable/YouTube.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/embeddable/YouTube.java
@@ -19,7 +19,7 @@ import java.net.URISyntaxException;
 
 import org.jetbrains.annotations.Nullable;
 
-public interface YouTube {
+public interface YouTube extends Embeddable {
 
     /**
      * Name of the resource property that defines the id of the YouTube video.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/embeddable/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/embeddable/package-info.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("1.0.0")
+@Version("1.1.0")
 package com.adobe.cq.wcm.core.components.models.embeddable;
 
 import org.osgi.annotation.versioning.Version;

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embed.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embed.html
@@ -17,6 +17,7 @@
      data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.commonsTemplates="core/wcm/components/commons/v1/templates.html"
      data-sly-test.hasContent="${(embed.result && embed.result.processor) || embed.html || embed.embeddableResourceType}"
+     data-cmp-data-layer="${embed.data.json}"
      id="${component.id}"
      class="cmp-embed">
     <sly data-sly-test="${embed.result && embed.result.processor}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embeddable/youtube/youtube.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embeddable/youtube/youtube.html
@@ -15,6 +15,7 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <iframe data-sly-use.youTube="com.adobe.cq.wcm.core.components.models.embeddable.YouTube"
         data-sly-test="${!youtube.empty}"
+        data-cmp-data-layer="${youtube.data.json}"
         width="${youTube.iFrameWidth || '100%' @ context='scriptString'}"
         height="${youTube.iFrameHeight || 390 @ context='scriptString'}"
         src="${youTube.iFrameSrc}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v2/embed/embed.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v2/embed/embed.html
@@ -16,6 +16,7 @@
 <div data-sly-use.embed="com.adobe.cq.wcm.core.components.models.Embed"
      data-sly-use.commonsTemplates="core/wcm/components/commons/v1/templates.html"
      data-sly-test.hasContent="${(embed.result && embed.result.processor) || embed.html || embed.embeddableResourceType}"
+     data-cmp-data-layer="${embed.data.json}"
      id="${embed.id}"
      class="cmp-embed">
     <sly data-sly-test="${embed.result && embed.result.processor}"


### PR DESCRIPTION
- add DataBuilder for Embeddable
- add DataLayer support to youtube embeddable as an example to provide the videoId

fixes #1638

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1638 
| Patch: Bug Fix?          | 👎
| Minor: New Feature?      | 👍
| Major: Breaking Change?  | 👎
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
