### PR TITLE
Components Library logo does not show up on publish instances after release 2.17.0 #1650

### DIFF
--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractImageTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractImageTest.java
@@ -78,6 +78,7 @@ public class AbstractImageTest {
     protected static final String TEMPLATE_PATH = "/conf/coretest/settings/wcm/templates/testtemplate";
     protected static final String TEMPLATE_STRUCTURE_PATH = TEMPLATE_PATH + "/structure";
     protected static final String TEMPLATE_IMAGE_PATH = TEMPLATE_STRUCTURE_PATH + "/jcr:content/root/image_template";
+    protected static final String TEMPLATE_IMAGE_NO_DATE_PATH = TEMPLATE_STRUCTURE_PATH + "/jcr:content/root/image_template_no_date";
     protected static final String PNG_IMAGE_BINARY_NAME = "Adobe_Systems_logo_and_wordmark.png";
     protected static final String GIF_IMAGE_BINARY_NAME = "Adobe_Systems_logo_and_wordmark.gif";
     protected static final String JPG_IMAGE_BINARY_NAME = "Adobe_Systems_logo_and_wordmark.jpg";

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImplTest.java
@@ -41,6 +41,7 @@ public class ImageImplTest extends AbstractImageTest {
     protected static String PAGE = TEST_ROOT + "/test";
     private static final String IMAGE_TITLE_ALT = "Adobe Logo";
     protected static String IMAGE_FILE_REFERENCE = "/content/dam/core/images/Adobe_Systems_logo_and_wordmark.png";
+    protected static String IMAGE_FILE_REFERENCE_NO_DATE = "/content/dam/core/images/Adobe_Systems_logo_and_wordmark_no_date.png";
     private static final String IMAGE_LINK = "https://www.adobe.com";
     protected static String ASSET_NAME = "adobe-systems-logo-and-wordmark";
 
@@ -177,6 +178,34 @@ public class ImageImplTest extends AbstractImageTest {
         assertFalse(image.displayPopupTitle());
         assertEquals(CONTEXT_PATH + "/content/test-image.html", image.getLink());
         Utils.testJSONExport(image, Utils.getTestExporterJSONPath(testBase, TEMPLATE_IMAGE_PATH));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    protected void testImageFromTemplateStructureNoDate() {
+        context.contentPolicyMapping("core/wcm/components/image",
+                "allowedRenditionWidths", new int[]{600, 700, 800, 2000, 2500});
+        Image image = getImageUnderTest(TEMPLATE_IMAGE_NO_DATE_PATH);
+        assertEquals(CONTEXT_PATH + "/conf/coretest/settings/wcm/templates/testtemplate/structure." + selector + ".png/structure/jcr" +
+                "%3acontent/root/image_template_no_date.png", image.getSrc());
+        assertEquals(IMAGE_TITLE_ALT, image.getAlt());
+        assertEquals(IMAGE_TITLE_ALT, image.getTitle());
+        assertEquals(IMAGE_FILE_REFERENCE_NO_DATE, image.getFileReference());
+        String expectedJson = "{" +
+                "\"smartImages\":[\"/core/conf/coretest/settings/wcm/templates/testtemplate/structure." + selector +  "." + jpegQuality +
+                ".600.png/structure/jcr%3acontent/root/image_template_no_date.png\",\"/core/conf/coretest/settings/wcm/templates/testtemplate/structure." + selector + "." +
+                jpegQuality + ".700.png/structure/jcr%3acontent/root/image_template_no_date.png\", \"/core/conf/coretest/settings/wcm/templates/testtemplate/structure." +
+                selector + "." + jpegQuality + ".800.png/structure/jcr%3acontent/root/image_template_no_date.png\"," +
+                "\"/core/conf/coretest/settings/wcm/templates/testtemplate/structure." + selector +  "." + jpegQuality +
+                ".2000.png/structure/jcr%3acontent/root/image_template_no_date.png\",\"/core/conf/coretest/settings/wcm/templates/testtemplate/structure." + selector +  "." +
+                jpegQuality + ".2500.png/structure/jcr%3acontent/root/image_template_no_date.png\"]," +
+                "\"smartSizes\":[600,700,800,2000,2500]," +
+                "\"lazyEnabled\":true" +
+                "}";
+        compareJSON(expectedJson, image.getJson());
+        assertFalse(image.displayPopupTitle());
+        assertEquals(CONTEXT_PATH + "/content/test-image.html", image.getLink());
+        Utils.testJSONExport(image, Utils.getTestExporterJSONPath(testBase, TEMPLATE_IMAGE_NO_DATE_PATH));
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImplTest.java
@@ -258,6 +258,35 @@ public class ImageImplTest extends com.adobe.cq.wcm.core.components.internal.mod
     @Test
     @SuppressWarnings("deprecation")
     @Override
+    protected void testImageFromTemplateStructureNoDate() {
+        context.contentPolicyMapping(resourceType,
+                "allowedRenditionWidths", new int[]{600, 700, 800, 2000, 2500});
+        com.adobe.cq.wcm.core.components.models.Image image = getImageUnderTest(TEMPLATE_IMAGE_NO_DATE_PATH);
+        assertEquals(CONTEXT_PATH + "/conf/coretest/settings/wcm/templates/testtemplate/structure." + selector + ".png/structure/jcr%3acontent/root/image_template_no_date.png", image.getSrc());
+        assertEquals("Adobe Systems Logo and Wordmark in PNG format", image.getAlt());
+        assertEquals("Adobe Systems Logo and Wordmark", image.getTitle());
+        assertEquals(IMAGE_FILE_REFERENCE_NO_DATE, image.getFileReference());
+        String expectedJson = "{" +
+                "\"smartImages\":[" +
+                "\"/core/conf/coretest/settings/wcm/templates/testtemplate/structure." + selector + "." + JPEG_QUALITY +
+                ".600.png/structure/jcr%3acontent/root/image_template_no_date.png\",\"/core/conf/coretest/settings/wcm/templates/testtemplate/structure." + selector + "." +
+                JPEG_QUALITY +".700.png/structure/jcr%3acontent/root/image_template_no_date.png\", \"/core/conf/coretest/settings/wcm/templates/testtemplate/structure." +
+                selector + "." + JPEG_QUALITY + ".800.png/structure/jcr%3acontent/root/image_template_no_date.png\"," +
+                "\"/core/conf/coretest/settings/wcm/templates/testtemplate/structure." + selector + "." + JPEG_QUALITY + "." +
+                "2000.png/structure/jcr%3acontent/root/image_template_no_date.png\"," + "\"/core/conf/coretest/settings/wcm/templates/testtemplate/structure."
+                + selector + "." + JPEG_QUALITY +".2500.png/structure/jcr%3acontent/root/image_template_no_date.png\"" + "]," +
+                "\"smartSizes\":[600,700,800,2000,2500]," +
+                "\"lazyEnabled\":false" +
+                "}";
+        compareJSON(expectedJson, image.getJson());
+        assertTrue(image.displayPopupTitle());
+        assertEquals(CONTEXT_PATH + "/content/test-image.html", image.getLink());
+        Utils.testJSONExport(image, Utils.getTestExporterJSONPath(testBase, TEMPLATE_IMAGE_NO_DATE_PATH));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    @Override
     protected void testLocalFileWithoutFileNameParameter() {
         context.contentPolicyMapping(resourceType,
                 "allowedRenditionWidths", new int[]{600});

--- a/bundles/core/src/test/resources/image/exporter-image_template_no_date.json
+++ b/bundles/core/src/test/resources/image/exporter-image_template_no_date.json
@@ -1,0 +1,23 @@
+{
+    "id"       : "image-a2c6a064d4",
+    "alt"      : "Adobe Logo",
+    "title"    : "Adobe Logo",
+    "link"     : "/core/content/test-image.html",
+    "src"      : "/core/conf/coretest/settings/wcm/templates/testtemplate/structure.img.png/structure/jcr%3acontent/root/image_template_no_date.png",
+    ":type"    : "core/wcm/components/image",
+    "dataLayer": {
+        "image-a2c6a064d4": {
+            "@type"      : "core/wcm/components/image",
+            "dc:title"   : "Adobe Logo",
+            "xdm:linkURL": "/core/content/test-image.html",
+            "image"      : {
+                "repo:id"        : "60a1a56e-f3f4-4021-a7bf-ac7a51f0ffe5",
+                "repo:modifyDate": "1970-01-01T00:00:00Z",
+                "@type"          : "image/png",
+                "repo:path"      : "/content/dam/core/images/Adobe_Systems_logo_and_wordmark_no_date.png",
+                "xdm:tags"       : [],
+                "xdm:smartTags"  : {}
+            }
+        }
+    }
+}

--- a/bundles/core/src/test/resources/image/test-conf.json
+++ b/bundles/core/src/test/resources/image/test-conf.json
@@ -139,6 +139,14 @@
                                         "alt"               : "Adobe Logo",
                                         "jcr:title"         : "Adobe Logo",
                                         "linkURL"           : "/content/test"
+                                    },
+                                    "image_template_no_date"             : {
+                                        "jcr:primaryType"   : "nt:unstructured",
+                                        "fileReference"     : "/content/dam/core/images/Adobe_Systems_logo_and_wordmark_no_date.png",
+                                        "sling:resourceType": "core/wcm/components/image",
+                                        "alt"               : "Adobe Logo",
+                                        "jcr:title"         : "Adobe Logo",
+                                        "linkURL"           : "/content/test"
                                     }
                                 }
                             }

--- a/bundles/core/src/test/resources/image/test-content-dam.json
+++ b/bundles/core/src/test/resources/image/test-content-dam.json
@@ -174,6 +174,65 @@
             }
         }
     },
