### PR TITLE
[LinkHandler] Expose `LinkHandler` interface (#1818)

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
@@ -38,7 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.wcm.core.components.commons.link.Link;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.internal.resource.CoreResourceWrapper;
 import com.adobe.cq.wcm.core.components.models.ExperienceFragment;
 import com.adobe.cq.wcm.core.components.models.Teaser;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
@@ -46,7 +46,6 @@ import com.adobe.cq.wcm.core.components.util.ComponentUtils;
 import com.day.cq.commons.DownloadResource;
 import com.day.cq.commons.ImageResource;
 import com.day.cq.wcm.api.Page;
-import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.Template;
 import com.day.cq.wcm.api.designer.Designer;
 import com.day.cq.wcm.api.designer.Style;
@@ -323,7 +322,7 @@ public class Utils {
 
         if (imageFromPageImage) {
             Resource inheritedResource = null;
-            Optional<Link> link = linkHandler.getLink(resource);
+            Optional<Link<Page>> link = linkHandler.getLink(resource);
             boolean actionsEnabled = (currentStyle != null) ?
                     !currentStyle.get(Teaser.PN_ACTIONS_DISABLED, !properties.get(Teaser.PN_ACTIONS_ENABLED, false)) :
                     properties.get(Teaser.PN_ACTIONS_ENABLED, false);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
@@ -179,10 +179,10 @@ public class DefaultPathProcessor implements PathProcessor {
     @Nullable
     private String getVanityUrl(@NotNull String path, @NotNull ResourceResolver resourceResolver) {
         String vanityUrl = null;
-        if (path.endsWith(LinkHandler.HTML_EXTENSION)) {
+        if (path.endsWith(LinkHandlerImpl.HTML_EXTENSION)) {
             PageManager pageManager = resourceResolver.adaptTo(PageManager.class);
             if (pageManager != null) {
-                Page page = pageManager.getPage(path.substring(0, path.lastIndexOf(LinkHandler.HTML_EXTENSION)));
+                Page page = pageManager.getPage(path.substring(0, path.lastIndexOf(LinkHandlerImpl.HTML_EXTENSION)));
                 if (page != null) {
                     vanityUrl = page.getVanityUrl();
                     if (StringUtils.isNotBlank(vanityUrl) && !vanityUrl.startsWith("/")) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImpl.java
@@ -106,14 +106,12 @@ public class LinkHandlerImpl implements LinkHandler {
 
 
     @NotNull
-    @SuppressWarnings("rawtypes")
-    public Optional<Link> getLink(@NotNull Resource resource) {
+    public Optional<Link<Page>> getLink(@NotNull Resource resource) {
         return getLink(resource, PN_LINK_URL);
     }
 
    @NotNull
-    @SuppressWarnings("rawtypes")
-    public Optional<Link> getLink(@NotNull Resource resource, String linkURLPropertyName) {
+    public Optional<Link<Page>> getLink(@NotNull Resource resource, String linkURLPropertyName) {
         ValueMap props = resource.getValueMap();
         String linkURL = props.get(linkURLPropertyName, String.class);
         if (linkURL == null) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImpl.java
@@ -15,13 +15,14 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.link;
 
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
+import com.adobe.cq.wcm.core.components.commons.link.Link;
+import com.adobe.cq.wcm.core.components.internal.models.v2.PageImpl;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.PathProcessor;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.designer.Style;
+import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -38,13 +39,12 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.wcm.core.components.commons.link.Link;
-import com.adobe.cq.wcm.core.components.internal.models.v2.PageImpl;
-import com.adobe.cq.wcm.core.components.services.link.PathProcessor;
-import com.day.cq.wcm.api.Page;
-import com.day.cq.wcm.api.PageManager;
-import com.day.cq.wcm.api.designer.Style;
-import com.google.common.collect.ImmutableSet;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_ACCESSIBILITY_LABEL;
 import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_TARGET;
@@ -58,23 +58,10 @@ import static com.adobe.cq.wcm.core.components.internal.link.LinkImpl.ATTR_TITLE
  * Simple implementation for resolving and validating links from model's resources.
  * This is a Sling model that can be injected into other models using the <code>@Self</code> annotation.
  */
-@Model(adaptables = SlingHttpServletRequest.class)
-public class LinkHandler {
+@Model(adaptables = SlingHttpServletRequest.class, adapters = {LinkHandler.class})
+public class LinkHandlerImpl implements LinkHandler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LinkHandler.class);
-
-    public static final String HTML_EXTENSION = ".html";
-
-    /**
-     * Name of the resource property that for redirecting pages will indicate if original page or redirect target page should be returned.
-     * Default is `false`. If `true` - original page is returned. If `false` or not configured - redirect target page.
-     */
-    public static final String PN_DISABLE_SHADOWING = "disableShadowing";
-
-    /**
-     * Flag indicating if shadowing is disabled.
-     */
-    public static final boolean PROP_DISABLE_SHADOWING_DEFAULT = false;
+    private static final Logger LOGGER = LoggerFactory.getLogger(LinkHandlerImpl.class);
 
     /**
      * List of allowed/supported values for link target.
@@ -117,26 +104,14 @@ public class LinkHandler {
      */
     private Boolean shadowingDisabled;
 
-    /**
-     * Resolves a link from the properties of the given resource.
-     *
-     * @param resource Resource
-     * @return {@link Optional} of  {@link Link}
-     */
+
     @NotNull
     @SuppressWarnings("rawtypes")
     public Optional<Link> getLink(@NotNull Resource resource) {
         return getLink(resource, PN_LINK_URL);
     }
 
-    /**
-     * Resolves a link from the properties of the given resource.
-     *
-     * @param resource            Resource
-     * @param linkURLPropertyName Property name to read link URL from.
-     * @return {@link Optional} of  {@link Link}
-     */
-    @NotNull
+   @NotNull
     @SuppressWarnings("rawtypes")
     public Optional<Link> getLink(@NotNull Resource resource, String linkURLPropertyName) {
         ValueMap props = resource.getValueMap();
@@ -150,12 +125,6 @@ public class LinkHandler {
         return Optional.ofNullable(getLink(linkURL, linkTarget, linkAccessibilityLabel, linkTitleAttribute).orElse(null));
     }
 
-    /**
-     * Builds a link pointing to the given target page.
-     * @param page Target page
-     *
-     * @return {@link Optional} of  {@link Link<Page>}
-     */
     @NotNull
     public Optional<Link<Page>> getLink(@Nullable Page page) {
         if (page == null) {
@@ -165,13 +134,6 @@ public class LinkHandler {
         return buildLink(pair.getRight(), request, pair.getLeft(), null);
     }
 
-    /**
-     * Builds a link with the given Link URL and target.
-     * @param linkURL Link URL
-     * @param target Target
-     *
-     * @return {@link Optional} of  {@link Link<Page>}
-     */
     @NotNull
     public Optional<Link<Page>> getLink(@Nullable String linkURL, @Nullable String target) {
         Pair<Page, String> pair = resolvePage(getPage(linkURL).orElse(null));
@@ -182,15 +144,6 @@ public class LinkHandler {
                 new HashMap<String, String>() {{ put(ATTR_TARGET, resolvedLinkTarget); }});
     }
 
-    /**
-     * Builds a link with the given Link URL, target, accessibility label, title.
-     * @param linkURL Link URL
-     * @param target Target
-     * @param linkAccessibilityLabel Link Accessibility Label
-     * @param linkTitleAttribute Link Title Attribute
-     *
-     * @return {@link Optional} of  {@link Link<Page>}
-     */
     @NotNull
     public Optional<Link<Page>> getLink(@Nullable String linkURL, @Nullable String target, @Nullable String linkAccessibilityLabel, @Nullable String linkTitleAttribute) {
         Pair<Page, String> pair = resolvePage(getPage(linkURL).orElse(null));
@@ -352,14 +305,6 @@ public class LinkHandler {
         return new ImmutablePair<>(resolved, linkURL);
     }
 
-    /**
-     * Attempts to resolve the redirect chain starting from the given page, avoiding loops.
-     *
-     * @param page The starting {@link Page}
-     * @return A pair of {@link Page} and {@link String} the redirect chain resolves to. The page can be the original page, if no redirect
-     * target is defined or even {@code null} if the redirect chain does not resolve to a valid page, in this case one should use the right
-     * part of the pair (the {@link String} redirect target).
-     */
     @NotNull
     public Pair<Page, String> resolveRedirects(@Nullable final Page page) {
         Page result = page;
@@ -398,6 +343,4 @@ public class LinkHandler {
         }
         return shadowingDisabled;
     }
-
-
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImpl.java
@@ -42,7 +42,7 @@ import org.jetbrains.annotations.Nullable;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.SlingModelFilter;
 import com.adobe.cq.wcm.core.components.commons.link.Link;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.Container;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.models.datalayer.ContainerData;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImpl.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.Breadcrumb;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbItemImpl.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
 
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.components.Component;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ButtonImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ButtonImpl.java
@@ -35,7 +35,7 @@ import org.jetbrains.annotations.Nullable;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.commons.link.Link;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.Button;
 import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import com.adobe.cq.wcm.core.components.models.datalayer.builder.DataLayerBuilder;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ButtonImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ButtonImpl.java
@@ -21,6 +21,7 @@ import javax.annotation.PostConstruct;
 import javax.inject.Named;
 
 import com.adobe.cq.wcm.core.components.util.AbstractComponentImpl;
+import com.day.cq.wcm.api.Page;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Exporter;
@@ -79,7 +80,7 @@ public class ButtonImpl extends AbstractComponentImpl implements Button {
 
     @Self
     private LinkHandler linkHandler;
-    protected Optional<Link> link;
+    protected Optional<Link<@Nullable Page>> link;
 
     @PostConstruct
     private void initModel() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/DownloadImpl.java
@@ -44,7 +44,7 @@ import org.jetbrains.annotations.NotNull;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.commons.link.Link;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.internal.servlets.DownloadServlet;
 import com.adobe.cq.wcm.core.components.models.Download;
 import com.day.cq.commons.DownloadResource;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
@@ -124,7 +124,7 @@ public class ImageImpl extends AbstractComponentImpl implements Image {
     protected int jpegQuality;
     protected String imageName;
     protected Resource fileResource;
-    protected Optional<Link> link;
+    protected Optional<Link<Page>> link;
 
     public ImageImpl() {
         selector = AdaptiveImageServlet.DEFAULT_SELECTOR;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.commons.link.Link;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServlet;
 import com.adobe.cq.wcm.core.components.models.Image;
 import com.adobe.cq.wcm.core.components.models.datalayer.ImageData;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationImpl.java
@@ -35,7 +35,7 @@ import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.LanguageNavigation;
 import com.adobe.cq.wcm.core.components.models.LanguageNavigationItem;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationItemImpl.java
@@ -20,7 +20,7 @@ import java.util.Locale;
 
 import org.jetbrains.annotations.NotNull;
 
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.LanguageNavigationItem;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.adobe.cq.wcm.core.components.models.datalayer.PageData;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
@@ -39,7 +39,7 @@ import org.jetbrains.annotations.Nullable;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.internal.LocalizationUtils;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.Navigation;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.LanguageManager;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationItemImpl.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
 
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.components.Component;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
@@ -51,7 +51,7 @@ import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.export.json.SlingModelFilter;
 import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.internal.Utils;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.Page;
 import com.adobe.cq.wcm.core.components.models.datalayer.PageData;
 import com.adobe.cq.wcm.core.components.models.datalayer.builder.DataLayerBuilder;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageListItemImpl.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.wcm.core.components.commons.link.Link;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.models.datalayer.PageData;
 import com.adobe.cq.wcm.core.components.models.datalayer.builder.DataLayerBuilder;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
@@ -17,11 +17,10 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.Optional;
 
-import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
 
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.Page;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/RedirectItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/RedirectItemImpl.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.wcm.core.components.commons.link.Link;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
@@ -18,9 +18,11 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 import java.util.Calendar;
 import java.util.Optional;
 
+import com.day.cq.wcm.api.Page;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
@@ -34,7 +36,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 public class ResourceListItemImpl extends AbstractListItemImpl implements ListItem {
 
-    protected Optional<Link> link;
+    /**
+     * The link.
+     */
+    protected Optional<Link<@Nullable Page>> link;
+
     /**
      * The title.
      */

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
@@ -23,7 +23,7 @@ import org.apache.sling.api.resource.ValueMap;
 import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.wcm.core.components.commons.link.Link;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.components.Component;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -42,7 +42,7 @@ import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.internal.Heading;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.Image;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.models.Teaser;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TitleImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TitleImpl.java
@@ -37,7 +37,7 @@ import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.internal.Heading;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.Title;
 import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import com.adobe.cq.wcm.core.components.models.datalayer.builder.DataLayerBuilder;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TitleImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TitleImpl.java
@@ -85,7 +85,7 @@ public class TitleImpl extends AbstractComponentImpl implements Title {
 
     @Self
     private LinkHandler linkHandler;
-    protected Optional<Link> link;
+    protected Optional<Link<@Nullable Page>> link;
 
     /**
      * The {@link com.adobe.cq.wcm.core.components.internal.Heading} object for the type of this title.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImpl.java
@@ -50,7 +50,7 @@ import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.export.json.SlingModelFilter;
 import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.internal.form.FormConstants;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.form.Container;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.foundation.forms.FormStructureHelper;
@@ -103,7 +103,7 @@ public class ContainerImpl implements Container {
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
     @Nullable
     private String redirect;
-    
+
     @Self
     private LinkHandler linkHandler;
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/LanguageNavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/LanguageNavigationImpl.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.LanguageNavigation;
 import com.adobe.cq.wcm.core.components.models.LanguageNavigationItem;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/LanguageNavigationItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/LanguageNavigationItemImpl.java
@@ -20,7 +20,7 @@ import java.util.Locale;
 
 import org.jetbrains.annotations.NotNull;
 
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.LanguageNavigationItem;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ListImpl.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.internal.models.v1.PageListItemImpl;
 import com.adobe.cq.wcm.core.components.models.List;
 import com.adobe.cq.wcm.core.components.models.ListItem;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/NavigationImpl.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.Navigation;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/NavigationItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/NavigationItemImpl.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.wcm.core.components.commons.link.Link;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.components.Component;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
@@ -53,7 +53,7 @@ import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.config.HtmlPageItemConfig;
 import com.adobe.cq.wcm.core.components.config.HtmlPageItemsConfig;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.internal.models.v1.RedirectItemImpl;
 import com.adobe.cq.wcm.core.components.models.HtmlPageItem;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageListItemImpl.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.wcm.core.components.commons.link.Link;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.internal.resource.CoreResourceWrapper;
 import com.adobe.cq.wcm.core.components.models.datalayer.PageData;
 import com.adobe.cq.wcm.core.components.models.datalayer.builder.DataLayerBuilder;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/RedirectItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/RedirectItemImpl.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.wcm.core.components.commons.link.Link;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class RedirectItemImpl extends com.adobe.cq.wcm.core.components.internal.models.v1.RedirectItemImpl {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/BreadcrumbImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/BreadcrumbImpl.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.Breadcrumb;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/BreadcrumbItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/BreadcrumbItemImpl.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.wcm.core.components.commons.link.Link;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.internal.models.v2.NavigationItemImpl;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/ListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/ListImpl.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.internal.models.v2.PageListItemImpl;
 import com.adobe.cq.wcm.core.components.models.List;
 import com.adobe.cq.wcm.core.components.models.ListItem;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImpl.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.export.json.ExporterConstants;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.internal.models.v2.RedirectItemImpl;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.adobe.cq.wcm.core.components.models.Page;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -55,7 +55,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.internal.models.v1.AbstractImageDelegatingModel;
 import com.adobe.cq.wcm.core.components.internal.resource.CoreResourceWrapper;
 import com.adobe.cq.wcm.core.components.models.Image;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/SearchResultServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/SearchResultServlet.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import com.adobe.cq.wcm.core.components.internal.LocalizationUtils;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.internal.models.v1.PageListItemImpl;
 import com.adobe.cq.wcm.core.components.internal.models.v1.SearchImpl;
 import com.adobe.cq.wcm.core.components.models.ListItem;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/LinkHandler.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/LinkHandler.java
@@ -1,0 +1,110 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.services.link;
+
+import com.adobe.cq.wcm.core.components.commons.link.Link;
+import com.day.cq.wcm.api.Page;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ConsumerType;
+
+import java.util.Optional;
+
+/**
+ * interface for resolving and validating links from model's resources.
+ * This is implemented as Sling model that can be injected into other models using the <code>@Self</code> annotation.
+ */
+@ConsumerType
+public interface LinkHandler {
+
+    String HTML_EXTENSION = ".html";
+
+
+    /**
+     * Name of the resource property that for redirecting pages will indicate if original page or redirect target page should be returned.
+     * Default is `false`. If `true` - original page is returned. If `false` or not configured - redirect target page.
+     */
+    String PN_DISABLE_SHADOWING = "disableShadowing";
+
+    /**
+     * Flag indicating if shadowing is disabled.
+     */
+    boolean PROP_DISABLE_SHADOWING_DEFAULT = false;
+
+    /**
+     * Resolves a link from the properties of the given resource.
+     *
+     * @param resource Resource
+     * @return {@link Optional} of  {@link Link}
+     */
+    @NotNull
+    Optional<Link> getLink(@NotNull Resource resource);
+
+    /**
+     * Resolves a link from the properties of the given resource.
+     *
+     * @param resource            Resource
+     * @param linkURLPropertyName Property name to read link URL from.
+     * @return {@link Optional} of  {@link Link}
+     */
+    @NotNull
+    @SuppressWarnings("rawtypes")
+    Optional<Link> getLink(@NotNull Resource resource, String linkURLPropertyName);
+
+    /**
+     * Builds a link pointing to the given target page.
+     * @param page Target page
+     *
+     * @return {@link Optional} of  {@link Link< Page >}
+     */
+    @NotNull
+    Optional<Link<Page>> getLink(@Nullable Page page);
+
+    /**
+     * Builds a link with the given Link URL and target.
+     * @param linkURL Link URL
+     * @param target Target
+     *
+     * @return {@link Optional} of  {@link Link<Page>}
+     */
+    @NotNull
+    Optional<Link<Page>> getLink(@Nullable String linkURL, @Nullable String target);
+
+    /**
+     * Builds a link with the given Link URL, target, accessibility label, title.
+     * @param linkURL Link URL
+     * @param target Target
+     * @param linkAccessibilityLabel Link Accessibility Label
+     * @param linkTitleAttribute Link Title Attribute
+     *
+     * @return {@link Optional} of  {@link Link<Page>}
+     */
+    @NotNull
+    Optional<Link<Page>> getLink(@Nullable String linkURL, @Nullable String target, @Nullable String linkAccessibilityLabel, @Nullable String linkTitleAttribute);
+
+    /**
+     * Attempts to resolve the redirect chain starting from the given page, avoiding loops.
+     *
+     * @param page The starting {@link Page}
+     * @return A pair of {@link Page} and {@link String} the redirect chain resolves to. The page can be the original page, if no redirect
+     * target is defined or even {@code null} if the redirect chain does not resolve to a valid page, in this case one should use the right
+     * part of the pair (the {@link String} redirect target).
+     */
+    @NotNull
+    Pair<Page, String> resolveRedirects(@Nullable final Page page);
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/LinkHandler.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/LinkHandler.java
@@ -32,8 +32,10 @@ import java.util.Optional;
 @ConsumerType
 public interface LinkHandler {
 
+    /**
+     * Page extension.
+     */
     String HTML_EXTENSION = ".html";
-
 
     /**
      * Name of the resource property that for redirecting pages will indicate if original page or redirect target page should be returned.
@@ -50,52 +52,54 @@ public interface LinkHandler {
      * Resolves a link from the properties of the given resource.
      *
      * @param resource Resource
-     * @return {@link Optional} of  {@link Link}
+     * @return {@link Optional} of {@link Link}
      */
     @NotNull
-    Optional<Link> getLink(@NotNull Resource resource);
+    Optional<Link<@Nullable Page>> getLink(@NotNull Resource resource);
 
     /**
      * Resolves a link from the properties of the given resource.
      *
      * @param resource            Resource
      * @param linkURLPropertyName Property name to read link URL from.
-     * @return {@link Optional} of  {@link Link}
+     * @return {@link Optional} of {@link Link}
      */
     @NotNull
-    @SuppressWarnings("rawtypes")
-    Optional<Link> getLink(@NotNull Resource resource, String linkURLPropertyName);
+    Optional<Link<@Nullable Page>> getLink(@NotNull Resource resource, @NotNull String linkURLPropertyName);
 
     /**
      * Builds a link pointing to the given target page.
-     * @param page Target page
      *
-     * @return {@link Optional} of  {@link Link< Page >}
+     * @param page Target page
+     * @return {@link Optional} of {@link Link<Page>}
      */
     @NotNull
-    Optional<Link<Page>> getLink(@Nullable Page page);
+    Optional<Link<@Nullable Page>> getLink(@Nullable Page page);
 
     /**
      * Builds a link with the given Link URL and target.
-     * @param linkURL Link URL
-     * @param target Target
      *
-     * @return {@link Optional} of  {@link Link<Page>}
+     * @param linkURL Link URL
+     * @param target  Target
+     * @return {@link Optional} of {@link Link<Page>}
      */
     @NotNull
-    Optional<Link<Page>> getLink(@Nullable String linkURL, @Nullable String target);
+    Optional<Link<@Nullable Page>> getLink(@Nullable String linkURL, @Nullable String target);
 
     /**
      * Builds a link with the given Link URL, target, accessibility label, title.
-     * @param linkURL Link URL
-     * @param target Target
-     * @param linkAccessibilityLabel Link Accessibility Label
-     * @param linkTitleAttribute Link Title Attribute
      *
-     * @return {@link Optional} of  {@link Link<Page>}
+     * @param linkURL                Link URL
+     * @param target                 Target
+     * @param linkAccessibilityLabel Link Accessibility Label
+     * @param linkTitleAttribute     Link Title Attribute
+     * @return {@link Optional} of {@link Link<Page>}
      */
     @NotNull
-    Optional<Link<Page>> getLink(@Nullable String linkURL, @Nullable String target, @Nullable String linkAccessibilityLabel, @Nullable String linkTitleAttribute);
+    Optional<Link<@Nullable Page>> getLink(@Nullable String linkURL,
+                                           @Nullable String target,
+                                           @Nullable String linkAccessibilityLabel,
+                                           @Nullable String linkTitleAttribute);
 
     /**
      * Attempts to resolve the redirect chain starting from the given page, avoiding loops.
@@ -106,5 +110,5 @@ public interface LinkHandler {
      * part of the pair (the {@link String} redirect target).
      */
     @NotNull
-    Pair<Page, String> resolveRedirects(@Nullable final Page page);
+    Pair<@Nullable Page, @Nullable String> resolveRedirects(@Nullable final Page page);
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/PathProcessor.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/PathProcessor.java
@@ -25,7 +25,7 @@ import org.osgi.annotation.versioning.ConsumerType;
 
 /**
  * A service that can process a given path. This service is used by the
- * {@link com.adobe.cq.wcm.core.components.internal.link.LinkHandler} to build the final
+ * {@link com.adobe.cq.wcm.core.components.services.link.LinkHandler} to build the final
  * {@link com.adobe.cq.wcm.core.components.commons.link.Link}. The path processor chain of the Link Handler can be extended by a custom
  * path processor which has to get a higher service ranking than the
  * {@link com.adobe.cq.wcm.core.components.internal.link.DefaultPathProcessor}.
@@ -40,7 +40,7 @@ public interface PathProcessor {
      * @param path the path which should be processed
      * @param request the current request
      * @return {@code true} if the processor should handle the given path, otherwise {@code false} and the next path processor is applied by
-     * the {@link com.adobe.cq.wcm.core.components.internal.link.LinkHandler} if present
+     * the {@link com.adobe.cq.wcm.core.components.services.link.LinkHandler} if present
      */
     boolean accepts(@NotNull String path, @NotNull SlingHttpServletRequest request);
 
@@ -70,12 +70,12 @@ public interface PathProcessor {
 
 
     /**
-     * Processes the HTML attributes for the {@link com.adobe.cq.wcm.core.components.internal.link.LinkHandler}
+     * Processes the HTML attributes for the {@link com.adobe.cq.wcm.core.components.services.link.LinkHandler}
      * @param path the path of the linked resource
      * @param htmlAttributes the origin HTML attributes of the link
      * @return a map of the processed HTML attributes for the link
      */
     default @Nullable Map<String, String> processHtmlAttributes(@NotNull String path, @Nullable Map<String, String> htmlAttributes) {
         return htmlAttributes;
-    };
+    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/package-info.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("1.1.0")
+@Version("1.2.0")
 package com.adobe.cq.wcm.core.components.services.link;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessorTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessorTest.java
@@ -15,18 +15,17 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.link;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.servlethelpers.MockSlingHttpServletRequest;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.day.cq.commons.Externalizer;
 import com.day.cq.wcm.api.Page;
 import com.google.common.collect.ImmutableMap;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.servlethelpers.MockSlingHttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -83,10 +82,10 @@ class DefaultPathProcessorTest {
                 ImmutableMap.of("sling:vanityPath", "vanity.html"));
         DefaultPathProcessor underTest = context.registerInjectActivateService(new DefaultPathProcessor(), ImmutableMap.of(
                 "vanityConfig", DefaultPathProcessor.VanityConfig.MAPPING.getValue()));
-        assertTrue(underTest.accepts(page.getPath() + LinkHandler.HTML_EXTENSION, context.request()));
-        assertEquals("/content/links/site1/en.html", underTest.sanitize(page.getPath() + LinkHandler.HTML_EXTENSION, context.request()));
-        assertEquals("/vanity.html", underTest.map(page.getPath() + LinkHandler.HTML_EXTENSION, context.request()));
-        assertEquals("https://example.org/vanity.html", underTest.externalize(page.getPath() + LinkHandler.HTML_EXTENSION, context.request()));
+        assertTrue(underTest.accepts(page.getPath() + LinkHandlerImpl.HTML_EXTENSION, context.request()));
+        assertEquals("/content/links/site1/en.html", underTest.sanitize(page.getPath() + LinkHandlerImpl.HTML_EXTENSION, context.request()));
+        assertEquals("/vanity.html", underTest.map(page.getPath() + LinkHandlerImpl.HTML_EXTENSION, context.request()));
+        assertEquals("https://example.org/vanity.html", underTest.externalize(page.getPath() + LinkHandlerImpl.HTML_EXTENSION, context.request()));
     }
 
     @Test
@@ -95,11 +94,11 @@ class DefaultPathProcessorTest {
                 ImmutableMap.of("sling:vanityPath", "vanity.html"));
         DefaultPathProcessor underTest = context.registerInjectActivateService(new DefaultPathProcessor(), ImmutableMap.of(
                 "vanityConfig", "shouldBeDefault"));
-        assertEquals("/content/site1/en.html", underTest.map(page.getPath() + LinkHandler.HTML_EXTENSION, context.request()));
-        assertEquals("https://example.org/content/links/site1/en.html", underTest.externalize(page.getPath() + LinkHandler.HTML_EXTENSION, context.request()));
+        assertEquals("/content/site1/en.html", underTest.map(page.getPath() + LinkHandlerImpl.HTML_EXTENSION, context.request()));
+        assertEquals("https://example.org/content/links/site1/en.html", underTest.externalize(page.getPath() + LinkHandlerImpl.HTML_EXTENSION, context.request()));
         context.request().setContextPath("/cp");
         underTest = context.registerInjectActivateService(new DefaultPathProcessor(), ImmutableMap.of(
                 "vanityConfig", DefaultPathProcessor.VanityConfig.ALWAYS.getValue()));
-        assertEquals("/cp/vanity.html", underTest.sanitize(page.getPath() + LinkHandler.HTML_EXTENSION, context.request()));
+        assertEquals("/cp/vanity.html", underTest.sanitize(page.getPath() + LinkHandlerImpl.HTML_EXTENSION, context.request()));
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImplTest.java
@@ -17,6 +17,7 @@ package com.adobe.cq.wcm.core.components.internal.link;
 
 import java.util.Optional;
 
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import org.apache.sling.api.resource.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,7 @@ import static com.adobe.cq.wcm.core.components.internal.link.LinkTestUtils.asser
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(AemContextExtension.class)
-class LinkHandlerTest {
+class LinkHandlerImplTest {
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImplTest.java
@@ -21,9 +21,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandlerImpl;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.servlethelpers.MockRequestDispatcherFactory;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +32,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.adobe.cq.export.json.SlingModelFilter;
 import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
-import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.form.Container;
 import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.foundation.forms.FormStructureHelper;
@@ -61,9 +58,6 @@ public class ContainerImplTest {
     @Mock
     private FormStructureHelper formStructureHelper;
 
-    @Mock
-    private MockRequestDispatcherFactory requestDispatcherFactory;
-
     @BeforeEach
     public void setUp() {
         context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, CONTAINING_PAGE);
@@ -89,7 +83,6 @@ public class ContainerImplTest {
                         .collect(Collectors.toList());
             }
         });
-        context.registerAdapter(MockSlingHttpServletRequest.class, LinkHandler.class, new LinkHandlerImpl());
         FormsHelperStubber.createStub();
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImplTest.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import com.adobe.cq.wcm.core.components.internal.link.LinkHandlerImpl;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.servlethelpers.MockRequestDispatcherFactory;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
@@ -33,7 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.adobe.cq.export.json.SlingModelFilter;
 import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
 import com.adobe.cq.wcm.core.components.models.form.Container;
 import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.foundation.forms.FormStructureHelper;
@@ -88,7 +89,7 @@ public class ContainerImplTest {
                         .collect(Collectors.toList());
             }
         });
-        context.registerAdapter(MockSlingHttpServletRequest.class, LinkHandler.class, new LinkHandler());
+        context.registerAdapter(MockSlingHttpServletRequest.class, LinkHandler.class, new LinkHandlerImpl());
         FormsHelperStubber.createStub();
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/NavigationItemImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/NavigationItemImplTest.java
@@ -15,14 +15,13 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v2;
 
-import java.util.Collections;
-
+import com.adobe.cq.wcm.core.components.services.link.LinkHandler;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.components.Component;
 import org.apache.sling.api.resource.ValueMap;
 import org.junit.jupiter.api.Test;
 
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
-import com.day.cq.wcm.api.Page;
-import com.day.cq.wcm.api.components.Component;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1818 
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | yes
| Major: Breaking Change?  | no
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

This pull request includes the commits made by @jkoebner in PR #1819. 
The commits made in that PR have been rebased to resolve conflicts, but have otherwise been unchanged and attribution is intact.

This PR expands on #1819 by:

- Removing the raw `Link` return types from the `LinkHandler` interface, and replacing them with `Link<Page>`
- Updating model implementations that use the `LinkHandler` to be compatible with this change. Other exported interfaces that return a raw `Link` are *not* modified so as to retain backwards compatibility for the time being.
- Adding additional tests for the `LinkHandlerImpl`. Specifically, tests for redirect chains and shadowing. 
- Correcting a testing bug where the resource injected into the `LinkHandlerImpl` is not the correct resource - this issue only surfaces once you start testing the ability to disable redirect shadowing in the link handler.
- Significantly reworking `LinkHandlerImpl` so as to:
  - apply consistent formatting
  - add `@Override` annotations where appropriate
  - add JavaDoc comments to all non-override methods/fields
  - make private methods static where possible
  - Update the `LinkHandlerImpl#getLink(String, String)` method to reduce duplication of code

There is one change that might be contentious. The `LinkHandlerImpl` class has been changed from field injection to constructor injection. I understand that constructor injection is not the typical pattern for this project; however, the benefit of this change is that it permits (internally) the direct instantiation of a `LinkHandlerImpl` without having to rely on a model - as long as you can satisfy the constructor requirements.
 In truth, the `LinkHandler` feels more like a service than a model to me, and so using constructor injection allows it to continue functioning as a model for backwards compatibility, but also opens up the possibility (in the future) for creating a `LinkHandlerFactory` service that can provide `LinkHandler`s as a factory service that can be used outside the context of sling models. If constructor injection is used (as it is in this PR) then the link handler _can_ function both ways. 
