### PR TITLE
CIF-2293: get page description from page model

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
@@ -102,6 +102,7 @@ public class PageImpl extends AbstractComponentImpl implements Page {
     protected String designPath;
     protected String staticDesignPath;
     protected String title;
+    protected String description;
     protected String brandSlug;
 
     protected String[] clientLibCategories = new String[0];
@@ -123,6 +124,7 @@ public class PageImpl extends AbstractComponentImpl implements Page {
     @PostConstruct
     protected void initModel() {
         title = currentPage.getTitle();
+        description = currentPage.getDescription();
         if (StringUtils.isBlank(title)) {
             title = currentPage.getName();
         }
@@ -199,6 +201,11 @@ public class PageImpl extends AbstractComponentImpl implements Page {
     @Override
     public String getTitle() {
         return title;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
@@ -238,6 +238,16 @@ public interface Page extends ContainerExporter, Component {
     }
 
     /**
+     * Returns the description of this page.
+     *
+     * @return the page's description
+     * @since com.adobe.cq.wcm.core.components.models 11.0.0; marked <code>default</code> in 12.23.0
+     */
+    default String getDescription() {
+        return null;
+    }
+
+    /**
      * Returns the brand slug of this page.
      *
      * @return the page's brandSlug

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImplTest.java
@@ -52,7 +52,7 @@ public class PageImplTest {
     protected static final String DESIGN_PATH = "/etc/designs/mysite";
     protected static final String CSS_CLASS_NAMES_KEY = "cssClassNames";
 
-    private static final String DESING_CACHE_KEY = "io.wcm.testing.mock.aem.context.MockAemSlingBindings_design_/content/page/templated" +
+    private static final String DESIGN_CACHE_KEY = "io.wcm.testing.mock.aem.context.MockAemSlingBindings_design_/content/page/templated" +
             "-page";
     private static final String TEST_BASE = "/page";
     private static final String FN_FAVICON_ICO = "favicon.ico";
@@ -70,7 +70,7 @@ public class PageImplTest {
     private static final String PN_TOUCH_ICON_152 = "touchIcon152";
 
     protected final AemContext context = CoreComponentTestContext.newAemContext();
-    
+
     protected String testBase;
 
     @BeforeEach
@@ -104,6 +104,7 @@ public class PageImplTest {
         assertEquals(page.getLastModifiedDate().getTime(), calendar.getTime());
         assertEquals("en-GB", page.getLanguage());
         assertEquals("Templated Page", page.getTitle());
+        assertEquals("Description", page.getDescription());
         assertEquals("Brand Slug", page.getBrandSlug());
         assertEquals(DESIGN_PATH, page.getDesignPath());
         assertEquals(DESIGN_PATH + "/static.css", page.getStaticDesignPath());
@@ -151,7 +152,7 @@ public class PageImplTest {
                     Design design = designer.getDesign(pagePath);
                     Design spyDesign = Mockito.spy(design);
                     Mockito.doReturn(propertyMap.get(DESIGN_PATH_KEY)).when(spyDesign).getPath();
-                    request.setAttribute(DESING_CACHE_KEY, spyDesign);
+                    request.setAttribute(DESIGN_CACHE_KEY, spyDesign);
                 }
             }
 

--- a/bundles/core/src/test/resources/page/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/exporter-templated-page.json
@@ -3,6 +3,7 @@
     "designPath": "/etc/designs/mysite",
     "staticDesignPath": "/etc/designs/mysite/static.css",
     "title": "Templated Page",
+    "description": "Description",
     "brandSlug": "Brand Slug",
     "lastModifiedDate": 1453282416000,
     "templateName": "product-page",

--- a/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
@@ -2,6 +2,7 @@
   "id": "page-bb590de134",
   "designPath": "/etc/designs/mysite",
   "title": "Templated Page",
+  "description": "Description",
   "brandSlug": "Brand Slug",
   "lastModifiedDate": 1453282416000,
   "templateName": "product-page",

--- a/bundles/core/src/test/resources/page/v3/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/v3/exporter-templated-page.json
@@ -2,6 +2,7 @@
   "id": "page-bb590de134",
   "designPath": "/etc/designs/mysite",
   "title": "Templated Page",
+  "description": "Description",
   "brandSlug": "Brand Slug",
   "lastModifiedDate": 1453282416000,
   "templateName": "product-page",

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v1/page/head.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v1/page/head.html
@@ -17,7 +17,7 @@
     <meta charset="UTF-8">
     <title>${page.title}${page.brandSlug ? ' | ' : ''}${page.brandSlug}</title>
     <meta data-sly-test.keywords="${page.keywords}" name="keywords" content="${keywords}"/>
-    <meta data-sly-test.description="${properties['jcr:description']}" name="description" content="${description}"/>
+    <meta data-sly-test.description="${page.description || properties['jcr:description']}" name="description" content="${description}"/>
     <meta data-sly-test.templateName="${page.templateName}" name="template" content="${templateName}"/>
     <sly data-sly-include="head.socialmedia.html"></sly>
     <sly data-sly-include="customheaderlibs.html"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/head.html
@@ -19,7 +19,7 @@
     <meta charset="UTF-8">
     <title>${page.title}${page.brandSlug ? ' | ' : ''}${page.brandSlug}</title>
     <meta data-sly-test.keywords="${page.keywords}" name="keywords" content="${keywords}"/>
-    <meta data-sly-test.description="${properties['jcr:description']}" name="description" content="${description}"/>
+    <meta data-sly-test.description="${page.description || properties['jcr:description']}" name="description" content="${description}"/>
     <meta data-sly-test.templateName="${page.templateName}" name="template" content="${templateName}"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta data-sly-test="${page.robotsTags}" name="robots" content="${page.robotsTags @ join=', '}">

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/head.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/head.html
@@ -19,7 +19,7 @@
     <meta charset="UTF-8">
     <title>${page.title}${page.brandSlug ? ' | ' : ''}${page.brandSlug}</title>
     <meta data-sly-test.keywords="${page.keywords}" name="keywords" content="${keywords}"/>
-    <meta data-sly-test.description="${properties['jcr:description']}" name="description" content="${description}"/>
+    <meta data-sly-test.description="${page.description || properties['jcr:description']}" name="description" content="${description}"/>
     <meta data-sly-test.templateName="${page.templateName}" name="template" content="${templateName}"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta data-sly-test="${page.robotsTags}" name="robots" content="${page.robotsTags @ join=', '}">


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

The page's `head.html` renders the page description using `${properties[jcr:description]}` which does not allow any pages to overwrite the description without overwriting the head.html. For CIF we did this in our own page component but now have additional efforts to keep track on the latest features of the WCM Core Components Page. 

In this PR I added a `getDescription()` to the `Page` model which custom implementations of the `Page` can implement to provide an alternative description (for example from a product or category dynamically rendered on a "template"-like page). To guarantee backwards compatibility this PR uses HTL logical operators to fallback to the current behaviour (using `${properties[jcr:description]}`)