### PR TITLE
[Teaser] Hide pretitle in dialog if disabled in policy (#1809)

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -68,6 +68,7 @@
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
                                             <pretitle
+                                                granite:hide="${cqDesign.pretitleHidden}"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="A pretitle that will be displayed above the Teaser's title."

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
@@ -131,6 +131,7 @@
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
                                             <pretitle
+                                                granite:hide="${cqDesign.pretitleHidden}"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="A pretitle that will be displayed above the Teaser's title."


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1809
| Patch: Bug Fix?          | Y
| Minor: New Feature?      | N
| Major: Breaking Change?  | N
| Tests Added + Pass?      | N/A
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | N
| License                  | Apache License, Version 2.0

Hides the `pretitle` field in the `Teaser` dialog (V1 & V2) if the `pretitleHidden` property is set to `true` on the teaser policy.
