### PR TITLE
[List][Navigation] Display external URL redirect targets (#1713)

### DIFF
--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkTestUtils.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkTestUtils.java
@@ -40,7 +40,7 @@ public final class LinkTestUtils {
                                        @Nullable SlingHttpServletRequest request) {
         assertTrue(link.isValid(), "linkValid");
         assertEquals(MockExternalizerFactory.ROOT + linkURL, link.getExternalizedURL(), "linkExternalizedUrl");
-        if (request != null && StringUtils.isNotEmpty(request.getContextPath())) {
+        if (request != null && StringUtils.isNotEmpty(request.getContextPath()) && !linkURL.startsWith("http")) {
             linkURL = request.getContextPath().concat(linkURL);
         }
         assertEquals(linkURL, link.getURL(), "linkUrl");

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImplTest.java
@@ -324,7 +324,8 @@ public class NavigationImplTest {
                         "/content/navigation/navigation-1/navigation-1-1/navigation-1-1-2/navigation-1-1-2-2/navigation-1-1-2-2-1.html"},
                 {"/content/navigation-redirect/navigation-1/navigation-1-1/navigation-1-1-2/navigation-1-1-2-3", 4, false,
                         "/content/navigation-redirect/navigation-1/navigation-1-1/navigation-1-1-2/navigation-1-1-2-3.html"},
-                {"/content/navigation-redirect/navigation-2", 1, false, "/content/navigation-redirect/navigation-2.html"}
+                {"/content/navigation-redirect/navigation-2", 1, false, "/content/navigation-redirect/navigation-2.html"},
+                {"/content/navigation-redirect/navigation-3", 1, false, "https://www.adobe.com", true}
         };
         verifyNavigationItems(expectedPages, getNavigationItems(navigation));
         Utils.testJSONExport(navigation, Utils.getTestExporterJSONPath(testBase, "navigation9"));
@@ -365,7 +366,8 @@ public class NavigationImplTest {
                 "/content/navigation-redirect/navigation-1/navigation-1-1/navigation-1-1-2/navigation-1-1-2-1.html"},
             {"/content/navigation-redirect/navigation-1/navigation-1-1/navigation-1-1-2/navigation-1-1-2-3", 4, false,
                 "/content/navigation-redirect/navigation-1/navigation-1-1/navigation-1-1-2/navigation-1-1-2-3.html"},
-            {"/content/navigation-redirect/navigation-2", 1, false, "/content/navigation-redirect/navigation-2.html"}
+            {"/content/navigation-redirect/navigation-2", 1, false, "/content/navigation-redirect/navigation-2.html"},
+            {"/content/navigation-redirect/navigation-3", 1, false, "/content/navigation-redirect/navigation-3.html"}
         };
         verifyNavigationItems(expectedPages, getNavigationItems(navigation));
         Utils.testJSONExport(navigation, Utils.getTestExporterJSONPath(testBase, "navigation16"));
@@ -390,7 +392,8 @@ public class NavigationImplTest {
                 "/content/navigation/navigation-1/navigation-1-1/navigation-1-1-2/navigation-1-1-2-2/navigation-1-1-2-2-1.html"},
             {"/content/navigation-redirect/navigation-1/navigation-1-1/navigation-1-1-2/navigation-1-1-2-3", 4, false,
                 "/content/navigation-redirect/navigation-1/navigation-1-1/navigation-1-1-2/navigation-1-1-2-3.html"},
-            {"/content/navigation-redirect/navigation-2", 1, false, "/content/navigation-redirect/navigation-2.html"}
+            {"/content/navigation-redirect/navigation-2", 1, false, "/content/navigation-redirect/navigation-2.html"},
+            {"/content/navigation-redirect/navigation-3", 1, false, "https://www.adobe.com", true}
         };
         verifyNavigationItems(expectedPages, getNavigationItems(navigation));
         Utils.testJSONExport(navigation, Utils.getTestExporterJSONPath(testBase, "navigation17"));
@@ -513,7 +516,11 @@ public class NavigationImplTest {
             assertEquals(expectedPages[index][0], item.getPath(), "The navigation tree doesn't seem to have the correct order.");
             assertEquals(expectedPages[index][1], item.getLevel(), "The navigation item's level is not what was expected: " + item.getPath());
             assertEquals(expectedPages[index][2], item.isActive(), "The navigation item's active state is not what was expected: " + item.getPath());
-            assertEquals(CONTEXT_PATH + expectedPages[index][3], item.getURL(), "The navigation item's URL is not what was expected: " + item.getPath());
+            String expectedURL = expectedPages[index][3].toString();
+            if (!expectedURL.startsWith("http")) {
+                expectedURL = CONTEXT_PATH + expectedURL;
+            }
+            assertEquals(expectedURL, item.getURL(), "The navigation item's URL is not what was expected: " + item.getPath());
             verifyNavigationItem(expectedPages[index], item);
             index++;
         }
