### PR TITLE
CIF-2249: Use LinkHandler for PageImpl#getCanonicalLink() fallback

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
@@ -50,6 +50,7 @@ import com.adobe.aem.wcm.seo.SeoTags;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.export.json.ExporterConstants;
+import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.config.HtmlPageItemConfig;
 import com.adobe.cq.wcm.core.components.config.HtmlPageItemsConfig;
 import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
@@ -125,12 +126,6 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
      */
     @OSGiService
     private ConfigurationResolver configurationResolver;
-
-    /**
-     * The @{@link PathProcessor} service.
-     */
-    @OSGiService
-    private PathProcessor pathProcessor;
 
     /**
      * The current component context.
@@ -331,7 +326,8 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     }
 
     @Override
-    public @Nullable String getCanonicalLink() {
+    @Nullable
+    public String getCanonicalLink() {
         if (this.canonicalUrl == null) {
             String canonicalUrl;
             try {
@@ -342,13 +338,14 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
             }
             this.canonicalUrl = canonicalUrl != null
                 ? canonicalUrl
-                : pathProcessor.externalize(currentPage.getPath(), request) + LinkHandler.HTML_EXTENSION;
+                : linkHandler.getLink(currentPage).map(Link::getExternalizedURL).orElse(null);
         }
         return canonicalUrl;
     }
 
     @Override
-    public @NotNull Map<Locale, String> getAlternateLanguageLinks() {
+    @NotNull
+    public Map<Locale, String> getAlternateLanguageLinks() {
         if (alternateLanguageLinks == null) {
             try {
                 if (currentStyle != null && currentStyle.get(PN_STYLE_RENDER_ALTERNATE_LANGUAGE_LINKS, Boolean.FALSE)) {
@@ -367,7 +364,8 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     }
 
     @Override
-    public @NotNull List<String> getRobotsTags() {
+    @NotNull
+    public List<String> getRobotsTags() {
         if (robotsTags == null) {
             try {
                 SeoTags seoTags = resource.adaptTo(SeoTags.class);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
@@ -58,7 +58,6 @@ import com.adobe.cq.wcm.core.components.internal.models.v1.RedirectItemImpl;
 import com.adobe.cq.wcm.core.components.models.HtmlPageItem;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.adobe.cq.wcm.core.components.models.Page;
-import com.adobe.cq.wcm.core.components.services.link.PathProcessor;
 import com.adobe.granite.license.ProductInfoProvider;
 import com.adobe.granite.ui.clientlibs.ClientLibrary;
 import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImplTest.java
@@ -271,7 +271,6 @@ public class PageImplTest extends com.adobe.cq.wcm.core.components.internal.mode
         assertEquals("https://example.org/content/page/templated-page.html", page.getCanonicalLink());
     }
 
-
     @Test
     public void testCanonicalLinkWhenSeoApiUnavailable() {
         context.registerAdapter(Resource.class, SeoTags.class, (Function<Resource, SeoTags>) resource -> {


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | CIF-2249
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | 
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

In order to handle the existence of multiple `PathProcessor` services consistently the `PageImpl` must use the `LinkHandler` when falling back on getting the canonical url and the sites-seo api/implementation is missing. 