### PR TITLE
GH-1710 - [Teaser] Inherit page image

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -19,13 +19,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import javax.annotation.PostConstruct;
-import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -165,16 +163,15 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
     }};
 
     /**
+     * The teaser link
+     */
+    protected Optional<Link<Page>> link;
+
+    /**
      * The current component.
      */
     @ScriptVariable
     private Component component;
-
-    /**
-     * The current resource.
-     */
-    @Inject
-    private Resource resource;
 
     /**
      * The page manager.
@@ -189,20 +186,13 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
     protected Style currentStyle;
 
     /**
-     * The current request.
-     */
-    @Self
-    private SlingHttpServletRequest request;
-
-    /**
      * The model factory service.
      */
     @OSGiService
     private ModelFactory modelFactory;
 
     @Self
-    private LinkHandler linkHandler;
-    protected Optional<Link<Page>> link;
+    protected LinkHandler linkHandler;
 
     /**
      * Initialize the model.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/resource/CoreResourceWrapper.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/resource/CoreResourceWrapper.java
@@ -36,19 +36,27 @@ public class CoreResourceWrapper extends ResourceWrapper {
 
     private ValueMap valueMap;
     private String overriddenResourceType;
+    private Map<String, Resource> overriddenChildren;
 
     public CoreResourceWrapper(@NotNull Resource resource, @NotNull String overriddenResourceType) {
-        this(resource, overriddenResourceType, null, null);
+        this(resource, overriddenResourceType, null, null, null);
     }
 
     public CoreResourceWrapper(@NotNull Resource resource, @NotNull String overriddenResourceType,
                                @Nullable List<String> hiddenProperties, @Nullable Map<String, String> overriddenProperties) {
+        this(resource, overriddenResourceType, hiddenProperties, overriddenProperties, null);
+    }
+
+    public CoreResourceWrapper(@NotNull Resource resource, @NotNull String overriddenResourceType,
+                               @Nullable List<String> hiddenProperties, @Nullable Map<String, String> overriddenProperties,
+                               @Nullable Map<String, Resource> overriddenChildren) {
         super(resource);
         if (StringUtils.isEmpty(overriddenResourceType)) {
             throw new IllegalArgumentException("The " + CoreResourceWrapper.class.getName() + " needs to override the resource type of " +
                     "the wrapped resource, but the resourceType argument was null or empty.");
         }
         this.overriddenResourceType = overriddenResourceType;
+        this.overriddenChildren = overriddenChildren;
         valueMap = new ValueMapDecorator(new HashMap<>(resource.getValueMap()));
         valueMap.put(ResourceResolver.PROPERTY_RESOURCE_TYPE, overriddenResourceType);
         if (overriddenProperties != null) {
@@ -75,6 +83,17 @@ public class CoreResourceWrapper extends ResourceWrapper {
     @NotNull
     public ValueMap getValueMap() {
         return valueMap;
+    }
+
+    @Override
+    @Nullable
+    public Resource getChild(String relPath) {
+        if (overriddenChildren != null) {
+            if (overriddenChildren.containsKey(relPath)) {
+                return overriddenChildren.get(relPath);
+            }
+        }
+        return super.getChild(relPath);
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
@@ -33,6 +33,23 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public interface Image extends Component {
 
     /**
+     * Name of the resource property that will indicate if the image is inherited from the featured image of the page.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.22.0
+     */
+    String PN_IMAGE_FROM_PAGE_IMAGE = "imageFromPageImage";
+
+    /**
+     * Name of the resource property that will indicate if the value of the {@code alt} attribute should be inherited
+     * from the featured image of the page.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.22.0
+     */
+    String PN_ALT_VALUE_FROM_PAGE_IMAGE = "altValueFromPageImage";
+
+
+
+    /**
      * Name of the configuration policy property that will store the allowed rendition widths for an image.
      *
      * @since com.adobe.cq.wcm.core.components.models 11.0.0

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/PageImageThumbnailTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/PageImageThumbnailTest.java
@@ -50,10 +50,14 @@ public class PageImageThumbnailTest {
         MockSlingHttpServletRequest request = context.request();
         MockRequestPathInfo requestPathInfo = (MockRequestPathInfo) request.getRequestPathInfo();
         requestPathInfo.setSuffix(RESOURCE1);
+        requestPathInfo.setResourcePath(RESOURCE1);
         PageImageThumbnail pageImageThumbnail = request.adaptTo(PageImageThumbnail.class);
         if (pageImageThumbnail != null) {
             assertEquals("featured image alt", pageImageThumbnail.getAlt(), "getAlt()");
             assertEquals("/content/page/_jcr_content/_cq_featuredimage.coreimg.png", pageImageThumbnail.getSrc(), "getSrc()");
+            assertEquals("/content/page/jcr:content/root/responsivegrid/image", pageImageThumbnail.getComponentPath(), "getComponentPath()");
+            assertEquals("/content/page/jcr:content/root/responsivegrid/image", pageImageThumbnail.getConfigPath(), "getConfigPath()");
+            assertEquals("/content/page", pageImageThumbnail.getCurrentPagePath(), "getCurrentPagePath()");
         } else {
             fail("can't create page image thumnbail model");
         }
@@ -68,6 +72,18 @@ public class PageImageThumbnailTest {
         if (pageImageThumbnail != null) {
             assertEquals("featured image alt", pageImageThumbnail.getAlt(), "getAlt()");
             assertEquals("/content/page/_jcr_content/_cq_featuredimage.coreimg.png", pageImageThumbnail.getSrc(), "getSrc()");
+        }
+    }
+
+    @Test
+    void testPageImageThumbnailWithLinkURL() {
+        context.currentResource(RESOURCE1);
+        MockSlingHttpServletRequest request = context.request();
+        request.setParameterMap(ImmutableMap.of("item", RESOURCE1, "linkURL", "/content/page1"));
+        PageImageThumbnail pageImageThumbnail = request.adaptTo(PageImageThumbnail.class);
+        if (pageImageThumbnail != null) {
+            assertEquals("featured image alt for page 1", pageImageThumbnail.getAlt(), "getAlt()");
+            assertEquals("/content/page1/_jcr_content/_cq_featuredimage.coreimg.png", pageImageThumbnail.getSrc(), "getSrc()");
         }
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImplTest.java
@@ -104,10 +104,10 @@ public class TeaserImplTest extends com.adobe.cq.wcm.core.components.internal.mo
         ValueMap imageProperties = imageResource.getValueMap();
         String linkURL = imageProperties.get("linkURL", String.class);
         String fileReference = imageProperties.get("fileReference", String.class);
-        assertEquals("/content/teasers/jcr:content/cq:featuredimage", imageResource.getPath(), "image resource: path");
+        assertEquals("/content/teasers/jcr:content/root/responsivegrid/teaser-20", imageResource.getPath(), "image resource: path");
         assertEquals("core/wcm/components/image/v3/image", imageResource.getResourceType(), "image resource: resource type");
         assertEquals("/content/teasers", linkURL, "image resource: linkURL");
-        assertEquals("/content/dam/core/images/Adobe_Systems_logo_and_wordmark.png", fileReference, "image resource: fileReference");
+        assertNull(fileReference, "image resource: fileReference");
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(testBase, "teaser20"));
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/resource/CoreResourceWrapperTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/resource/CoreResourceWrapperTest.java
@@ -63,7 +63,7 @@ public class CoreResourceWrapperTest {
         }};
         Resource wrappedResource = new CoreResourceWrapper(prepareResourceToBeWrapped(properties), "d/e/f", new ArrayList<String>() {{
             add("b");
-        }}, new HashMap<>());
+        }}, new HashMap<>(), null);
 
         Map<String, Object> expectedProperties = new HashMap<>(properties);
         expectedProperties.put(ResourceResolver.PROPERTY_RESOURCE_TYPE, "d/e/f");
@@ -85,7 +85,7 @@ public class CoreResourceWrapperTest {
         Map<String, String> overriddenProperties = new HashMap<>();
         overriddenProperties.put("a", "1");
         overriddenProperties.put("b", "2");
-        Resource wrappedResource = new CoreResourceWrapper(toBeWrapped, "a/b/c", new ArrayList<>(), overriddenProperties);
+        Resource wrappedResource = new CoreResourceWrapper(toBeWrapped, "a/b/c", new ArrayList<>(), overriddenProperties, null);
 
         // isResourceType()
         assertTrue(wrappedResource.isResourceType("a/b/c"));

--- a/bundles/core/src/test/resources/commons/editor/dialog/pageimagethumbnail/test-content.json
+++ b/bundles/core/src/test/resources/commons/editor/dialog/pageimagethumbnail/test-content.json
@@ -38,5 +38,32 @@
         }
       }
     }
+  },
+  "page1": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content"    : {
+      "jcr:primaryType"   : "cq:PageContent",
+      "jcr:title"         : "Carousel Test",
+      "sling:resourceType": "core/wcm/components/page/v3/page",
+      "jcr:description"   : "Carousel description",
+      "cq:featuredimage": {
+        "jcr:primaryType": "nt:unstructured",
+        "jcr:createdBy": "admin",
+        "altValueFromDAM"   : "false",
+        "alt"               : "featured image alt for page 1",
+        "file"              : {
+          "jcr:primaryType": "nt:file",
+          "jcr:createdBy"  : "admin",
+          "jcr:content"    : {
+            "jcr:primaryType"   : "nt:resource",
+            "jcr:lastModifiedBy": "admin",
+            "jcr:mimeType"      : "image/png",
+            ":jcr:data"         : 10453365,
+            "jcr:uuid"          : "22a0a463-9614-48c5-8215-a35ffc7d1088"
+          }
+        },
+        "sling:resourceType": "core/wcm/components/image/v3/image"
+      }
+    }
   }
 }

--- a/bundles/core/src/test/resources/teaser/v2/exporter-teaser12.json
+++ b/bundles/core/src/test/resources/teaser/v2/exporter-teaser12.json
@@ -11,7 +11,7 @@
         "url": "/core/content/teasers.html"
     },
     ":type": "core/wcm/components/teaser/v2/teaser",
-    "imagePath": "/core/content/teasers/_jcr_content/_cq_featuredimage.coreimg.png/1490005239000/adobe-systems-logo-and-wordmark.png",
+    "imagePath": "/core/content/teasers/_jcr_content/root/responsivegrid/teaser-9.coreimg.png/1490005239000/adobe-systems-logo-and-wordmark.png",
     "dataLayer": {
         "teaser-c8b7c5c73f": {
             "@type": "core/wcm/components/teaser/v2/teaser",

--- a/bundles/core/src/test/resources/teaser/v2/exporter-teaser20.json
+++ b/bundles/core/src/test/resources/teaser/v2/exporter-teaser20.json
@@ -9,7 +9,7 @@
         "url": "/core/content/teasers.html"
     },
     ":type": "core/wcm/components/teaser/v2/teaser",
-    "imagePath": "/core/content/teasers/_jcr_content/_cq_featuredimage.coreimg.png/1490005239000/adobe-systems-logo-and-wordmark.png",
+    "imagePath": "/core/content/teasers/_jcr_content/root/responsivegrid/teaser-20.coreimg.png/1490005239000/adobe-systems-logo-and-wordmark.png",
     "dataLayer": {
         "teaser-12fce3601b": {
             "@type": "core/wcm/components/teaser/v2/teaser",

--- a/content/package-lock.json
+++ b/content/package-lock.json
@@ -613,7 +613,7 @@
                 },
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                     "dev": true
                 },
@@ -644,7 +644,7 @@
             "dependencies": {
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -657,13 +657,13 @@
                 },
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                     "dev": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -1383,7 +1383,7 @@
             "dependencies": {
                 "opn": {
                     "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
                     "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
                     "dev": true,
                     "requires": {
@@ -1765,7 +1765,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -1841,7 +1841,7 @@
         },
         "combined-stream": {
             "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+            "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
             "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
             "dev": true,
             "requires": {
@@ -2952,7 +2952,7 @@
         },
         "form-data": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
             "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
             "dev": true,
             "requires": {
@@ -2963,7 +2963,7 @@
             "dependencies": {
                 "async": {
                     "version": "0.9.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                    "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
                     "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
                     "dev": true
                 }
@@ -4691,7 +4691,7 @@
                 },
                 "jsonfile": {
                     "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+                    "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
                     "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                     "dev": true,
                     "requires": {
@@ -4790,7 +4790,7 @@
                 },
                 "load-json-file": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                    "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
@@ -4870,7 +4870,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -4894,7 +4894,7 @@
                 },
                 "yargs": {
                     "version": "6.6.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+                    "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
                     "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
                     "dev": true,
                     "requires": {
@@ -4915,7 +4915,7 @@
                 },
                 "yargs-parser": {
                     "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+                    "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
                     "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
                     "dev": true,
                     "requires": {
@@ -5769,7 +5769,7 @@
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
                     "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
                     "dev": true
                 }
@@ -7995,7 +7995,7 @@
             "dependencies": {
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -8008,7 +8008,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -8537,7 +8537,7 @@
         },
         "wrap-ansi": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
@@ -8567,7 +8567,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -8658,7 +8658,7 @@
         },
         "yargs": {
             "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
+            "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
             "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
             "dev": true,
             "requires": {
@@ -8705,7 +8705,7 @@
                 },
                 "load-json-file": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                    "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
@@ -8779,7 +8779,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -8803,7 +8803,7 @@
                 },
                 "yargs-parser": {
                     "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+                    "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
                     "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
                     "dev": true,
                     "requires": {

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/pageimagethumbnail/v1/pageimagethumbnail/clientlibs/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/pageimagethumbnail/v1/pageimagethumbnail/clientlibs/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[core.wcm.components.commons.editor.dialog.pageimagethumbnail.v1]"
+    dependencies="[jquery]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/pageimagethumbnail/v1/pageimagethumbnail/clientlibs/css.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/pageimagethumbnail/v1/pageimagethumbnail/clientlibs/css.txt
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright 2021 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=css
+
+pageimagethumbnail.less

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/pageimagethumbnail/v1/pageimagethumbnail/clientlibs/css/pageimagethumbnail.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/pageimagethumbnail/v1/pageimagethumbnail/clientlibs/css/pageimagethumbnail.less
@@ -1,0 +1,19 @@
+/*
+ *  Copyright 2021 Adobe
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+.cq-page-image-thumbnail .cq-FileUpload-thumbnail {
+    background: #eaeaea;
+}

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/pageimagethumbnail/v1/pageimagethumbnail/pageimagethumbnail.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/pageimagethumbnail/v1/pageimagethumbnail/pageimagethumbnail.html
@@ -14,7 +14,10 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.thumbnail="com.adobe.cq.wcm.core.components.commons.editor.dialog.inherited.PageImageThumbnail">
-    <coral-fileupload class="cq-page-image-thumbnail coral-Form-field cq-FileUpload _coral-FileUpload">
+    <coral-fileupload class="cq-page-image-thumbnail coral-Form-field cq-FileUpload _coral-FileUpload"
+                      data-thumbnail-current-page-path="${thumbnail.currentPagePath}"
+                      data-thumbnail-component-path="${thumbnail.componentPath}"
+                      data-thumbnail-config-path="${thumbnail.configPath}">
         <div class="cq-FileUpload-thumbnail">
             <div class="cq-FileUpload-thumbnail-img">
                 <img class="cq-page-image-thumbnail__image"
@@ -28,8 +31,10 @@
                         <use xlink:href="#spectrum-icon-18-Image"></use>
                     </svg>
                 </coral-icon>
-
             </div>
+            <button data-sly-test="${hasSrc}" type="button" class="_coral-Button _coral-Button--primary _coral-Button--quiet" disabled><coral-button-label class="_coral-Button-label">Edit</coral-button-label></button>
+            <button data-sly-test="${hasSrc}" type="button" class="_coral-Button _coral-Button--primary _coral-Button--quiet" disabled><coral-button-label class="_coral-Button-label">Clear</coral-button-label></button>
+            <button data-sly-test="${hasSrc}" type="button" class="_coral-Button _coral-Button--primary _coral-Button--quiet" disabled><coral-button-label class="_coral-Button-label">Pick</coral-button-label></button>
         </div>
     </coral-fileupload>
 </div>

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/README.md
@@ -50,9 +50,7 @@ The following properties are written to JCR for this Image component and are exp
 1. `./isDecorative` - if set to `true`, then the image will be ignored by assistive technology
 1. `./alt` - defines the value of the HTML `alt` attribute (not needed if `./isDecorative` is set to `true`)
 1. `./altValueFromDAM` - if `true`, the HTML `alt` attribute is inherited from the DAM asset.
-1. `./altValueFromPageImage` - if `true`, the HTML `alt` attribute is inherited from the featured image of the page. This property is only enabled when `./imageFromPageImage` is `true`.
-1. `./imageFromPageImage` - if `true`, the image is inherited from the featured image of the page.
-1. `./linkURL` - allows defining a URL to which the image will link to
+1. `./linkURL` - allows defining a URL to which the image will link to.  
 1. `./width` - allows defining a HTML `width` attribute, useful for browser to calculate the aspect ratio of the image, preventing the layout shifts
 1.  `./height` - allows defining a HTML `height` attribute, useful for browser to calculate the aspect ratio of the image, preventing the layout shifts
 1. `./jcr:title` - defines the value of the HTML `title` attribute or the value of the caption, depending on the value of
@@ -64,7 +62,8 @@ otherwise a caption will be rendered
 1. `./imagePreset` - defines the name for the Dynamic Media Image Preset to apply to the Dynamic Media image URL.
 1. `./smartCropRendition` - defines how Dynamic Media Smart Crop image renders. `SmartCrop:Auto` means that the component will automatically select Smart Crop rendition which fits the container size better; the name of specific Smart Crop rendition will force the component to render that image rendition only.
 1. `./imageModifiers` - defines additional Dynamic Media Image Serving commands separated by '&amp;'. Field gives complete flexibility to change Dynamic Media image rendering.
-
+1. `./imageFromPageImage` - if `true`, the image is inherited from the featured image of either the linked page if `./linkURL` is set or the current page.
+1. `./altValueFromPageImage` - if `true` and if `./imageFromPageImage` is `true`, the HTML `alt` attribute is inherited from the featured image of either the linked page if `./linkURL` is set or the current page.
 
 ## Extending from This Component
 1. In case you overwrite the image's HTL script, make sure the necessary attributes for the JavaScript loading script are contained in the markup at the right position (see section below).

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/_cq_dialog/.content.xml
@@ -20,7 +20,7 @@
     jcr:primaryType="nt:unstructured"
     jcr:title="Image"
     sling:resourceType="cq/gui/components/authoring/dialog"
-    extraClientlibs="[core.wcm.components.image.v3.editor]"
+    extraClientlibs="[core.wcm.components.image.v3.editor,core.wcm.components.commons.editor.dialog.pageimagethumbnail.v1]"
     helpPath="https://www.adobe.com/go/aem_cmp_image_v3"
     trackingFeature="core-components:image:v3">
     <content
@@ -54,7 +54,7 @@
                                                 checked="${true}"
                                                 fieldDescription="When checked, uses the image defined for the page."
                                                 name="./imageFromPageImage"
-                                                text="Inherit - Image taken from the page"
+                                                text="Inherit featured image from linked page or current page"
                                                 uncheckedValue="false"
                                                 value="{Boolean}true"/>
                                             <pageImageThumbnail
@@ -84,7 +84,7 @@
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                         fieldDescription="Textual alternative of the meaning or function of the image, for visually impaired readers."
-                                                        fieldLabel="Alternative Text"
+                                                        fieldLabel="Alternative text for accessibility"
                                                         name="./alt"
                                                         required="{Boolean}true"/>
                                                     <altValueFromPageImage
@@ -93,7 +93,7 @@
                                                         checked="true"
                                                         fieldDescription="When checked, populate the image's alt attribute with the value of the dc:description metadata in DAM."
                                                         name="./altValueFromPageImage"
-                                                        text="Inherit - Value taken from the page featured image"
+                                                        text="Inherit alternative text from linked page or current page"
                                                         uncheckedValue="false"
                                                         value="{Boolean}true"/>
                                                     <altValueFromDAM
@@ -102,7 +102,7 @@
                                                         checked="${not empty cqDesign.altValueFromDAM ? cqDesign.altValueFromDAM : true}"
                                                         fieldDescription="When checked, populate the image's alt attribute with the value of the dc:description metadata in DAM."
                                                         name="./altValueFromDAM"
-                                                        text="Inherit - Value taken from the DAM asset"
+                                                        text="Inherit from description of asset"
                                                         uncheckedValue="false"
                                                         value="{Boolean}true"/>
                                                 </items>
@@ -113,7 +113,7 @@
                                                 checked="${not empty cqDesign.isDecorative ? cqDesign.isDecorative : false}"
                                                 fieldDescription="Check if the image should be ignored by assistive technology and therefore does not require an alternative text. This applies to decorative images only."
                                                 name="./isDecorative"
-                                                text="Ignore the accessiblity alternative text, the image is decorative"
+                                                text="Don't require an alternative text for accessiblity"
                                                 uncheckedValue="false"
                                                 value="{Boolean}true"/>
                                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/_cq_dialog/.content.xml
@@ -52,9 +52,9 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
                                                 checked="${true}"
-                                                fieldDescription="When checked, uses the image defined for the page."
+                                                fieldDescription="Use the featured image defined in the properties of the linked page, or in the properties of the current page when no link is defined."
                                                 name="./imageFromPageImage"
-                                                text="Inherit featured image from linked page or current page"
+                                                text="Inherit featured image from page"
                                                 uncheckedValue="false"
                                                 value="{Boolean}true"/>
                                             <pageImageThumbnail
@@ -91,9 +91,9 @@
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
                                                         checked="true"
-                                                        fieldDescription="When checked, populate the image's alt attribute with the value of the dc:description metadata in DAM."
+                                                        fieldDescription="Use the description defined on the referenced asset, or the alternative text defined in the page properties."
                                                         name="./altValueFromPageImage"
-                                                        text="Inherit alternative text from linked page or current page"
+                                                        text="Inherit alternative text from page"
                                                         uncheckedValue="false"
                                                         value="{Boolean}true"/>
                                                     <altValueFromDAM
@@ -111,9 +111,9 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
                                                 checked="${not empty cqDesign.isDecorative ? cqDesign.isDecorative : false}"
-                                                fieldDescription="Check if the image should be ignored by assistive technology and therefore does not require an alternative text. This applies to decorative images only."
+                                                fieldDescription="If the image is mostly decorative and doesn't convey additional meaning to a visitor, then it might be acceptable to not provide an alternative text, which will make the image ignored by assistive technology like screen readers."
                                                 name="./isDecorative"
-                                                text="Don't require an alternative text for accessiblity"
+                                                text="Don’t provide an alternative text"
                                                 uncheckedValue="false"
                                                 value="{Boolean}true"/>
                                         </items>
@@ -232,19 +232,17 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML WIDTH attribute to apply to the component, useful for browser to calculate the aspect ratio of the image, preventing the layout shifts"
                                                 fieldLabel="Width"
-                                                name="./width"
-                                            />
+                                                name="./width"/>
                                             <height
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML HEIGHT attribute to apply to the component, useful for browser to calculate the aspect ratio of the image, preventing the layout shifts."
                                                 fieldLabel="Height"
-                                                name="./height"
-                                            />
+                                                name="./height"/>
                                             <linkURL
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
-                                                fieldDescription="Make the image a link to another resource."
+                                                fieldDescription="Make the image a link to another resource. When a link is defined and when the image inherits from the page, the image is the featured image of the linked page."
                                                 fieldLabel="Link"
                                                 nodeTypes="dam:Asset, nt:file, cq:Page"
                                                 name="./linkURL"

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/README.md
@@ -49,18 +49,23 @@ device) is disabled
 The following properties are written to JCR for this Teaser component and are expected to be available as `Resource` properties:
 
 1. `./actionsEnabled` - property that defines whether or not the teaser has Call-to-Action elements
-2. `./actions` - child node where the Call-to-Action elements are stored as a list of `item` nodes with the following properties
+1. `./actions` - child node where the Call-to-Action elements are stored as a list of `item` nodes with the following properties
     1. `link` - property that stores the Call-to-Action link
-    2. `text` - property that stores the Call-to-Action text
-3. `./fileReference` - property or `file` child node - will store either a reference to the image file, or the image file
-4. `./linkURL` - link applied to teaser elements. URL or path to a content page
-5. `./pretitle` - defines the value of the teaser pretitle
-6. `./jcr:title` - defines the value of the teaser title and HTML `title` attribute of the teaser image
-7. `./titleFromPage` - defines whether or not the title value is taken from the linked page
-8. `./jcr:description` - defines the value of the teaser description
-9. `./descriptionFromPage` - defines whether or not the description value is taken from the linked page
-10. `./id` - defines the component HTML ID attribute.
-11. `./titleType` - stores the value for this title's HTML element type
+    1. `text` - property that stores the Call-to-Action text
+1. `./fileReference` - property or `file` child node - will store either a reference to the image file, or the image file
+1. `./linkURL` - link applied to teaser elements. URL or path to a content page
+1. `./pretitle` - defines the value of the teaser pretitle
+1. `./jcr:title` - defines the value of the teaser title and HTML `title` attribute of the teaser image
+1. `./titleFromPage` - defines whether or not the title value is taken from the linked page
+1. `./jcr:description` - defines the value of the teaser description
+1. `./descriptionFromPage` - defines whether or not the description value is taken from the linked page
+1. `./id` - defines the component HTML ID attribute.
+1. `./titleType` - stores the value for this title's HTML element type
+1. `./isDecorative` - if set to `true`, then the image will be ignored by assistive technology
+1. `./alt` - defines the value of the HTML `alt` attribute (not needed if `./isDecorative` is set to `true`)
+1. `./altValueFromDAM` - if `true`, the HTML `alt` attribute is inherited from the DAM asset.
+1. `./imageFromPageImage` - if `true`, the image is inherited from the featured image of either the linked page if `./linkURL` is set or the current page.
+1. `./altValueFromPageImage` - if `true` and if `./imageFromPageImage` is `true`, the HTML `alt` attribute is inherited from the featured image of either the linked page if `./linkURL` is set or the current page.
 
 ### Extending the Teaser Component
 When extending the Teaser component by using `sling:resourceSuperType`, developers need to define the `imageDelegate` property for
@@ -70,6 +75,13 @@ For example:
 ```
 imageDelegate="core/wcm/components/image/v3/image"
 ```
+
+## Client Libraries
+The component reuses the following editor client library categories that include JavaScript
+handling for dialog interaction. They are already included by its edit dialog:
+* `core.wcm.components.teaser.v1.design`
+* `core.wcm.components.teaser.v1.editor`
+* `core.wcm.components.image.v3.editor`
 
 ## BEM Description
 ```
@@ -87,7 +99,7 @@ BLOCK cmp-teaser
 ## Information
 * **Vendor**: Adobe
 * **Version**: v2
-* **Compatibility**: AEM 6.3
+* **Compatibility**: AEM 6.5
 * **Status**: work-in-progress
 * **Documentation**: [https://www.adobe.com/go/aem\_cmp\_teaser\_v2](https://www.adobe.com/go/aem_cmp_teaser_v2)
 * **Component Library**: [https://www.adobe.com/go/aem\_cmp\_library\_teaser](https://www.adobe.com/go/aem_cmp_library_teaser)

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
@@ -3,11 +3,11 @@
     jcr:primaryType="nt:unstructured"
     jcr:title="Teaser"
     sling:resourceType="cq/gui/components/authoring/dialog"
-    extraClientlibs="[core.wcm.components.teaser.v1.editor]"
+    extraClientlibs="[core.wcm.components.teaser.v1.editor,core.wcm.components.image.v3.editor]"
     helpPath="https://www.adobe.com/go/aem_cmp_teaser_v2"
     trackingFeature="core-components:teaser:v2">
     <content
-        granite:class="cmp-teaser__editor"
+        granite:class="cmp-teaser__editor cmp-image__editor"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="granite/ui/components/coral/foundation/container">
         <items jcr:primaryType="nt:unstructured">
@@ -18,40 +18,8 @@
                 <items jcr:primaryType="nt:unstructured">
                     <image
                         jcr:primaryType="nt:unstructured"
-                        jcr:title="Image"
-                        sling:resourceType="granite/ui/components/coral/foundation/container"
-                        margin="{Boolean}true">
-                        <items jcr:primaryType="nt:unstructured">
-                            <columns
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
-                                margin="{Boolean}true">
-                                <items jcr:primaryType="nt:unstructured">
-                                    <column
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/coral/foundation/container">
-                                        <items jcr:primaryType="nt:unstructured">
-                                            <file
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="cq/gui/components/authoring/dialog/fileupload"
-                                                allowUpload="{Boolean}false"
-                                                autoStart="{Boolean}false"
-                                                class="cq-droptarget"
-                                                fieldLabel="Image Asset"
-                                                fileNameParameter="./fileName"
-                                                fileReferenceParameter="./fileReference"
-                                                mimeTypes="[image/gif,image/jpeg,image/png,image/tiff,image/svg+xml]"
-                                                multiple="{Boolean}false"
-                                                name="./file"
-                                                title="Upload Image Asset"
-                                                uploadUrl="${suffix.path}"
-                                                useHTML5="{Boolean}true"/>
-                                        </items>
-                                    </column>
-                                </items>
-                            </columns>
-                        </items>
-                    </image>
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/apps/core/wcm/components/image/v3/image/cq:dialog/content/items/tabs/items/asset"/>
                     <text
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Text"

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
@@ -16,10 +16,105 @@
                 sling:resourceType="granite/ui/components/coral/foundation/tabs"
                 maximized="{Boolean}true">
                 <items jcr:primaryType="nt:unstructured">
-                    <image
+                    <actions
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="granite/ui/components/coral/foundation/include"
-                        path="/apps/core/wcm/components/image/v3/image/cq:dialog/content/items/tabs/items/asset"/>
+                        jcr:title="Links"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <linksNote
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/text"
+                                                text="The teaser title, description and image can be inherited from the linked page, or from page linked in the first call to action. If neither a link nor a call to cation is specified, then the title, description and image will be inherited from the current page."/>
+                                            <linkURL
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
+                                                fieldDescription="Links the teaser to a unique destination page or external URL. For multiple destination links, use call to actions instead."
+                                                fieldLabel="Link"
+                                                name="./linkURL"
+                                                rootPath="/content"
+                                                wrapperClass="foundation-toggleable cmp-teaser__editor-link-url"/>
+                                            <actionsEnabled
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                fieldDescription="Allows to link the teaser to multiple destinations. The page linked in the first call to action is used when inheriting the teaser title, description or image."
+                                                name="./actionsEnabled"
+                                                text="Link to destination with call to actions"
+                                                uncheckedValue="{Boolean}false"
+                                                value="{Boolean}true">
+                                                <granite:rendercondition
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="/libs/granite/ui/components/coral/foundation/renderconditions/simple"
+                                                    expression="${!cqDesign.actionsDisabled}"/>
+                                            </actionsEnabled>
+                                            <actionsDisabled
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                checked="{Boolean}false"
+                                                disabled="{Boolean}true"
+                                                fieldDescription="Allows to link the teaser to multiple destinations. The page linked in the first call to action is used when inheriting the teaser title, description or image."
+                                                ignoreData="{Boolean}true"
+                                                name="./actionsEnabled"
+                                                text="Link to destination with call to actions"
+                                                uncheckedValue="{Boolean}false"
+                                                value="{Boolean}true">
+                                                <granite:rendercondition
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="/libs/granite/ui/components/coral/foundation/renderconditions/simple"
+                                                    expression="${cqDesign.actionsDisabled}"/>
+                                            </actionsDisabled>
+                                            <actions
+                                                granite:class="foundation-toggleable cmp-teaser__editor-multifield_actions"
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                                composite="{Boolean}true">
+                                                <field
+                                                    granite:class="cmp-teaser__editor-action"
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/container"
+                                                    name="./actions">
+                                                    <items jcr:primaryType="nt:unstructured">
+                                                        <link
+                                                            granite:class="cmp-teaser__editor-actionField"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="cq/gui/components/coral/common/form/pagefield"
+                                                            emptyText="Link"
+                                                            name="link"
+                                                            required="{Boolean}true"
+                                                            rootPath="/content">
+                                                            <granite:data
+                                                                jcr:primaryType="nt:unstructured"
+                                                                cmp-teaser-v1-dialog-edit-hook="actionLink"/>
+                                                        </link>
+                                                        <text
+                                                            granite:class="cmp-teaser__editor-actionField"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                            emptyText="Text"
+                                                            name="text"
+                                                            required="{Boolean}true">
+                                                            <granite:data
+                                                                jcr:primaryType="nt:unstructured"
+                                                                cmp-teaser-v1-dialog-edit-hook="actionTitle"/>
+                                                        </text>
+                                                    </items>
+                                                </field>
+                                            </actions>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </actions>
                     <text
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Text"
@@ -262,101 +357,10 @@
                             </columns>
                         </items>
                     </text>
-                    <actions
+                    <image
                         jcr:primaryType="nt:unstructured"
-                        jcr:title="Link &amp; Actions"
-                        sling:resourceType="granite/ui/components/coral/foundation/container"
-                        margin="{Boolean}true">
-                        <items jcr:primaryType="nt:unstructured">
-                            <columns
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
-                                margin="{Boolean}true">
-                                <items jcr:primaryType="nt:unstructured">
-                                    <column
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/coral/foundation/container">
-                                        <items jcr:primaryType="nt:unstructured">
-                                            <linkURL
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
-                                                fieldDescription="Link applied to teaser elements. URL or path to a content page."
-                                                fieldLabel="Link"
-                                                name="./linkURL"
-                                                rootPath="/content"
-                                                wrapperClass="foundation-toggleable cmp-teaser__editor-link-url"/>
-                                            <actionsEnabled
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                                fieldDescription="When checked, enables definition of Call-To-Actions. The linked page of the first Call-To-Action is used when populating title and description."
-                                                name="./actionsEnabled"
-                                                text="Enable Call-To-Actions"
-                                                uncheckedValue="{Boolean}false"
-                                                value="{Boolean}true">
-                                                <granite:rendercondition
-                                                    jcr:primaryType="nt:unstructured"
-                                                    sling:resourceType="/libs/granite/ui/components/coral/foundation/renderconditions/simple"
-                                                    expression="${!cqDesign.actionsDisabled}"/>
-                                            </actionsEnabled>
-                                            <actionsDisabled
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                                checked="{Boolean}false"
-                                                disabled="{Boolean}true"
-                                                fieldDescription="When checked, enables definition of Call-To-Actions. The linked page of the first Call-To-Action is used when populating title and description."
-                                                ignoreData="{Boolean}true"
-                                                name="./actionsEnabled"
-                                                text="Enable Call-To-Actions"
-                                                uncheckedValue="{Boolean}false"
-                                                value="{Boolean}true">
-                                                <granite:rendercondition
-                                                    jcr:primaryType="nt:unstructured"
-                                                    sling:resourceType="/libs/granite/ui/components/coral/foundation/renderconditions/simple"
-                                                    expression="${cqDesign.actionsDisabled}"/>
-                                            </actionsDisabled>
-                                            <actions
-                                                granite:class="foundation-toggleable cmp-teaser__editor-multifield_actions"
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
-                                                composite="{Boolean}true">
-                                                <field
-                                                    granite:class="cmp-teaser__editor-action"
-                                                    jcr:primaryType="nt:unstructured"
-                                                    sling:resourceType="granite/ui/components/coral/foundation/container"
-                                                    name="./actions">
-                                                    <items jcr:primaryType="nt:unstructured">
-                                                        <link
-                                                            granite:class="cmp-teaser__editor-actionField"
-                                                            jcr:primaryType="nt:unstructured"
-                                                            sling:resourceType="cq/gui/components/coral/common/form/pagefield"
-                                                            emptyText="Link"
-                                                            name="link"
-                                                            required="{Boolean}true"
-                                                            rootPath="/content">
-                                                            <granite:data
-                                                                jcr:primaryType="nt:unstructured"
-                                                                cmp-teaser-v1-dialog-edit-hook="actionLink"/>
-                                                        </link>
-                                                        <text
-                                                            granite:class="cmp-teaser__editor-actionField"
-                                                            jcr:primaryType="nt:unstructured"
-                                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                            emptyText="Text"
-                                                            name="text"
-                                                            required="{Boolean}true">
-                                                            <granite:data
-                                                                jcr:primaryType="nt:unstructured"
-                                                                cmp-teaser-v1-dialog-edit-hook="actionTitle"/>
-                                                        </text>
-                                                    </items>
-                                                </field>
-                                            </actions>
-                                        </items>
-                                    </column>
-                                </items>
-                            </columns>
-                        </items>
-                    </actions>
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/apps/core/wcm/components/image/v3/image/cq:dialog/content/items/tabs/items/asset"/>
                 </items>
             </tabs>
         </items>

--- a/extensions/amp/content/package-lock.json
+++ b/extensions/amp/content/package-lock.json
@@ -352,7 +352,7 @@
                 },
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                     "dev": true
                 },
@@ -383,7 +383,7 @@
             "dependencies": {
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -396,13 +396,13 @@
                 },
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                     "dev": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -1122,7 +1122,7 @@
             "dependencies": {
                 "opn": {
                     "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
                     "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
                     "dev": true,
                     "requires": {
@@ -1504,7 +1504,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -1580,7 +1580,7 @@
         },
         "combined-stream": {
             "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+            "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
             "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
             "dev": true,
             "requires": {
@@ -2691,7 +2691,7 @@
         },
         "form-data": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
             "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
             "dev": true,
             "requires": {
@@ -2702,7 +2702,7 @@
             "dependencies": {
                 "async": {
                     "version": "0.9.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                    "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
                     "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
                     "dev": true
                 }
@@ -4430,7 +4430,7 @@
                 },
                 "jsonfile": {
                     "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+                    "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
                     "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                     "dev": true,
                     "requires": {
@@ -4529,7 +4529,7 @@
                 },
                 "load-json-file": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                    "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
@@ -4609,7 +4609,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -4648,7 +4648,7 @@
                 },
                 "yargs-parser": {
                     "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+                    "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
                     "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
                     "dev": true,
                     "requires": {
@@ -5502,7 +5502,7 @@
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
                     "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
                     "dev": true
                 }
@@ -7716,7 +7716,7 @@
             "dependencies": {
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -7729,7 +7729,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -8288,7 +8288,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -8426,7 +8426,7 @@
                 },
                 "load-json-file": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                    "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
@@ -8500,7 +8500,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -8518,7 +8518,7 @@
                 },
                 "yargs-parser": {
                     "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+                    "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
                     "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
                     "dev": true,
                     "requires": {


### PR DESCRIPTION
- support inheriting the image and the alternative text from the featured image of the linked page if defined or from the current page
- share the same logic and UI between the Image v3 and Teaser v2
- update current tests

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1710
| Patch: Bug Fix?          |
| Minor: New Feature?      | Yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

Unit and Selenium tests are currently being worked on and will be added later: tracked with https://github.com/adobe/aem-core-wcm-components/issues/1722