@@ -524,7 +531,11 @@ public class NavigationImplTest {
         assertEquals(expectedPage[0], item.getPath(), "The navigation tree doesn't seem to have the correct order.");
         assertEquals(expectedPage[1], item.getLevel(), "The navigation item's level is not what was expected: " + item.getPath());
         assertEquals(expectedPage[2], item.isActive(), "The navigation item's active state is not what was expected: " + item.getPath());
-        assertEquals(CONTEXT_PATH + expectedPage[3], item.getURL(), "The navigation item's URL is not what was expected: " + item.getPath());
+        String expectedURL = expectedPage[3].toString();
+        if (!expectedURL.startsWith("http")) {
+            expectedURL = CONTEXT_PATH + expectedURL;
+        }
+        assertEquals(expectedURL, item.getURL(), "The navigation item's URL is not what was expected: " + item.getPath());
     }
 
 }

--- a/bundles/core/src/test/resources/navigation/exporter-navigation16.json
+++ b/bundles/core/src/test/resources/navigation/exporter-navigation16.json
@@ -133,6 +133,24 @@
             }
           },
           ":type": "cq:PageContent"
+        },
+        {
+          "id": "navigation-c07c8768dd-item-a5f41f35db",
+          "path": "/content/navigation-redirect/navigation-3",
+          "children": [],
+          "level": 1,
+          "active": false,
+          "current": false,
+          "title": "Navigation 3",
+          "url": "/core/content/navigation-redirect/navigation-3.html",
+          "dataLayer": {
+            "navigation-c07c8768dd-item-a5f41f35db": {
+              "@type": "core/wcm/components/navigation/v1/navigation/item",
+              "dc:title": "Navigation 3",
+              "xdm:linkURL": "/core/content/navigation-redirect/navigation-3.html"
+            }
+          },
+          ":type":"cq:PageContent"
         }
       ],
       "level": 0,

--- a/bundles/core/src/test/resources/navigation/exporter-navigation17.json
+++ b/bundles/core/src/test/resources/navigation/exporter-navigation17.json
@@ -133,6 +133,24 @@
             }
           },
           ":type": "cq:PageContent"
+        },
+        {
+          "id": "navigation-6dc2dc2172-item-a5f41f35db",
+          "path": "/content/navigation-redirect/navigation-3",
+          "children": [],
+          "level": 1,
+          "active": false,
+          "current": false,
+          "title": "Navigation 3",
+          "url": "https://www.adobe.com",
+          "dataLayer": {
+            "navigation-6dc2dc2172-item-a5f41f35db": {
+              "@type": "core/wcm/components/navigation/v1/navigation/item",
+              "dc:title": "Navigation 3",
+              "xdm:linkURL": "https://www.adobe.com"
+            }
+          },
+          ":type":"cq:PageContent"
         }
       ],
       "level": 0,

--- a/bundles/core/src/test/resources/navigation/exporter-navigation9.json
+++ b/bundles/core/src/test/resources/navigation/exporter-navigation9.json
@@ -133,6 +133,24 @@
             }
           },
           ":type": "cq:PageContent"
+        },
+        {
+          "id": "navigation-e6f3e5ac55-item-a5f41f35db",
+          "path": "/content/navigation-redirect/navigation-3",
+          "children": [],
+          "level": 1,
+          "active": false,
+          "current": false,
+          "title": "Navigation 3",
+          "url": "https://www.adobe.com",
+          "dataLayer": {
+            "navigation-e6f3e5ac55-item-a5f41f35db": {
+              "@type": "core/wcm/components/navigation/v1/navigation/item",
+              "dc:title": "Navigation 3",
+              "xdm:linkURL": "https://www.adobe.com"
+            }
+          },
+          ":type":"cq:PageContent"
         }
       ],
       "level": 0,

--- a/bundles/core/src/test/resources/navigation/test-content.json
+++ b/bundles/core/src/test/resources/navigation/test-content.json
@@ -525,6 +525,14 @@
                     }
                 }
             }
