### PR TITLE
issue-1659 - Instead of sorting by file binary size, the AdaptiveImageServlet should sort by width as documentation suggest.

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -524,7 +524,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
                 if (dimension.getWidth() >= width) {
                     // if best rendition exist, compare the best rendition's width and make it's too big
                     // bestRendition.getDimension will not be null, or else it wouldn't be set
-                    if (bestRendition == null || bestRendition.getDimension().getWidth() > dimension.getWidth()) {
+                    if (bestRendition == null || bestRendition.getDimension() == null || bestRendition.getDimension().getWidth() > dimension.getWidth()) {
                         bestRendition = enhancedRendition;
                         if (StringUtils.equals(bestRendition.getPath(), asset.getOriginal().getPath())) {
                             metrics.markOriginalRenditionUsed();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -514,21 +514,22 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
      */
     @NotNull
     private EnhancedRendition getBestRendition(@NotNull Asset asset, int width) throws IOException {
-        // Sort renditions by file size
-        SortedSet<Rendition> renditions = new TreeSet<>((o1, o2) -> Long.valueOf(o1.getSize() - o2.getSize()).intValue());
-        renditions.addAll(asset.getRenditions());
+        // No longer sorting by rendition binary file size first
         EnhancedRendition bestRendition = null;
         // Find first rendition that has a width larger or equal than wanted
-        for (Rendition rendition : renditions) {
+        for (Rendition rendition : asset.getRenditions()) {
             EnhancedRendition enhancedRendition = new EnhancedRendition(rendition);
             Dimension dimension = enhancedRendition.getDimension();
             if (dimension != null) {
                 if (dimension.getWidth() >= width) {
-                    bestRendition = enhancedRendition;
-                    if (StringUtils.equals(bestRendition.getPath(), asset.getOriginal().getPath())) {
-                        metrics.markOriginalRenditionUsed();
+                    // if best rendition exist, compare the best rendition's width and make it's too big
+                    // bestRendition.getDimension will not be null, or else it wouldn't be set
+                    if (bestRendition == null || bestRendition.getDimension().getWidth() > dimension.getWidth()) {
+                        bestRendition = enhancedRendition;
+                        if (StringUtils.equals(bestRendition.getPath(), asset.getOriginal().getPath())) {
+                            metrics.markOriginalRenditionUsed();
+                        }
                     }
-                    break;
                 }
             }
         }


### PR DESCRIPTION


<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/adobe/aem-core-wcm-components/issues/1659
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes, no test added but existing JUnit passed
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

For more detailed write up with test files please see https://github.com/adobe/aem-core-wcm-components/issues/1659 - the current logic first sort by binary file size of the rendition then attempts to find the rendition with the best fit. Current behavior does not align with the documentation and more critically is not a sustainable solution for a lot of image renditions.
