### PR TITLE
#1775 Alt attribute removed from skip to main content link

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/body.skiptomaincontent.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/body.skiptomaincontent.html
@@ -19,7 +19,6 @@
      data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
      data-sly-test="${page.mainContentSelector}">
     <a class="cmp-page__skiptomaincontent-link"
-       alt="${'Skip to main content link' @ i18n}"
        href="#${page.mainContentSelector}">${'Skip to main content' @ i18n}</a>
 </div>
 <sly data-sly-call="${clientlib.css @ categories='core.wcm.components.page.v2.skiptomaincontent'}"


### PR DESCRIPTION
Alt attribute removed from skip to main content link in page v3.

Fixes #1775 