+    "Adobe_Systems_logo_and_wordmark_no_date.png": {
+        "jcr:primaryType": "dam:Asset",
+        "jcr:mixinTypes" : [
+            "mix:referenceable"
+        ],
+        "jcr:createdBy"  : "admin",
+        "jcr:uuid"       : "60a1a56e-f3f4-4021-a7bf-ac7a51f0ffe5",
+        "jcr:content"    : {
+            "jcr:primaryType"   : "dam:AssetContent",
+            "dam:assetState"    : "processed",
+            "dam:relativePath"  : "core/images/Adobe_Systems_logo_and_wordmark.png",
+            "renditions"        : {
+                "jcr:primaryType"         : "nt:folder",
+                "cq5dam.web.1280.1280.jpg": {
+                    "jcr:primaryType": "nt:file",
+                    "jcr:content"    : {
+                        "jcr:primaryType"   : "oak:Resource",
+                        "jcr:mimeType"      : "image/jpg",
+                        ":jcr:data"         : 27795
+                    }
+                },
+                "original"                : {
+                    "jcr:primaryType": "nt:file",
+                    "jcr:content"    : {
+                        "jcr:primaryType"   : "oak:Resource",
+                        "jcr:mimeType"      : "image/png",
+                        ":jcr:data"         : 49069
+                    }
+                }
+            },
+            "related"           : {
+                "jcr:primaryType": "nt:unstructured"
+            },
+            "metadata"          : {
+                "jcr:primaryType"            : "nt:unstructured",
+                "jcr:mixinTypes"             : [
+                    "cq:Taggable"
+                ],
+                "dam:Physicalheightininches" : "27.77777862548828",
+                "dam:Physicalwidthininches"  : "27.77777862548828",
+                "dam:Fileformat"             : "PNG",
+                "dam:Progressive"            : "no",
+                "tiff:ImageLength"           : 2000,
+                "dam:extracted"              : "Mon Mar 20 2017 11:20:38 GMT+0100",
+                "dc:format"                  : "image/png",
+                "dam:Bitsperpixel"           : 8,
+                "dam:MIMEtype"               : "image/png",
+                "dam:Physicalwidthindpi"     : 72,
+                "dam:Physicalheightindpi"    : 72,
+                "dam:Numberofimages"         : 1,
+                "dam:Numberoftextualcomments": 0,
+                "tiff:ImageWidth"            : 2000,
+                "dam:sha1"                   : "bb3aa5c9b452b04808006037911705d3592bfd71",
+                "dam:size"                   : 49069,
+                "dc:title": "Adobe Systems Logo and Wordmark",
+                "dc:description": "Adobe Systems Logo and Wordmark in PNG format"
+            }
+        }
+    },
     "Adobe_Systems_logo_and_wordmark.jpg": {
         "jcr:primaryType": "dam:Asset",
         "jcr:mixinTypes" : [

--- a/bundles/core/src/test/resources/image/v2/exporter-image_template_no_date.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image_template_no_date.json
@@ -1,0 +1,36 @@
+{
+    "id"            : "image-a2c6a064d4",
+    "alt"           : "Adobe Systems Logo and Wordmark in PNG format",
+    "title"         : "Adobe Systems Logo and Wordmark",
+    "link"          : "/core/content/test-image.html",
+    "src"           : "/core/conf/coretest/settings/wcm/templates/testtemplate/structure.coreimg.png/structure/jcr%3acontent/root/image_template_no_date.png",
+    "srcUriTemplate": "/core/conf/coretest/settings/wcm/templates/testtemplate/structure.coreimg.82{.width}.png/structure/jcr:content/root/image_template_no_date.png",
+    "areas"         : [],
+    "lazyThreshold" : 0,
+    "dmImage"       : false,
+    "uuid"          : "60a1a56e-f3f4-4021-a7bf-ac7a51f0ffe5",
+    "widths"        : [
+        600,
+        700,
+        800,
+        2000,
+        2500
+    ],
+    "lazyEnabled"   : false,
+    ":type"         : "core/wcm/components/image/v2/image",
+    "dataLayer"     : {
+        "image-a2c6a064d4": {
+            "@type"      : "core/wcm/components/image/v2/image",
+            "dc:title"   : "Adobe Systems Logo and Wordmark",
+            "xdm:linkURL": "/core/content/test-image.html",
+            "image"      : {
+                "repo:id"        : "60a1a56e-f3f4-4021-a7bf-ac7a51f0ffe5",
+                "repo:modifyDate": "1970-01-01T00:00:00Z",
+                "@type"          : "image/png",
+                "repo:path"      : "/content/dam/core/images/Adobe_Systems_logo_and_wordmark_no_date.png",
+                "xdm:tags"       : [],
+                "xdm:smartTags"  : {}
+            }
+        }
+    }
+}

--- a/bundles/core/src/test/resources/image/v2/test-conf.json
+++ b/bundles/core/src/test/resources/image/v2/test-conf.json
@@ -172,6 +172,14 @@
                     "alt"               : "Adobe Logo",
                     "jcr:title"         : "Adobe Logo",
                     "linkURL"           : "/content/test"
+                  },
+                  "image_template_no_date"             : {
+                    "jcr:primaryType"   : "nt:unstructured",
+                    "fileReference"     : "/content/dam/core/images/Adobe_Systems_logo_and_wordmark_no_date.png",
+                    "sling:resourceType": "core/wcm/components/image/v2/image",
+                    "alt"               : "Adobe Logo",
+                    "jcr:title"         : "Adobe Logo",
+                    "linkURL"           : "/content/test"
                   }
                 }
               }

