### PR TITLE
[Search v1] The searching is breaking when some of the page found has a redirect link

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
@@ -364,7 +364,7 @@ public class LinkHandler {
     public Pair<Page, String> resolveRedirects(@Nullable final Page page) {
         Page result = page;
         String redirectTarget = null;
-        if (page != null) {
+        if (page != null && page.getPageManager() != null) {
             Set<String> redirectCandidates = new LinkedHashSet<>();
             redirectCandidates.add(page.getPath());
             while (result != null && StringUtils

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
@@ -369,7 +369,7 @@ public class LinkHandler {
             redirectCandidates.add(page.getPath());
             while (result != null && StringUtils
                     .isNotEmpty((redirectTarget = result.getProperties().get(PageImpl.PN_REDIRECT_TARGET, String.class)))) {
-                result = pageManager.getPage(redirectTarget);
+                result = page.getPageManager().getPage(redirectTarget);
                 if (result != null) {
                     if (!redirectCandidates.add(result.getPath())) {
                         LOGGER.warn("Detected redirect loop for the following pages: {}.", redirectCandidates);

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/SearchResultServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/SearchResultServletTest.java
@@ -150,7 +150,8 @@ public class SearchResultServletTest {
             ImmutableMap.of("url", CONTEXT_PATH + "/content/en/search/page2.html", "title", "Page2", "id", "search-0dc87a6d22-item-ad3d190367"),
             ImmutableMap.of("url", CONTEXT_PATH + "/content/en/search/page-template.html", "title", "Page3", "id", "search-0dc87a6d22-item-1abc47fffe"),
             ImmutableMap.of("url", CONTEXT_PATH + "/content/en/search/xf-page.html", "title", "XF Page", "id", "search-0dc87a6d22-item-2246ed81a7"),
-            ImmutableMap.of("url", CONTEXT_PATH + "/content/en/search/xf-page-template.html", "title", "XF Page Template", "id", "search-0dc87a6d22-item-7345474d48")
+            ImmutableMap.of("url", CONTEXT_PATH + "/content/en/search/xf-page-template.html", "title", "XF Page Template", "id", "search-0dc87a6d22-item-7345474d48"),
+            ImmutableMap.of("url", CONTEXT_PATH + "/content/en/search.html", "title", "Search", "id", "search-0dc87a6d22-item-04a609b18b")
         );
 
         validateResponse(context.response(), expected);
@@ -228,7 +229,8 @@ public class SearchResultServletTest {
             ImmutableMap.of("url", CONTEXT_PATH + "/content/en/search/page2.html", "title", "Page2", "id", "search-ea349504cd-item-ad3d190367"),
             ImmutableMap.of("url", CONTEXT_PATH + "/content/en/search/page-template.html", "title", "Page3", "id", "search-ea349504cd-item-1abc47fffe"),
             ImmutableMap.of("url", CONTEXT_PATH + "/content/en/search/xf-page.html", "title", "XF Page", "id", "search-ea349504cd-item-2246ed81a7"),
-            ImmutableMap.of("url", CONTEXT_PATH + "/content/en/search/xf-page-template.html", "title", "XF Page Template", "id", "search-ea349504cd-item-7345474d48")
+            ImmutableMap.of("url", CONTEXT_PATH + "/content/en/search/xf-page-template.html", "title", "XF Page Template", "id", "search-ea349504cd-item-7345474d48"),
+            ImmutableMap.of("url", CONTEXT_PATH + "/content/en/search.html", "title", "Search", "id", "search-ea349504cd-item-04a609b18b")
         );
 
         validateResponse(context.response(), expected);

--- a/bundles/core/src/test/resources/search/test-content.json
+++ b/bundles/core/src/test/resources/search/test-content.json
@@ -154,6 +154,14 @@
                     "jcr:title"      : "XF Page Template",
                     "cq:template"    : "/conf/test/settings/wcm/templates/xf-search-template"
                 }
+            },
+            "redirect-page" : {
+                "jcr:primaryType": "cq:Page",
+                "jcr:content"    : {
+                    "jcr:primaryType"  : "cq:PageContent",
+                    "jcr:title"        : "Redirect Page",
+                    "cq:redirectTarget": "/content/en/search"
+                }
             }
         }
     },


### PR DESCRIPTION


* Use page manager from page to prevent NPE
* Updated test content and expected results to include a redirect page

Fixes #1848