### PR TITLE
CIF-2300: move jackson annotations from LinkImpl to Link

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/link/Link.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/link/Link.java
@@ -22,12 +22,19 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ConsumerType;
 
+import com.adobe.cq.wcm.core.components.internal.jackson.LinkHtmlAttributesSerializer;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 /**
  * Describes a link target.
  *
  * @since com.adobe.cq.wcm.core.components.commons.link 1.0.0
  */
 @ConsumerType
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public interface Link<T> {
 
     /**
@@ -67,6 +74,7 @@ public interface Link<T> {
      * @return Link URL or {@code null} if link is invalid
      */
     @Nullable
+    @JsonIgnore
     default String getURL() {
         return null;
     }
@@ -78,6 +86,7 @@ public interface Link<T> {
      * @return Mapped link URL or {@code null} if link is invalid or no processing can be done
      */
     @Nullable
+    @JsonProperty("url")
     default String getMappedURL() {
         return null;
     }
@@ -89,6 +98,7 @@ public interface Link<T> {
      * @return Full link URL or {@code null} if link is invalid or can't be externalized.
      */
     @Nullable
+    @JsonIgnore
     default String getExternalizedURL() {
         return null;
     }
@@ -102,6 +112,9 @@ public interface Link<T> {
      * @since com.adobe.cq.wcm.core.components.commons.link 1.0.0
      */
     @NotNull
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonSerialize(using = LinkHtmlAttributesSerializer.class)
+    @JsonProperty("attributes")
     default Map<String, String> getHtmlAttributes() {
         return Collections.emptyMap();
     }
@@ -113,6 +126,7 @@ public interface Link<T> {
      * @since com.adobe.cq.wcm.core.components.commons.link 1.0.0
      */
     @Nullable
+    @JsonIgnore
     default T getReference() {
         return null;
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkImpl.java
@@ -37,7 +37,6 @@ import com.google.common.collect.ImmutableMap;
 /**
  * Wraps link information to be used in models.
  */
-@JsonInclude(Include.NON_NULL)
 public final class LinkImpl<T> implements Link<T> {
 
     public static final String ATTR_HREF = "href";
@@ -82,7 +81,6 @@ public final class LinkImpl<T> implements Link<T> {
      * @return Link URL, can be {@code null} if link is not valid
      */
     @Override
-    @JsonIgnore
     public @Nullable String getURL() {
         return url;
     }
@@ -93,13 +91,11 @@ public final class LinkImpl<T> implements Link<T> {
      * @return Processed link URL, can be {@code null} if link is not valid or no processors are defined
      */
     @Override
-    @JsonProperty("url")
     public @Nullable String getMappedURL() {
         return mappedUrl;
     }
 
     @Override
-    @JsonIgnore
     public @Nullable String getExternalizedURL() {
         return externalizedUrl;
     }
@@ -111,9 +107,6 @@ public final class LinkImpl<T> implements Link<T> {
      * @return {@link Map} of HTML attributes, may include the URL as {@code href}
      */
     @Override
-    @JsonInclude(Include.NON_EMPTY)
-    @JsonSerialize(using = LinkHtmlAttributesSerializer.class)
-    @JsonProperty("attributes")
     public @NotNull Map<String, String> getHtmlAttributes() {
         return htmlAttributes;
     }
@@ -124,7 +117,6 @@ public final class LinkImpl<T> implements Link<T> {
      * @return Link referenced WCM/DAM entity or {@code null} if link does not point to one
      */
     @Override
-    @JsonIgnore
     public @Nullable T getReference() {
         return reference;
     }
@@ -150,5 +142,4 @@ public final class LinkImpl<T> implements Link<T> {
         }
         return ImmutableMap.copyOf(attributes);
     }
-
 }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