+        },
+        "navigation-3": {
+            "jcr:primaryType": "cq:Page",
+            "jcr:content": {
+                "jcr:primaryType": "cq:PageContent",
+                "jcr:title": "Navigation 3",
+                "cq:redirectTarget": "https://www.adobe.com"
+            }
         }
     },
     "navigation-redirect-chain": {

--- a/bundles/core/src/test/resources/navigation/v2/exporter-navigation16.json
+++ b/bundles/core/src/test/resources/navigation/v2/exporter-navigation16.json
@@ -154,6 +154,27 @@
             }
           },
           ":type": "cq:PageContent"
+        },
+        {
+          "id": "navigation-c07c8768dd-item-a5f41f35db",
+          "path": "/content/navigation-redirect/navigation-3",
+          "children": [],
+          "level": 1,
+          "active": false,
+          "current": false,
+          "title": "Navigation 3",
+          "link": {
+            "url": "/core/content/navigation-redirect/navigation-3.html",
+            "valid": true
+          },
+          "dataLayer": {
+            "navigation-c07c8768dd-item-a5f41f35db": {
+              "@type": "core/wcm/components/navigation/v2/navigation/item",
+              "dc:title": "Navigation 3",
+              "xdm:linkURL": "/core/content/navigation-redirect/navigation-3.html"
+            }
+          },
+          ":type":"cq:PageContent"
         }
       ],
       "level": 0,

--- a/bundles/core/src/test/resources/navigation/v2/exporter-navigation17.json
+++ b/bundles/core/src/test/resources/navigation/v2/exporter-navigation17.json
@@ -154,6 +154,27 @@
             }
           },
           ":type": "cq:PageContent"
+        },
+        {
+          "id": "navigation-6dc2dc2172-item-a5f41f35db",
+          "path": "/content/navigation-redirect/navigation-3",
+          "children": [],
+          "level": 1,
+          "active": false,
+          "current": false,
+          "title": "Navigation 3",
+          "link": {
+            "url": "https://www.adobe.com",
+            "valid": true
+          },
+          "dataLayer": {
+            "navigation-6dc2dc2172-item-a5f41f35db": {
+              "@type": "core/wcm/components/navigation/v2/navigation/item",
+              "dc:title": "Navigation 3",
+              "xdm:linkURL": "https://www.adobe.com"
+            }
+          },
+          ":type":"cq:PageContent"
         }
       ],
       "level": 0,

--- a/bundles/core/src/test/resources/navigation/v2/exporter-navigation9.json
+++ b/bundles/core/src/test/resources/navigation/v2/exporter-navigation9.json
@@ -154,6 +154,27 @@
             }
           },
           ":type": "cq:PageContent"
+        },
+        {
+          "id": "navigation-e6f3e5ac55-item-a5f41f35db",
+          "path": "/content/navigation-redirect/navigation-3",
+          "children": [],
+          "level": 1,
+          "active": false,
+          "current": false,
+          "title": "Navigation 3",
+          "link": {
+            "url": "https://www.adobe.com",
+            "valid": true
+          },
+          "dataLayer": {
+            "navigation-e6f3e5ac55-item-a5f41f35db": {
+              "@type": "core/wcm/components/navigation/v2/navigation/item",
+              "dc:title": "Navigation 3",
+              "xdm:linkURL": "https://www.adobe.com"
+            }
+          },
+          ":type":"cq:PageContent"
         }
       ],
       "level": 0,

--- a/bundles/core/src/test/resources/navigation/v2/test-content.json
+++ b/bundles/core/src/test/resources/navigation/v2/test-content.json
@@ -525,6 +525,14 @@
                     }
                 }
             }
+        },
+        "navigation-3": {
+            "jcr:primaryType": "cq:Page",
+            "jcr:content": {
+                "jcr:primaryType": "cq:PageContent",
+                "jcr:title": "Navigation 3",
+                "cq:redirectTarget": "https://www.adobe.com"
+            }
         }
     },
     "navigation-redirect-chain": {


### PR DESCRIPTION
* Displays external redirect target URLs.
* Added in the page list item implementation, alongside the existing logic for crawling redirect pages.
* Will be available in the Navigation, List, Breadcrumb and Language Navigation components, which all use the page list item.
* A follow-up could be to handle the crawling of redirect pages globally, perhaps directly in the link handler.
* Updates unit test case to include an external redirect example, for the Navigation component.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1713` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | N/A
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0