### PR TITLE
#1456 Disabled childreneditor if panel is a livecopy

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/childreneditor/Item.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/childreneditor/Item.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 /**
  * Defines an {@code Item} class, used by the children editor {@code Editor} Sling Model.
  *
- * @since com.adobe.cq.wcm.core.components.commons.editor.dialog.childreneditor 1.1.0
+ * @since com.adobe.cq.wcm.core.components.commons.editor.dialog.childreneditor 1.0.0
  */
 public class Item {
     public static final Logger LOG = LoggerFactory.getLogger(Item.class);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/childreneditor/Item.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/childreneditor/Item.java
@@ -15,6 +15,8 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.commons.editor.dialog.childreneditor;
 
+import com.day.cq.wcm.api.WCMException;
+import com.day.cq.wcm.msm.api.LiveRelationshipManager;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -24,15 +26,18 @@ import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.components.Component;
 import com.day.cq.wcm.api.components.ComponentManager;
 import com.day.text.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
 /**
  * Defines an {@code Item} class, used by the children editor {@code Editor} Sling Model.
  *
- * @since com.adobe.cq.wcm.core.components.commons.editor.dialog.childreneditor 1.0.0
+ * @since com.adobe.cq.wcm.core.components.commons.editor.dialog.childreneditor 1.1.0
  */
 public class Item {
+    public static final Logger LOG = LoggerFactory.getLogger(Item.class);
 
     protected String name;
     protected String value;
@@ -40,6 +45,7 @@ public class Item {
     protected String iconName;
     protected String iconPath;
     protected String iconAbbreviation;
+    protected boolean isLiveCopy;
 
     /**
      * Name of the resource property that defines a panel title
@@ -80,6 +86,14 @@ public class Item {
             ValueMap vm = resource.getValueMap();
             value = Optional.ofNullable(vm.get(PN_PANEL_TITLE, String.class))
                 .orElseGet(() -> vm.get(JcrConstants.JCR_TITLE, String.class));
+            LiveRelationshipManager mgr = request.getResourceResolver().adaptTo(LiveRelationshipManager.class);
+            if (mgr != null) {
+                try {
+                    isLiveCopy = mgr.hasLiveRelationship(resource) && !mgr.getLiveRelationship(resource, true).getStatus().isCancelled();
+                } catch (WCMException e) {
+                    LOG.error("Something went wrong while checking live copy status for resource {}", resource.getPath(), e);
+                }
+            }
         }
         ComponentManager componentManager = request.getResourceResolver().adaptTo(ComponentManager.class);
         if (componentManager != null) {
@@ -188,4 +202,12 @@ public class Item {
         return iconAbbreviation;
     }
 
+    /**
+     * Checks if the panel is the target of a livecopy.
+     *
+     * @return {@code true} if the panel is target of a livecopy
+     */
+    public boolean isLiveCopy() {
+        return isLiveCopy;
+    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/childreneditor/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/childreneditor/package-info.java
@@ -19,7 +19,7 @@
  * </p>
  *
  */
-@Version("1.0.0")
+@Version("1.1.0")
 package com.adobe.cq.wcm.core.components.commons.editor.dialog.childreneditor;
 
 import org.osgi.annotation.versioning.Version;

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/childreneditor/v1/childreneditor/childreneditor.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/childreneditor/v1/childreneditor/childreneditor.html
@@ -20,12 +20,31 @@
                   data-container-path = "${childrenEditor.container.path}">
     <coral-multifield-item data-sly-repeat.item="${childrenEditor.items}" data-name="${item.name}">
         <div class="cmp-childreneditor__item">
+            <coral-icon data-sly-test.isLiveCopy="${item.isLiveCopy}"
+                        class="coral-Form-fieldinfo coral3-Icon coral3-Icon--infoCircle coral3-Icon--sizeS"
+                        icon="infoCircle"
+                        tabindex="0"
+                        size="S"
+                        role="img"
+                        aria-label="description"></coral-icon>
+            <coral-tooltip data-sly-test="${isLiveCopy}"
+                           target="_prev"
+                           placement="right"
+                           class="coral3-Tooltip coral3-Tooltip--info coral3-Tooltip--arrowLeft"
+                           aria-hidden="true"
+                           variant="info"
+                           tabindex="-1"
+                           role="tooltip"
+                           style="z-index: 10020; max-width: 1070px; left: 205px; top: -3px;">
+                <coral-tooltip-content>You have to cancel the inheritance for the panel in order to change its title.</coral-tooltip-content>
+            </coral-tooltip>
             <sly data-sly-call="${iconTemplate.icon @ item=item}"></sly>
             <input is="coral-textfield"
                    class="cmp-childreneditor__item-title"
                    data-cmp-hook-childreneditor="itemTitle"
                    name="./${item.name}/cq:panelTitle"
                    value="${item.value}"
+                   data-sly-attribute.disabled="${item.isLiveCopy}"
                    placeholder="${item.title}">
         </div>
     </coral-multifield-item>

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/childreneditor/v1/childreneditor/clientlibs/css/childreneditor.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/childreneditor/v1/childreneditor/clientlibs/css/childreneditor.less
@@ -18,9 +18,15 @@
 @cmp-childreneditor-item-icon-height: 38px;
 @cmp-childreneditor-item-icon-margin-right: 8px;
 @cmp-childreneditor-item-title-buffer: 10px;
+@cmp-childreneditor-info-icon-width: 18px;
 
 .cmp-childreneditor {
     width: 100%;
+
+    .coral-Form-fieldinfo {
+        line-height: @cmp-childreneditor-item-icon-height;
+        vertical-align: bottom;
+    }
 }
 
 .cmp-childreneditor__item-icon {
@@ -42,5 +48,5 @@
 }
 
 .cmp-childreneditor__item-title {
-    width: ~"calc(100% - (@{cmp-childreneditor-item-icon-width} + @{cmp-childreneditor-item-icon-margin-right} + @{cmp-childreneditor-item-title-buffer}))";
+    width: ~"calc(100% - (@{cmp-childreneditor-item-icon-width} + @{cmp-childreneditor-item-icon-margin-right} + @{cmp-childreneditor-item-title-buffer} + @{cmp-childreneditor-info-icon-width}))";
 }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1456 
| Patch: Bug Fix?          | yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Not yet - first wanted to propose this before writing the unit test
| Documentation Provided   | Yes
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
There were a few ways of going around the initial issue:
- Keeping the panel titles on the tabs component itself
    - This means linking the tab title to the content with some sort of mapping table, which feels more like a hack 
- Moving the panel title to the panel itself
    - This would mean rework in all existing component + all custom components that want too use the tabs/accordion component, which is far from ideal either. 
- ...

Since none of these quite sat right with me, I started thinking how we can make it clear to the editor they should cancel the inheritance for the panel in order for the title to stay overridden after rolling out again (since it’s kept on the panel itself).

It looked like a good solution to me to disable the editing of the tab title if the panel still has inheritance intact. It visually shows the editor that currently they can’t change the title, and leaves no room for errors.
![image](https://user-images.githubusercontent.com/10723393/124395108-8b334c00-dd02-11eb-9eaf-e9a241557dc4.png)
![image](https://user-images.githubusercontent.com/10723393/124395112-8ff80000-dd02-11eb-95a7-6f6354a5bc61.png)
