### PR TITLE
Allow <link rel="preload" as="style"..> for links injected with HtmlPageItemsConfig

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/HtmlPageItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/HtmlPageItem.java
@@ -161,7 +161,7 @@ public interface HtmlPageItem {
         public String[] getAttributeNames() {
             switch(this) {
                 case LINK:
-                    return new String[] {"crossorigin", PN_HREF, "hreflang", "media", "referrerpolicy", "rel", "sizes", "title", "type", "as"};
+                    return new String[] {"as", "crossorigin", PN_HREF, "hreflang", "media", "referrerpolicy", "rel", "sizes", "title", "type"};
                 case SCRIPT:
                     return new String[] {"async", "charset", "defer", PN_SRC, "type"};
                 case META:

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/HtmlPageItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/HtmlPageItem.java
@@ -161,7 +161,7 @@ public interface HtmlPageItem {
         public String[] getAttributeNames() {
             switch(this) {
                 case LINK:
-                    return new String[] {"crossorigin", PN_HREF, "hreflang", "media", "referrerpolicy", "rel", "sizes", "title", "type"};
+                    return new String[] {"crossorigin", PN_HREF, "hreflang", "media", "referrerpolicy", "rel", "sizes", "title", "type", "as"};
                 case SCRIPT:
                     return new String[] {"async", "charset", "defer", PN_SRC, "type"};
                 case META:

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImplTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import com.adobe.cq.wcm.core.components.models.HtmlPageItem;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.testing.mock.caconfig.MockContextAwareConfig;
 import org.junit.jupiter.api.BeforeEach;
@@ -199,6 +200,12 @@ public class PageImplTest extends com.adobe.cq.wcm.core.components.internal.mode
         loadHtmlPageItemsConfig(false);
         assertNotNull(page.getHtmlPageItems());
         assertEquals(3, page.getHtmlPageItems().size(), "Unexpected number of HTML page items");
+        int[] attributeCounts = { 3, 1, 1 };
+        int index = 0;
+        for (HtmlPageItem item : page.getHtmlPageItems()) {
+            assertEquals(attributeCounts[index], item.getAttributes().size());
+            index++;
+        }
     }
 
     @Test
@@ -207,6 +214,12 @@ public class PageImplTest extends com.adobe.cq.wcm.core.components.internal.mode
         Page page = getPageUnderTest(PAGE);
         assertNotNull(page.getHtmlPageItems());
         assertEquals(3, page.getHtmlPageItems().size(), "Unexpected number of HTML page items");
+        int[] attributeCounts = { 3, 1, 1 };
+        int index = 0;
+        for (HtmlPageItem item : page.getHtmlPageItems()) {
+            assertEquals(attributeCounts[index], item.getAttributes().size());
+            index++;
+        }
     }
 
     @Test

--- a/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
@@ -12,7 +12,9 @@
       "element": "link",
       "location": "header",
       "attributes": {
-        "href": "/_theme/theme.css"
+        "href": "/_theme/theme.css",
+        "rel": "preload",
+        "as": "style"
       }
     },
     {

--- a/bundles/core/src/test/resources/page/v2/test-sling-configs-deprecated-caconfig.json
+++ b/bundles/core/src/test/resources/page/v2/test-sling-configs-deprecated-caconfig.json
@@ -8,7 +8,9 @@
             "location"       : "header",
             "attributes"     : {
                 "jcr:primaryType": "nt:unstructured",
-                "href"           : "/theme.css"
+                "href"           : "/theme.css",
+                "rel"            : "preload",
+                "as"             : "style"
             }
         },
         "theme.js"       : {

--- a/bundles/core/src/test/resources/page/v2/test-sling-configs.json
+++ b/bundles/core/src/test/resources/page/v2/test-sling-configs.json
@@ -16,6 +16,16 @@
               "jcr:primaryType": "nt:unstructured",
               "name"           : "href",
               "value"          : "/theme.css"
+            },
+            "rel" : {
+              "jcr:primaryType": "nt:unstructured",
+              "name"           : "rel",
+              "value"          : "preload"
+            },
+            "as" : {
+              "jcr:primaryType": "nt:unstructured",
+              "name"           : "as",
+              "value"          : "style"
             }
           }
         },

--- a/bundles/core/src/test/resources/page/v3/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/v3/exporter-templated-page.json
@@ -12,7 +12,9 @@
       "element": "link",
       "location": "header",
       "attributes": {
-        "href": "/_theme/theme.css"
+        "href": "/_theme/theme.css",
+        "rel": "preload",
+        "as": "style"
       }
     },
     {

--- a/bundles/core/src/test/resources/page/v3/test-sling-configs-deprecated-caconfig.json
+++ b/bundles/core/src/test/resources/page/v3/test-sling-configs-deprecated-caconfig.json
@@ -8,7 +8,9 @@
       "location"       : "header",
       "attributes"     : {
         "jcr:primaryType": "nt:unstructured",
-        "href"           : "/theme.css"
+        "href"           : "/theme.css",
+        "rel"            : "preload",
+        "as"             : "style"
       }
     },
     "theme.js"       : {

--- a/bundles/core/src/test/resources/page/v3/test-sling-configs.json
+++ b/bundles/core/src/test/resources/page/v3/test-sling-configs.json
@@ -16,6 +16,16 @@
               "jcr:primaryType": "nt:unstructured",
               "name"           : "href",
               "value"          : "/theme.css"
+            },
+            "rel" : {
+              "jcr:primaryType": "nt:unstructured",
+              "name"           : "rel",
+              "value"          : "preload"
+            },
+            "as" : {
+              "jcr:primaryType": "nt:unstructured",
+              "name"           : "as",
+              "value"          : "style"
             }
           }
         },


### PR DESCRIPTION
- adds the missing `as` attribute
- updates test cases to check for this attribute

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1823` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      | 👍
| Major: Breaking Change?  |
| Tests Added + Pass?      | 👍
| Documentation Provided   | N/A (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