--- a/bundles/core/src/test/resources/image/v3/exporter-image_template_no_date.json
+++ b/bundles/core/src/test/resources/image/v3/exporter-image_template_no_date.json
@@ -1,0 +1,40 @@
+{
+    "id"            : "image-a2c6a064d4",
+    "alt"           : "Adobe Systems Logo and Wordmark in PNG format",
+    "title"         : "Adobe Systems Logo and Wordmark",
+    "src"           : "/core/conf/coretest/settings/wcm/templates/testtemplate/structure.coreimg.png/structure/jcr%3acontent/root/image_template_no_date.png",
+    "srcUriTemplate": "/core/conf/coretest/settings/wcm/templates/testtemplate/structure.coreimg.82{.width}.png/structure/jcr:content/root/image_template_no_date.png",
+    "areas"         : [],
+    "lazyThreshold" : 0,
+    "dmImage"       : false,
+    "uuid"          : "60a1a56e-f3f4-4021-a7bf-ac7a51f0ffe5",
+    "srcset"        : "/core/conf/coretest/settings/wcm/templates/testtemplate/structure.coreimg.82.600.png/structure/jcr:content/root/image_template_no_date.png 600w,/core/conf/coretest/settings/wcm/templates/testtemplate/structure.coreimg.82.700.png/structure/jcr:content/root/image_template_no_date.png 700w,/core/conf/coretest/settings/wcm/templates/testtemplate/structure.coreimg.82.800.png/structure/jcr:content/root/image_template_no_date.png 800w,/core/conf/coretest/settings/wcm/templates/testtemplate/structure.coreimg.82.2000.png/structure/jcr:content/root/image_template_no_date.png 2000w,/core/conf/coretest/settings/wcm/templates/testtemplate/structure.coreimg.82.2500.png/structure/jcr:content/root/image_template_no_date.png 2500w",
+    "imageLink"     : {
+        "valid": true,
+        "url"  : "/core/content/test-image.html"
+    },
+    "widths"        : [
+        600,
+        700,
+        800,
+        2000,
+        2500
+    ],
+    "lazyEnabled"   : false,
+    ":type"         : "core/wcm/components/image/v3/image",
+    "dataLayer"     : {
+        "image-a2c6a064d4": {
+            "@type"      : "core/wcm/components/image/v3/image",
+            "dc:title"   : "Adobe Systems Logo and Wordmark",
+            "xdm:linkURL": "/core/content/test-image.html",
+            "image"      : {
+                "repo:id"        : "60a1a56e-f3f4-4021-a7bf-ac7a51f0ffe5",
+                "repo:modifyDate": "1970-01-01T00:00:00Z",
+                "@type"          : "image/png",
+                "repo:path"      : "/content/dam/core/images/Adobe_Systems_logo_and_wordmark_no_date.png",
+                "xdm:tags"       : [],
+                "xdm:smartTags"  : {}
+            }
+        }
+    }
+}

