### PR TITLE
Add process html attributes to the PathProcessor interface

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
@@ -15,6 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.link;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.httpclient.URI;
@@ -167,6 +168,11 @@ public class DefaultPathProcessor implements PathProcessor {
             externalPath = path;
         }
         return externalPath;
+    }
+
+    @Override
+    public @Nullable Map<String, String> processHtmlAttributes(@NotNull String path, @Nullable Map<String, String> htmlAttributes) {
+        return htmlAttributes;
     }
 
     @NotNull

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
@@ -168,7 +168,7 @@ public class LinkHandler {
             return pathProcessors.stream()
                     .filter(pathProcessor -> pathProcessor.accepts(path, request))
                     .findFirst().map(pathProcessor -> new LinkImpl<>(pathProcessor.sanitize(path, request), pathProcessor.map(path,
-                            request), pathProcessor.externalize(path, request), page, htmlAttributes));
+                            request), pathProcessor.externalize(path, request), page, pathProcessor.processHtmlAttributes(path, htmlAttributes)));
         } else {
             return Optional.of(new LinkImpl<>(path, path, path, page, htmlAttributes));
         }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/PathProcessor.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/PathProcessor.java
@@ -15,9 +15,12 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.services.link;
 
+import java.util.Map;
+
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ConsumerType;
 
 /**
@@ -64,4 +67,13 @@ public interface PathProcessor {
      * @return the external link of the given path
      */
     @NotNull String externalize(@NotNull String path, @NotNull SlingHttpServletRequest request);
+
+
+    /**
+     * Process the HTML attributes for the {@link com.adobe.cq.wcm.core.components.internal.link.LinkHandler}
+     * @param path the path of the linked resource
+     * @param htmlAttributes the origin HTML attributes of the link
+     * @return a map of the processed HTML attributes for the link
+     */
+    @Nullable Map<String, String> processHtmlAttributes(@NotNull String path, @Nullable Map<String, String> htmlAttributes);
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/package-info.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("1.0.0")
+@Version("2.0.0")
 package com.adobe.cq.wcm.core.components.services.link;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
- extend PathProcessor interface to process html attributes
- add default handling to the DefaultPathProcessor

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1702 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