--- a/bundles/core/src/test/resources/image/v3/test-conf.json
+++ b/bundles/core/src/test/resources/image/v3/test-conf.json
@@ -172,6 +172,14 @@
                     "alt"               : "Adobe Logo",
                     "jcr:title"         : "Adobe Logo",
                     "linkURL"           : "/content/test"
+                  },
+                  "image_template_no_date"             : {
+                    "jcr:primaryType"   : "nt:unstructured",
+                    "fileReference"     : "/content/dam/core/images/Adobe_Systems_logo_and_wordmark_no_date.png",
+                    "sling:resourceType": "core/wcm/components/image/v3/image",
+                    "alt"               : "Adobe Logo",
+                    "jcr:title"         : "Adobe Logo",
+                    "linkURL"           : "/content/test"
                   }
                 }
               }

--- a/testing/it/it-content/package-lock.json
+++ b/testing/it/it-content/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "com.adobe.cq.core.wcm.components.it.content",
-  "version": "2.16.3-SNAPSHOT",
+  "version": "2.17.1-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/testing/it/it-content/package.json
+++ b/testing/it/it-content/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.adobe.cq.core.wcm.components.it.content",
-    "version": "2.16.3-SNAPSHOT",
+    "version": "2.17.1-SNAPSHOT",
     "description": "Adobe Experience Manager Core WCM Components IT Content",
     "license": "Apache-2.0",
     "private": false,


### PR DESCRIPTION
* Added unit tests for changes in #1651
