### PR TITLE
[LinkHandler] General improvements + add non-exported interface (#1863)

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
@@ -46,7 +46,6 @@ import com.adobe.cq.wcm.core.components.util.ComponentUtils;
 import com.day.cq.commons.DownloadResource;
 import com.day.cq.commons.ImageResource;
 import com.day.cq.wcm.api.Page;
-import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.Template;
 import com.day.cq.wcm.api.designer.Designer;
 import com.day.cq.wcm.api.designer.Style;
@@ -323,7 +322,7 @@ public class Utils {
 
         if (imageFromPageImage) {
             Resource inheritedResource = null;
-            Optional<Link> link = linkHandler.getLink(resource);
+            Optional<Link<Page>> link = linkHandler.getLink(resource);
             boolean actionsEnabled = (currentStyle != null) ?
                     !currentStyle.get(Teaser.PN_ACTIONS_DISABLED, !properties.get(Teaser.PN_ACTIONS_ENABLED, false)) :
                     properties.get(Teaser.PN_ACTIONS_ENABLED, false);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
@@ -32,8 +32,10 @@ import java.util.Optional;
 @ConsumerType
 public interface LinkHandler {
 
+    /**
+     * Page extension.
+     */
     String HTML_EXTENSION = ".html";
-
 
     /**
      * Name of the resource property that for redirecting pages will indicate if original page or redirect target page should be returned.
@@ -50,52 +52,54 @@ public interface LinkHandler {
      * Resolves a link from the properties of the given resource.
      *
      * @param resource Resource
-     * @return {@link Optional} of  {@link Link}
+     * @return {@link Optional} of {@link Link}
      */
     @NotNull
-    Optional<Link> getLink(@NotNull Resource resource);
+    Optional<Link<@Nullable Page>> getLink(@NotNull Resource resource);
 
     /**
      * Resolves a link from the properties of the given resource.
      *
      * @param resource            Resource
      * @param linkURLPropertyName Property name to read link URL from.
-     * @return {@link Optional} of  {@link Link}
+     * @return {@link Optional} of {@link Link}
      */
     @NotNull
-    @SuppressWarnings("rawtypes")
-    Optional<Link> getLink(@NotNull Resource resource, String linkURLPropertyName);
+    Optional<Link<@Nullable Page>> getLink(@NotNull Resource resource, @NotNull String linkURLPropertyName);
 
     /**
      * Builds a link pointing to the given target page.
-     * @param page Target page
      *
-     * @return {@link Optional} of  {@link Link<Page>}
+     * @param page Target page
+     * @return {@link Optional} of {@link Link<Page>}
      */
     @NotNull
-    Optional<Link<Page>> getLink(@Nullable Page page);
+    Optional<Link<@Nullable Page>> getLink(@Nullable Page page);
 
     /**
      * Builds a link with the given Link URL and target.
-     * @param linkURL Link URL
-     * @param target Target
      *
-     * @return {@link Optional} of  {@link Link<Page>}
+     * @param linkURL Link URL
+     * @param target  Target
+     * @return {@link Optional} of {@link Link<Page>}
      */
     @NotNull
-    Optional<Link<Page>> getLink(@Nullable String linkURL, @Nullable String target);
+    Optional<Link<@Nullable Page>> getLink(@Nullable String linkURL, @Nullable String target);
 
     /**
      * Builds a link with the given Link URL, target, accessibility label, title.
-     * @param linkURL Link URL
-     * @param target Target
-     * @param linkAccessibilityLabel Link Accessibility Label
-     * @param linkTitleAttribute Link Title Attribute
      *
-     * @return {@link Optional} of  {@link Link<Page>}
+     * @param linkURL                Link URL
+     * @param target                 Target
+     * @param linkAccessibilityLabel Link Accessibility Label
+     * @param linkTitleAttribute     Link Title Attribute
+     * @return {@link Optional} of {@link Link<Page>}
      */
     @NotNull
-    Optional<Link<Page>> getLink(@Nullable String linkURL, @Nullable String target, @Nullable String linkAccessibilityLabel, @Nullable String linkTitleAttribute);
+    Optional<Link<@Nullable Page>> getLink(@Nullable String linkURL,
+                                           @Nullable String target,
+                                           @Nullable String linkAccessibilityLabel,
+                                           @Nullable String linkTitleAttribute);
 
     /**
      * Attempts to resolve the redirect chain starting from the given page, avoiding loops.
@@ -106,5 +110,5 @@ public interface LinkHandler {
      * part of the pair (the {@link String} redirect target).
      */
     @NotNull
-    Pair<Page, String> resolveRedirects(@Nullable final Page page);
+    Pair<@Nullable Page, @Nullable String> resolveRedirects(@Nullable final Page page);
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
@@ -1,0 +1,110 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.link;
+
+import com.adobe.cq.wcm.core.components.commons.link.Link;
+import com.day.cq.wcm.api.Page;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ConsumerType;
+
+import java.util.Optional;
+
+/**
+ * interface for resolving and validating links from model's resources.
+ * This is implemented as Sling model that can be injected into other models using the <code>@Self</code> annotation.
+ */
+@ConsumerType
+public interface LinkHandler {
+
+    String HTML_EXTENSION = ".html";
+
+
+    /**
+     * Name of the resource property that for redirecting pages will indicate if original page or redirect target page should be returned.
+     * Default is `false`. If `true` - original page is returned. If `false` or not configured - redirect target page.
+     */
+    String PN_DISABLE_SHADOWING = "disableShadowing";
+
+    /**
+     * Flag indicating if shadowing is disabled.
+     */
+    boolean PROP_DISABLE_SHADOWING_DEFAULT = false;
+
+    /**
+     * Resolves a link from the properties of the given resource.
+     *
+     * @param resource Resource
+     * @return {@link Optional} of  {@link Link}
+     */
+    @NotNull
+    Optional<Link> getLink(@NotNull Resource resource);
+
+    /**
+     * Resolves a link from the properties of the given resource.
+     *
+     * @param resource            Resource
+     * @param linkURLPropertyName Property name to read link URL from.
+     * @return {@link Optional} of  {@link Link}
+     */
+    @NotNull
+    @SuppressWarnings("rawtypes")
+    Optional<Link> getLink(@NotNull Resource resource, String linkURLPropertyName);
+
+    /**
+     * Builds a link pointing to the given target page.
+     * @param page Target page
+     *
+     * @return {@link Optional} of  {@link Link<Page>}
+     */
+    @NotNull
+    Optional<Link<Page>> getLink(@Nullable Page page);
+
+    /**
+     * Builds a link with the given Link URL and target.
+     * @param linkURL Link URL
+     * @param target Target
+     *
+     * @return {@link Optional} of  {@link Link<Page>}
+     */
+    @NotNull
+    Optional<Link<Page>> getLink(@Nullable String linkURL, @Nullable String target);
+
+    /**
+     * Builds a link with the given Link URL, target, accessibility label, title.
+     * @param linkURL Link URL
+     * @param target Target
+     * @param linkAccessibilityLabel Link Accessibility Label
+     * @param linkTitleAttribute Link Title Attribute
+     *
+     * @return {@link Optional} of  {@link Link<Page>}
+     */
+    @NotNull
+    Optional<Link<Page>> getLink(@Nullable String linkURL, @Nullable String target, @Nullable String linkAccessibilityLabel, @Nullable String linkTitleAttribute);
+
+    /**
+     * Attempts to resolve the redirect chain starting from the given page, avoiding loops.
+     *
+     * @param page The starting {@link Page}
+     * @return A pair of {@link Page} and {@link String} the redirect chain resolves to. The page can be the original page, if no redirect
+     * target is defined or even {@code null} if the redirect chain does not resolve to a valid page, in this case one should use the right
+     * part of the pair (the {@link String} redirect target).
+     */
+    @NotNull
+    Pair<Page, String> resolveRedirects(@Nullable final Page page);
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImpl.java
@@ -104,16 +104,14 @@ public class LinkHandlerImpl implements LinkHandler {
     private Boolean shadowingDisabled;
 
     @NotNull
-    @SuppressWarnings("rawtypes")
     @Override
-    public Optional<Link> getLink(@NotNull Resource resource) {
+    public Optional<Link<Page>> getLink(@NotNull Resource resource) {
         return getLink(resource, PN_LINK_URL);
     }
 
     @NotNull
-    @SuppressWarnings("rawtypes")
     @Override
-    public Optional<Link> getLink(@NotNull Resource resource, String linkURLPropertyName) {
+    public Optional<Link<Page>> getLink(@NotNull Resource resource, @NotNull String linkURLPropertyName) {
         ValueMap props = resource.getValueMap();
         String linkURL = props.get(linkURLPropertyName, String.class);
         if (linkURL == null) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImpl.java
@@ -59,9 +59,9 @@ import static com.adobe.cq.wcm.core.components.internal.link.LinkImpl.ATTR_TITLE
  * This is a Sling model that can be injected into other models using the <code>@Self</code> annotation.
  */
 @Model(adaptables = SlingHttpServletRequest.class)
-public class LinkHandler {
+public class LinkHandlerImpl {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LinkHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LinkHandlerImpl.class);
 
     public static final String HTML_EXTENSION = ".html";
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImpl.java
@@ -29,15 +29,14 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
-import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
-import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
+import javax.inject.Named;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -58,8 +57,11 @@ import static com.adobe.cq.wcm.core.components.internal.link.LinkImpl.ATTR_TITLE
  * This is a Sling model that can be injected into other models using the <code>@Self</code> annotation.
  */
 @Model(adaptables = SlingHttpServletRequest.class, adapters = {LinkHandler.class})
-public class LinkHandlerImpl implements LinkHandler {
+public final class LinkHandlerImpl implements LinkHandler {
 
+    /**
+     * Default logger.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(LinkHandlerImpl.class);
 
     /**
@@ -72,30 +74,17 @@ public class LinkHandlerImpl implements LinkHandler {
     /**
      * The current {@link SlingHttpServletRequest}.
      */
-    @Self
-    private SlingHttpServletRequest request;
-
-    /**
-     * The current resource properties
-     */
-    @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
-    private ValueMap properties;
+    private final SlingHttpServletRequest request;
 
     /**
      * The current resource style/policies
      */
-    @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
-    private Style currentStyle;
+    private final Style style;
 
     /**
-     * Reference to {@link PageManager}
+     * Registered path processors.
      */
-    @ScriptVariable
-    @org.apache.sling.models.annotations.Optional
-    private PageManager pageManager;
-
-    @OSGiService
-    private List<PathProcessor> pathProcessors;
+    private final List<PathProcessor> pathProcessors;
 
     /**
      * Variable that defines how to handle pages that redirect. Given pages PageA and PageB where PageA redirects to PageB,
@@ -103,75 +92,93 @@ public class LinkHandlerImpl implements LinkHandler {
      */
     private Boolean shadowingDisabled;
 
+    /**
+     * Construct a LinkHandler.
+     *
+     * @param slingRequest      The current request.
+     * @param pathProcessorList The list of path processors.
+     * @param currentStyle      The current style.
+     */
+    @Inject
+    public LinkHandlerImpl(@Named("sling-object") @NotNull final SlingHttpServletRequest slingRequest,
+                           @Named("osgi-services") @NotNull final List<PathProcessor> pathProcessorList,
+                           @ScriptVariable(name = "currentStyle") @org.apache.sling.models.annotations.Optional @Nullable final Style currentStyle) {
+        this.request = slingRequest;
+        this.pathProcessors = pathProcessorList;
+        this.style = currentStyle;
+    }
+
     @NotNull
     @Override
-    public Optional<Link<Page>> getLink(@NotNull Resource resource) {
+    public Optional<Link<@Nullable Page>> getLink(@NotNull final Resource resource) {
         return getLink(resource, PN_LINK_URL);
     }
 
     @NotNull
     @Override
-    public Optional<Link<Page>> getLink(@NotNull Resource resource, @NotNull String linkURLPropertyName) {
+    public Optional<Link<@Nullable Page>> getLink(@NotNull final Resource resource,
+                                                  @NotNull final String linkURLPropertyName) {
         ValueMap props = resource.getValueMap();
-        String linkURL = props.get(linkURLPropertyName, String.class);
-        if (linkURL == null) {
-            return Optional.empty();
-        }
-        String linkTarget = props.get(PN_LINK_TARGET, String.class);
-        String linkAccessibilityLabel = props.get(PN_LINK_ACCESSIBILITY_LABEL, String.class);
-        String linkTitleAttribute = props.get(PN_LINK_TITLE_ATTRIBUTE, String.class);
-        return Optional.ofNullable(getLink(linkURL, linkTarget, linkAccessibilityLabel, linkTitleAttribute).orElse(null));
+        return Optional.ofNullable(props.get(linkURLPropertyName, String.class))
+            .flatMap(linkURL -> getLink(
+                linkURL,
+                props.get(PN_LINK_TARGET, String.class),
+                props.get(PN_LINK_ACCESSIBILITY_LABEL, String.class),
+                props.get(PN_LINK_TITLE_ATTRIBUTE, String.class)
+            ));
     }
 
     @NotNull
     @Override
-    public Optional<Link<Page>> getLink(@Nullable Page page) {
-        if (page == null) {
-            return Optional.empty();
-        }
-        Pair<Page, String> pair = resolvePage(page);
-        return buildLink(pair.getRight(), request, pair.getLeft(), null);
+    public Optional<Link<@Nullable Page>> getLink(@Nullable final Page page) {
+        return Optional.ofNullable(page)
+            .map(this::resolvePage)
+            .flatMap(pair -> buildLink(pair.getRight(), pair.getLeft(), null));
     }
 
     @NotNull
     @Override
-    public Optional<Link<Page>> getLink(@Nullable String linkURL, @Nullable String target) {
-        Pair<Page, String> pair = resolvePage(getPage(linkURL).orElse(null));
-        linkURL = StringUtils.isNotEmpty(pair.getRight()) ? pair.getRight() : linkURL;
-        String resolvedLinkURL = validateAndResolveLinkURL(linkURL);
-        String resolvedLinkTarget = validateAndResolveLinkTarget(target);
-        return buildLink(resolvedLinkURL, request, pair.getLeft(),
-                new HashMap<String, String>() {{ put(ATTR_TARGET, resolvedLinkTarget); }});
+    public Optional<Link<@Nullable Page>> getLink(@Nullable final String linkURL, @Nullable final String target) {
+        return this.getLink(linkURL, target, null, null);
     }
 
     @NotNull
     @Override
-    public Optional<Link<Page>> getLink(@Nullable String linkURL, @Nullable String target, @Nullable String linkAccessibilityLabel, @Nullable String linkTitleAttribute) {
-        Pair<Page, String> pair = resolvePage(getPage(linkURL).orElse(null));
-        linkURL = StringUtils.isNotEmpty(pair.getRight()) ? pair.getRight() : linkURL;
-        String resolvedLinkURL = validateAndResolveLinkURL(linkURL);
-        String resolvedLinkTarget = validateAndResolveLinkTarget(target);
-        String validatedLinkAccessibilityLabel = validateLinkAccessibilityLabel(linkAccessibilityLabel);
-        String validatedLinkTitleAttribute = validateLinkTitleAttribute(linkTitleAttribute);
-        return Optional.of(buildLink(resolvedLinkURL, request, pair.getLeft(),
-                new HashMap<String, String>() {{
-                    put(ATTR_TARGET, resolvedLinkTarget);
-                    put(ATTR_ARIA_LABEL, validatedLinkAccessibilityLabel);
-                    put(ATTR_TITLE, validatedLinkTitleAttribute);
-                }}))
-                .orElse(null);
+    public Optional<Link<@Nullable Page>> getLink(@Nullable final String linkURL,
+                                                  @Nullable final String target,
+                                                  @Nullable final String linkAccessibilityLabel,
+                                                  @Nullable final String linkTitleAttribute) {
+        Pair<Page, String> pair = Optional.ofNullable(linkURL)
+            .flatMap(this::getPage)
+            .map(this::resolvePage)
+            .map(p -> ImmutablePair.of(p.getLeft(), validateAndResolveLinkURL(p.getRight())))
+            .orElseGet(() -> ImmutablePair.of(null, validateAndResolveLinkURL(linkURL)));
+
+        return buildLink(pair.getRight(), pair.getLeft(),
+            new HashMap<String, String>() {{
+                put(ATTR_TARGET, validateAndResolveLinkTarget(target));
+                validateLinkAccessibilityLabel(linkAccessibilityLabel).ifPresent((v) -> put(ATTR_ARIA_LABEL, v));
+                validateLinkTitleAttribute(linkTitleAttribute).ifPresent((v) -> put(ATTR_TITLE, v));
+            }});
     }
 
-    private Optional<Link<Page>> buildLink(String path, SlingHttpServletRequest request, Page page,
-                                           Map<String, String> htmlAttributes) {
-        if (StringUtils.isNotEmpty(path)) {
-            return pathProcessors.stream()
-                    .filter(pathProcessor -> pathProcessor.accepts(path, request))
-                    .findFirst().map(pathProcessor -> new LinkImpl<>(pathProcessor.sanitize(path, request), pathProcessor.map(path,
-                            request), pathProcessor.externalize(path, request), page, pathProcessor.processHtmlAttributes(path, htmlAttributes)));
-        } else {
-            return Optional.of(new LinkImpl<>(path, path, path, page, htmlAttributes));
-        }
+    @NotNull
+    private Optional<Link<@Nullable Page>> buildLink(@Nullable final String path,
+                                                     @Nullable final Page page,
+                                                     @Nullable final Map<String, String> htmlAttributes) {
+        return Optional.ofNullable(path)
+            .filter(StringUtils::isNotEmpty)
+            .map(p -> this.pathProcessors.stream()
+                .filter(pathProcessor -> pathProcessor.accepts(p, this.request))
+                .findFirst()
+                .map(pathProcessor -> (Link<Page>) new LinkImpl<>(
+                    pathProcessor.sanitize(p, this.request),
+                    pathProcessor.map(p, this.request),
+                    pathProcessor.externalize(p, this.request),
+                    page,
+                    pathProcessor.processHtmlAttributes(p, htmlAttributes)
+                )))
+            .orElseGet(() -> Optional.of(new LinkImpl<>(path, path, path, page, htmlAttributes)));
     }
 
     /**
@@ -181,81 +188,74 @@ public class LinkHandlerImpl implements LinkHandler {
      * @return The validated link URL or {@code null} if not valid
      */
     @Nullable
-    private String validateAndResolveLinkURL(String linkURL) {
-        if (!StringUtils.isEmpty(linkURL)) {
-            return getLinkURL(linkURL);
-        } else {
-            return null;
-        }
+    private String validateAndResolveLinkURL(@Nullable final String linkURL) {
+        return Optional.ofNullable(linkURL)
+            .filter(StringUtils::isNotEmpty)
+            .map(this::getLinkURL)
+            .orElse(null);
     }
 
     /**
      * Validates and resolves the link target.
-     * @param linkTarget Link target
      *
+     * @param linkTarget Link target
      * @return The validated link target or {@code null} if not valid
      */
-    private String validateAndResolveLinkTarget(String linkTarget) {
-        if (linkTarget != null && VALID_LINK_TARGETS.contains(linkTarget)) {
-            return linkTarget;
-        }
-        else {
-            return null;
-        }
+    @Nullable
+    private static String validateAndResolveLinkTarget(@Nullable final String linkTarget) {
+        return Optional.ofNullable(linkTarget)
+            .filter(VALID_LINK_TARGETS::contains)
+            .orElse(null);
     }
 
     /**
      * Validates the link accessibility label.
-     * @param linkAccessibilityLabel Link accessibility label
      *
-     * @return The validated link accessibility label or {@code null} if not valid
+     * @param linkAccessibilityLabel Link accessibility label
+     * @return The validated link accessibility label or empty if not valid
      */
-    private String validateLinkAccessibilityLabel(String linkAccessibilityLabel) {
-        if (!StringUtils.isBlank(linkAccessibilityLabel)) {
-            return linkAccessibilityLabel.trim();
-        }
-        else {
-            return null;
-        }
+    @NotNull
+    private static Optional<String> validateLinkAccessibilityLabel(@Nullable final String linkAccessibilityLabel) {
+        return Optional.ofNullable(linkAccessibilityLabel)
+            .filter(StringUtils::isNotBlank)
+            .map(String::trim);
     }
 
     /**
      * Validates the link title attribute.
-     * @param linkTitleAttribute Link title attribute
      *
-     * @return The validated link title attribute or {@code null} if not valid
+     * @param linkTitleAttribute Link title attribute
+     * @return The validated link title attribute or empty if not valid
      */
-    private String validateLinkTitleAttribute(String linkTitleAttribute) {
-        if (!StringUtils.isBlank(linkTitleAttribute)) {
-            return linkTitleAttribute.trim();
-        }
-        else {
-            return null;
-        }
+    @NotNull
+    private static Optional<String> validateLinkTitleAttribute(@Nullable final String linkTitleAttribute) {
+        return Optional.ofNullable(linkTitleAttribute)
+            .filter(StringUtils::isNotBlank)
+            .map(String::trim);
     }
 
     /**
      * If the provided {@code path} identifies a {@link Page}, this method will generate the correct URL for the page. Otherwise the
      * original {@code String} is returned.
-     * @param path the page path
      *
+     * @param path the page path
      * @return the URL of the page identified by the provided {@code path}, or the original {@code path} if this doesn't identify a {@link Page}
      */
     @NotNull
-    private String getLinkURL(@NotNull String path) {
+    private String getLinkURL(@NotNull final String path) {
         return getPage(path)
-                .map(this::getPageLinkURL)
-                .orElse(path);
+            .map(LinkHandlerImpl::getPageLinkURL)
+            .orElse(path);
     }
 
     /**
      * Given a {@link Page}, this method returns the correct URL with the extension
-     * @param page the page
      *
+     * @param page the page
      * @return the URL of the provided (@code page}
      */
     @NotNull
-    private String getPageLinkURL(@NotNull Page page) {
+    private static String getPageLinkURL(@NotNull final Page page) {
         return page.getPath() + HTML_EXTENSION;
     }
 
@@ -266,14 +266,10 @@ public class LinkHandlerImpl implements LinkHandler {
      * @return The {@link Page} corresponding to the path
      */
     @NotNull
-    private Optional<Page> getPage(@Nullable String path) {
-        if (pageManager == null) {
-            pageManager = request.getResourceResolver().adaptTo(PageManager.class);
-        }
-        if (pageManager == null) {
-            return Optional.empty();
-        }
-        return Optional.ofNullable(pageManager.getPage(path));
+    private Optional<Page> getPage(@Nullable final String path) {
+        return Optional.ofNullable(path)
+            .flatMap(p -> Optional.ofNullable(this.request.getResourceResolver().adaptTo(PageManager.class))
+                .map(pm -> pm.getPage(p)));
     }
 
     /**
@@ -284,38 +280,25 @@ public class LinkHandlerImpl implements LinkHandler {
      * @return A pair of {@link String} and {@link Page} the page resolves to.
      */
     @NotNull
-    private Pair<Page, String> resolvePage(@Nullable final Page page) {
-        Page resolved = page;
-        String redirectTarget = null;
-        String linkURL = null;
-        if (!isShadowingDisabled()) {
-            Pair<Page, String> pair = resolveRedirects(page);
-            resolved = pair.getLeft();
-            redirectTarget = pair.getRight();
+    private Pair<@Nullable Page, @NotNull String> resolvePage(@NotNull final Page page) {
+        Pair<Page, String> pair = !isShadowingDisabled() ? resolveRedirects(page) : new ImmutablePair<>(page, null);
+        if (pair.getLeft() == null && StringUtils.isNotEmpty(pair.getRight())) {
+            return new ImmutablePair<>(page, pair.getRight());
         }
-        if (resolved == null) {
-            if (StringUtils.isNotEmpty(redirectTarget)) {
-                return new ImmutablePair<>(page, redirectTarget);
-            } else {
-                resolved = page;
-            }
-        }
-        if (resolved != null) {
-            linkURL = getPageLinkURL(resolved);
-        }
-        return new ImmutablePair<>(resolved, linkURL);
+        Page resolved = Optional.ofNullable(pair.getLeft()).orElse(page);
+        return new ImmutablePair<>(resolved, getPageLinkURL(resolved));
     }
 
     @NotNull
     @Override
-    public Pair<Page, String> resolveRedirects(@Nullable final Page page) {
+    public Pair<@Nullable Page, @Nullable String> resolveRedirects(@Nullable final Page page) {
         Page result = page;
         String redirectTarget = null;
-        if (page != null && page.getPageManager() != null) {
+        if (page != null) {
             Set<String> redirectCandidates = new LinkedHashSet<>();
             redirectCandidates.add(page.getPath());
             while (result != null && StringUtils
-                    .isNotEmpty((redirectTarget = result.getProperties().get(PageImpl.PN_REDIRECT_TARGET, String.class)))) {
+                .isNotEmpty((redirectTarget = result.getProperties().get(PageImpl.PN_REDIRECT_TARGET, String.class)))) {
                 result = page.getPageManager().getPage(redirectTarget);
                 if (result != null) {
                     if (!redirectCandidates.add(result.getPath())) {
@@ -334,15 +317,14 @@ public class LinkHandlerImpl implements LinkHandler {
      * @return {@code true} if page shadowing is disabled, {@code false} otherwise
      */
     private boolean isShadowingDisabled() {
-        if (shadowingDisabled == null) {
-            shadowingDisabled = PROP_DISABLE_SHADOWING_DEFAULT;
-            if (currentStyle != null) {
-                shadowingDisabled = currentStyle.get(PN_DISABLE_SHADOWING, shadowingDisabled);
-            }
-            if (properties != null) {
-                shadowingDisabled = properties.get(PN_DISABLE_SHADOWING, shadowingDisabled);
-            }
+        if (this.shadowingDisabled == null) {
+            this.shadowingDisabled = Optional.ofNullable(this.request.getResource().getValueMap().get(PN_DISABLE_SHADOWING, Boolean.class))
+                .orElseGet(() ->
+                    Optional.ofNullable(this.style)
+                        .map(cs -> cs.get(PN_DISABLE_SHADOWING, Boolean.class))
+                        .orElse(PROP_DISABLE_SHADOWING_DEFAULT)
+                );
         }
-        return shadowingDisabled;
+        return this.shadowingDisabled;
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ButtonImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ButtonImpl.java
@@ -21,6 +21,7 @@ import javax.annotation.PostConstruct;
 import javax.inject.Named;
 
 import com.adobe.cq.wcm.core.components.util.AbstractComponentImpl;
+import com.day.cq.wcm.api.Page;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Exporter;
@@ -79,7 +80,7 @@ public class ButtonImpl extends AbstractComponentImpl implements Button {
 
     @Self
     private LinkHandler linkHandler;
-    protected Optional<Link> link;
+    protected Optional<Link<@Nullable Page>> link;
 
     @PostConstruct
     private void initModel() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
@@ -124,7 +124,7 @@ public class ImageImpl extends AbstractComponentImpl implements Image {
     protected int jpegQuality;
     protected String imageName;
     protected Resource fileResource;
-    protected Optional<Link> link;
+    protected Optional<Link<Page>> link;
 
     public ImageImpl() {
         selector = AdaptiveImageServlet.DEFAULT_SELECTOR;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PanelContainerItemImpl.java
@@ -17,7 +17,6 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.Optional;
 
-import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
@@ -18,9 +18,11 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 import java.util.Calendar;
 import java.util.Optional;
 
+import com.day.cq.wcm.api.Page;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
@@ -34,7 +36,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 public class ResourceListItemImpl extends AbstractListItemImpl implements ListItem {
 
-    protected Optional<Link> link;
+    /**
+     * The link.
+     */
+    protected Optional<Link<@Nullable Page>> link;
+
     /**
      * The title.
      */

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TitleImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TitleImpl.java
@@ -85,7 +85,7 @@ public class TitleImpl extends AbstractComponentImpl implements Title {
 
     @Self
     private LinkHandler linkHandler;
-    protected Optional<Link> link;
+    protected Optional<Link<@Nullable Page>> link;
 
     /**
      * The {@link com.adobe.cq.wcm.core.components.internal.Heading} object for the type of this title.

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImplTest.java
@@ -15,9 +15,11 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.link;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +33,10 @@ import com.day.cq.wcm.api.Page;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static com.adobe.cq.wcm.core.components.commons.link.Link.*;
+import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_ACCESSIBILITY_LABEL;
+import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_TARGET;
+import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_TITLE_ATTRIBUTE;
+import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_URL;
 import static com.adobe.cq.wcm.core.components.internal.link.LinkTestUtils.assertValidLink;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -41,27 +46,35 @@ class LinkHandlerImplTest {
     private final AemContext context = CoreComponentTestContext.newAemContext();
 
     private Page page;
-    private LinkHandler underTest;
 
     @BeforeEach
     void setUp() {
         page = context.create().page("/content/links/site1/en/");
         context.currentPage(page);
-        underTest = context.request().adaptTo(LinkHandler.class);
+    }
+
+    /**
+     * Get link for the given resource.
+     *
+     * @param linkResource The link resource.
+     * @return The value of {@link LinkHandler#getLink(Resource)}.
+     */
+    private Optional<Link> getLinkUnderTest(@NotNull final Resource linkResource) {
+        this.context.currentResource(linkResource);
+        return Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)).getLink(linkResource);
     }
 
     @Test
     void testResourceEmpty() {
         Resource linkResource = context.create().resource(page, "link");
-        Optional<Link> link = underTest.getLink(linkResource);
-        assertEquals(Optional.empty(), link);
+        assertEquals(Optional.empty(), getLinkUnderTest(linkResource));
     }
 
     @Test
     void testResourceExternalLink() {
         Resource linkResource = context.create().resource(page, "link",
                 PN_LINK_URL, "http://myhost");
-        Optional<Link> link = underTest.getLink(linkResource);
+        Optional<Link> link = getLinkUnderTest(linkResource);
 
         assertValidLink(link.get(), "http://myhost");
         assertNull(link.map(Link::getReference).orElse(null));
@@ -76,7 +89,7 @@ class LinkHandlerImplTest {
                 PN_LINK_TARGET, target,
                 PN_LINK_ACCESSIBILITY_LABEL, "My Host Label",
                 PN_LINK_TITLE_ATTRIBUTE, "My Host Title");
-        Optional<Link> link = underTest.getLink(linkResource);
+        Optional<Link> link = getLinkUnderTest(linkResource);
 
         assertValidLink(link.get(), "http://myhost", "My Host Label", "My Host Title", target);
         assertNull(link.map(Link::getReference).orElse(null));
@@ -88,7 +101,7 @@ class LinkHandlerImplTest {
         Resource linkResource = context.create().resource(page, "link",
                 PN_LINK_URL, "http://myhost",
                 PN_LINK_TARGET, target);
-        Optional<Link> link = underTest.getLink(linkResource);
+        Optional<Link> link = getLinkUnderTest(linkResource);
 
         // invalid target or _self target should be stripped away
         assertValidLink(link.get(), "http://myhost");
@@ -99,7 +112,8 @@ class LinkHandlerImplTest {
     void testResourcePageLink() {
         Resource linkResource = context.create().resource(page, "link",
                 PN_LINK_URL, page.getPath());
-        Optional<Link> link = underTest.getLink(linkResource);
+        Optional<Link> link = getLinkUnderTest(linkResource);
+
         assertValidLink(link.get(), page.getPath() + ".html");
         assertEquals(page, link.map(Link::getReference).orElse(null));
         assertEquals((page.getPath() + ".html").replaceAll("^\\/content\\/links\\/site1\\/(.+)","/content/site1/$1"),
@@ -108,11 +122,11 @@ class LinkHandlerImplTest {
 
     @Test
     void testResourcePageLinkWithNoInjectedPageManager() {
-        Utils.setInternalState(underTest, "pageManager", null);
+        Utils.setInternalState(Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)), "pageManager", null);
         context.request().setContextPath("/core");
         Resource linkResource = context.create().resource(page, "link",
                 PN_LINK_URL, page.getPath());
-        Optional<Link> link = underTest.getLink(linkResource);
+        Optional<Link> link = getLinkUnderTest(linkResource);
 
         // TODO: this link should be handled as invalid. but we keep this behavior for now to keep backwards compatibility
         assertEquals("/core/content/site1/en.html", link.get().getMappedURL());
@@ -122,7 +136,7 @@ class LinkHandlerImplTest {
     @Test
     void testMalformedURLLink() {
         String malformedURL = "https://a:80:b/c";
-        Optional<Link<Page>> link = underTest.getLink("https://a:80:b/c", null);
+        Optional<Link<Page>> link = Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)).getLink("https://a:80:b/c", null);
         assertEquals(malformedURL, link.get().getURL());
     }
 
@@ -130,7 +144,7 @@ class LinkHandlerImplTest {
     void testResourceInvalidPageLink() {
         Resource linkResource = context.create().resource(page, "link",
                 PN_LINK_URL, "/content/non-existing");
-        Optional<Link> link = underTest.getLink(linkResource);
+        Optional<Link> link = getLinkUnderTest(linkResource);
 
         // TODO: this link should be handled as invalid. but we keep this behavior for now to keep backwards compatibility
         assertValidLink(link.get(), "/content/non-existing");
@@ -139,7 +153,7 @@ class LinkHandlerImplTest {
 
     @Test
     void testPageLink() {
-        Optional<Link<Page>> link = underTest.getLink(page);
+        Optional<Link<Page>> link = Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)).getLink(page);
 
         assertValidLink(link.get(), page.getPath() + ".html");
         assertEquals("https://example.org" + page.getPath() + ".html", link.map(Link::getExternalizedURL).orElse(null));
@@ -148,14 +162,14 @@ class LinkHandlerImplTest {
 
     @Test
     void testPageLink_Null() {
-        Optional<Link<Page>> link = underTest.getLink((Page)null);
+        Optional<Link<Page>> link = Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)).getLink((Page)null);
 
         assertFalse(link.isPresent());
     }
 
     @Test
     void testEmptyLink() {
-        Optional<Link<Page>> link = underTest.getLink("", "");
+        Optional<Link<Page>> link = Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)).getLink("", "");
         if (link.isPresent()) {
             assertNull(link.get().getURL());
             assertNull(link.get().getMappedURL());
@@ -168,7 +182,7 @@ class LinkHandlerImplTest {
 
     @Test
     void testLinkURLPageLinkWithTarget() {
-        Optional<Link<Page>> link = underTest.getLink(page.getPath(), "_blank", null, null);
+        Optional<Link<Page>> link = Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)).getLink(page.getPath(), "_blank", null, null);
 
         assertValidLink(link.get(), page.getPath() + ".html", "_blank");
         assertEquals(page, link.map(Link::getReference).orElse(null));

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImplTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
-import com.adobe.cq.wcm.core.components.testing.Utils;
 import com.day.cq.wcm.api.Page;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
@@ -63,7 +62,7 @@ class LinkHandlerImplTest {
      * @param linkResource The link resource.
      * @return The value of {@link LinkHandler#getLink(Resource)}.
      */
-    private Optional<Link> getLinkUnderTest(@NotNull final Resource linkResource) {
+    private Optional<Link<Page>> getLinkUnderTest(@NotNull final Resource linkResource) {
         this.context.currentResource(linkResource);
         return Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)).getLink(linkResource);
     }
@@ -78,8 +77,9 @@ class LinkHandlerImplTest {
     void testResourceExternalLink() {
         Resource linkResource = context.create().resource(page, "link",
             Link.PN_LINK_URL, "http://myhost");
-        Optional<Link> link = getLinkUnderTest(linkResource);
+        Optional<Link<Page>> link = getLinkUnderTest(linkResource);
 
+        assertTrue(link.isPresent());
         assertValidLink(link.get(), "http://myhost");
         assertNull(link.map(Link::getReference).orElse(null));
         assertEquals("http://myhost", link.get().getMappedURL());
@@ -93,8 +93,9 @@ class LinkHandlerImplTest {
             Link.PN_LINK_TARGET, target,
             Link.PN_LINK_ACCESSIBILITY_LABEL, "My Host Label",
             Link.PN_LINK_TITLE_ATTRIBUTE, "My Host Title");
-        Optional<Link> link = getLinkUnderTest(linkResource);
+        Optional<Link<Page>> link = getLinkUnderTest(linkResource);
 
+        assertTrue(link.isPresent());
         assertValidLink(link.get(), "http://myhost", "My Host Label", "My Host Title", target);
         assertNull(link.map(Link::getReference).orElse(null));
     }
@@ -105,9 +106,10 @@ class LinkHandlerImplTest {
         Resource linkResource = context.create().resource(page, "link",
             Link.PN_LINK_URL, "http://myhost",
             Link.PN_LINK_TARGET, target);
-        Optional<Link> link = getLinkUnderTest(linkResource);
+        Optional<Link<Page>> link = getLinkUnderTest(linkResource);
 
         // invalid target or _self target should be stripped away
+        assertTrue(link.isPresent());
         assertValidLink(link.get(), "http://myhost");
         assertNull(link.map(Link::getReference).orElse(null));
     }
@@ -116,7 +118,9 @@ class LinkHandlerImplTest {
     void testResourcePageLink() {
         Resource linkResource = context.create().resource(page, "link",
             Link.PN_LINK_URL, page.getPath());
-        Optional<Link> link = getLinkUnderTest(linkResource);
+        Optional<Link<Page>> link = getLinkUnderTest(linkResource);
+
+        assertTrue(link.isPresent());
         assertValidLink(link.get(), page.getPath() + ".html");
         assertEquals(page, link.map(Link::getReference).orElse(null));
         assertEquals((page.getPath() + ".html").replaceAll("^\\/content\\/links\\/site1\\/(.+)", "/content/site1/$1"),
@@ -124,22 +128,11 @@ class LinkHandlerImplTest {
     }
 
     @Test
-    void testResourcePageLinkWithNoInjectedPageManager() {
-        Utils.setInternalState(Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)), "pageManager", null);
-        context.request().setContextPath("/core");
-        Resource linkResource = context.create().resource(page, "link",
-            Link.PN_LINK_URL, page.getPath());
-        Optional<Link> link = getLinkUnderTest(linkResource);
-
-        // TODO: this link should be handled as invalid. but we keep this behavior for now to keep backwards compatibility
-        assertEquals("/core/content/site1/en.html", link.get().getMappedURL());
-        assertEquals(page, link.map(Link::getReference).orElse(null));
-    }
-
-    @Test
     void testMalformedURLLink() {
         String malformedURL = "https://a:80:b/c";
         Optional<Link<Page>> link = Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)).getLink("https://a:80:b/c", null);
+
+        assertTrue(link.isPresent());
         assertEquals(malformedURL, link.get().getURL());
     }
 
@@ -147,9 +140,10 @@ class LinkHandlerImplTest {
     void testResourceInvalidPageLink() {
         Resource linkResource = context.create().resource(page, "link",
             Link.PN_LINK_URL, "/content/non-existing");
-        Optional<Link> link = getLinkUnderTest(linkResource);
+        Optional<Link<Page>> link = getLinkUnderTest(linkResource);
 
         // TODO: this link should be handled as invalid. but we keep this behavior for now to keep backwards compatibility
+        assertTrue(link.isPresent());
         assertValidLink(link.get(), "/content/non-existing");
         assertNull(link.get().getReference());
     }
@@ -158,6 +152,7 @@ class LinkHandlerImplTest {
     void testPageLink() {
         Optional<Link<Page>> link = Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)).getLink(page);
 
+        assertTrue(link.isPresent());
         assertValidLink(link.get(), page.getPath() + ".html");
         assertEquals("https://example.org" + page.getPath() + ".html", link.map(Link::getExternalizedURL).orElse(null));
         assertEquals(page, link.map(Link::getReference).orElse(null));
@@ -187,6 +182,7 @@ class LinkHandlerImplTest {
     void testLinkURLPageLinkWithTarget() {
         Optional<Link<Page>> link = Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)).getLink(page.getPath(), "_blank", null, null);
 
+        assertTrue(link.isPresent());
         assertValidLink(link.get(), page.getPath() + ".html", "_blank");
         assertEquals(page, link.map(Link::getReference).orElse(null));
     }
@@ -206,7 +202,7 @@ class LinkHandlerImplTest {
 
         // create a link to the first target page
         Resource linkResource = context.create().resource(page, "link", Link.PN_LINK_URL, targetPage1.getPath());
-        Optional<Link> link = getLinkUnderTest(linkResource);
+        Optional<Link<Page>> link = getLinkUnderTest(linkResource);
 
         assertTrue(link.isPresent());
         assertValidLink(link.get(), targetPage2.getPath() + ".html");
@@ -232,7 +228,7 @@ class LinkHandlerImplTest {
             Link.PN_LINK_URL, targetPage1.getPath(),
             LinkHandler.PN_DISABLE_SHADOWING, Boolean.TRUE
         );
-        Optional<Link> link = getLinkUnderTest(linkResource);
+        Optional<Link<Page>> link = getLinkUnderTest(linkResource);
 
         assertTrue(link.isPresent());
         assertValidLink(link.get(), targetPage1.getPath() + ".html");
@@ -261,7 +257,7 @@ class LinkHandlerImplTest {
         this.context.contentPolicyMapping("/placeholder", ImmutableMap.of(
             LinkHandler.PN_DISABLE_SHADOWING, Boolean.TRUE
         ));
-        Optional<Link> link = getLinkUnderTest(linkResource);
+        Optional<Link<Page>> link = getLinkUnderTest(linkResource);
 
         assertTrue(link.isPresent());
         assertValidLink(link.get(), targetPage1.getPath() + ".html");
@@ -287,7 +283,7 @@ class LinkHandlerImplTest {
             Link.PN_LINK_URL, targetPage1.getPath()
         );
 
-        Optional<Link> link = getLinkUnderTest(linkResource);
+        Optional<Link<Page>> link = getLinkUnderTest(linkResource);
 
         assertTrue(link.isPresent());
         assertValidLink(link.get(), "http://myhost");
@@ -312,7 +308,7 @@ class LinkHandlerImplTest {
 
         // create a link to the first target page
         Resource linkResource = context.create().resource(page, "link", Link.PN_LINK_URL, targetPage1.getPath());
-        Optional<Link> link = getLinkUnderTest(linkResource);
+        Optional<Link<Page>> link = getLinkUnderTest(linkResource);
 
         assertTrue(link.isPresent());
         assertEquals(targetPage2, link.get().getReference());

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImplTest.java
@@ -18,8 +18,12 @@ package com.adobe.cq.wcm.core.components.internal.link;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
+import com.adobe.cq.wcm.core.components.internal.models.v2.PageImpl;
+import com.google.common.collect.ImmutableMap;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,12 +37,12 @@ import com.day.cq.wcm.api.Page;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_ACCESSIBILITY_LABEL;
-import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_TARGET;
-import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_TITLE_ATTRIBUTE;
-import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_URL;
 import static com.adobe.cq.wcm.core.components.internal.link.LinkTestUtils.assertValidLink;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @ExtendWith(AemContextExtension.class)
 class LinkHandlerImplTest {
@@ -73,7 +77,7 @@ class LinkHandlerImplTest {
     @Test
     void testResourceExternalLink() {
         Resource linkResource = context.create().resource(page, "link",
-                PN_LINK_URL, "http://myhost");
+            Link.PN_LINK_URL, "http://myhost");
         Optional<Link> link = getLinkUnderTest(linkResource);
 
         assertValidLink(link.get(), "http://myhost");
@@ -85,10 +89,10 @@ class LinkHandlerImplTest {
     @ValueSource(strings = {"_blank", "_parent", "_top"})
     void testResourceExternalLinkWithAllowedTargetsAndAllAttributes(String target) {
         Resource linkResource = context.create().resource(page, "link",
-                PN_LINK_URL, "http://myhost",
-                PN_LINK_TARGET, target,
-                PN_LINK_ACCESSIBILITY_LABEL, "My Host Label",
-                PN_LINK_TITLE_ATTRIBUTE, "My Host Title");
+            Link.PN_LINK_URL, "http://myhost",
+            Link.PN_LINK_TARGET, target,
+            Link.PN_LINK_ACCESSIBILITY_LABEL, "My Host Label",
+            Link.PN_LINK_TITLE_ATTRIBUTE, "My Host Title");
         Optional<Link> link = getLinkUnderTest(linkResource);
 
         assertValidLink(link.get(), "http://myhost", "My Host Label", "My Host Title", target);
@@ -96,11 +100,11 @@ class LinkHandlerImplTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"_self","_invalid"})
+    @ValueSource(strings = {"_self", "_invalid"})
     void testResourceExternalLinkWithInvalidTargets(String target) {
         Resource linkResource = context.create().resource(page, "link",
-                PN_LINK_URL, "http://myhost",
-                PN_LINK_TARGET, target);
+            Link.PN_LINK_URL, "http://myhost",
+            Link.PN_LINK_TARGET, target);
         Optional<Link> link = getLinkUnderTest(linkResource);
 
         // invalid target or _self target should be stripped away
@@ -111,13 +115,12 @@ class LinkHandlerImplTest {
     @Test
     void testResourcePageLink() {
         Resource linkResource = context.create().resource(page, "link",
-                PN_LINK_URL, page.getPath());
+            Link.PN_LINK_URL, page.getPath());
         Optional<Link> link = getLinkUnderTest(linkResource);
-
         assertValidLink(link.get(), page.getPath() + ".html");
         assertEquals(page, link.map(Link::getReference).orElse(null));
-        assertEquals((page.getPath() + ".html").replaceAll("^\\/content\\/links\\/site1\\/(.+)","/content/site1/$1"),
-                link.get().getMappedURL());
+        assertEquals((page.getPath() + ".html").replaceAll("^\\/content\\/links\\/site1\\/(.+)", "/content/site1/$1"),
+            link.get().getMappedURL());
     }
 
     @Test
@@ -125,7 +128,7 @@ class LinkHandlerImplTest {
         Utils.setInternalState(Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)), "pageManager", null);
         context.request().setContextPath("/core");
         Resource linkResource = context.create().resource(page, "link",
-                PN_LINK_URL, page.getPath());
+            Link.PN_LINK_URL, page.getPath());
         Optional<Link> link = getLinkUnderTest(linkResource);
 
         // TODO: this link should be handled as invalid. but we keep this behavior for now to keep backwards compatibility
@@ -143,7 +146,7 @@ class LinkHandlerImplTest {
     @Test
     void testResourceInvalidPageLink() {
         Resource linkResource = context.create().resource(page, "link",
-                PN_LINK_URL, "/content/non-existing");
+            Link.PN_LINK_URL, "/content/non-existing");
         Optional<Link> link = getLinkUnderTest(linkResource);
 
         // TODO: this link should be handled as invalid. but we keep this behavior for now to keep backwards compatibility
@@ -162,7 +165,7 @@ class LinkHandlerImplTest {
 
     @Test
     void testPageLink_Null() {
-        Optional<Link<Page>> link = Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)).getLink((Page)null);
+        Optional<Link<Page>> link = Objects.requireNonNull(context.request().adaptTo(LinkHandler.class)).getLink((Page) null);
 
         assertFalse(link.isPresent());
     }
@@ -186,6 +189,133 @@ class LinkHandlerImplTest {
 
         assertValidLink(link.get(), page.getPath() + ".html", "_blank");
         assertEquals(page, link.map(Link::getReference).orElse(null));
+    }
+
+    /**
+     * Tests a link whose target is a series of redirect pages.
+     * This test confirms that link shadowing resolution functions properly.
+     */
+    @Test
+    void testLinkWithRedirect() {
+        // set up target pages
+        Page targetPage1 = context.create().page(page.getPath() + "/target1");
+        Page targetPage2 = context.create().page(page.getPath() + "/target2");
+
+        // set up redirects
+        Objects.requireNonNull(targetPage1.getContentResource().adaptTo(ModifiableValueMap.class)).put(PageImpl.PN_REDIRECT_TARGET, targetPage2.getPath());
+
+        // create a link to the first target page
+        Resource linkResource = context.create().resource(page, "link", Link.PN_LINK_URL, targetPage1.getPath());
+        Optional<Link> link = getLinkUnderTest(linkResource);
+
+        assertTrue(link.isPresent());
+        assertValidLink(link.get(), targetPage2.getPath() + ".html");
+        assertEquals("https://example.org" + targetPage2.getPath() + ".html", link.map(Link::getExternalizedURL).orElse(null));
+        assertEquals(targetPage2, link.map(Link::getReference).orElse(null));
+    }
+
+    /**
+     * Tests a link whose target is a series of redirect pages - but shadowing is disabled.
+     * This test confirms the ability to disable shadowing by property on the link component.
+     */
+    @Test
+    void testLinkWithRedirect_shadowingDisabledByProperty() {
+        // set up target pages
+        Page targetPage1 = context.create().page(page.getPath() + "/target1");
+        Page targetPage2 = context.create().page(page.getPath() + "/target2");
+
+        // set up redirects
+        Objects.requireNonNull(targetPage1.getContentResource().adaptTo(ModifiableValueMap.class)).put(PageImpl.PN_REDIRECT_TARGET, targetPage2.getPath());
+
+        // create a link to the first target page
+        Resource linkResource = context.create().resource(page, "link",
+            Link.PN_LINK_URL, targetPage1.getPath(),
+            LinkHandler.PN_DISABLE_SHADOWING, Boolean.TRUE
+        );
+        Optional<Link> link = getLinkUnderTest(linkResource);
+
+        assertTrue(link.isPresent());
+        assertValidLink(link.get(), targetPage1.getPath() + ".html");
+        assertEquals("https://example.org" + targetPage1.getPath() + ".html", link.map(Link::getExternalizedURL).orElse(null));
+        assertEquals(targetPage1, link.map(Link::getReference).orElse(null));
+    }
+
+    /**
+     * Tests a link whose target is a series of redirect pages - but shadowing is disabled.
+     * This test confirms the ability to disable shadowing by the style policy.
+     */
+    @Test
+    void testLinkWithRedirect_shadowingDisabledByStyle() {
+        // set up target pages
+        Page targetPage1 = context.create().page(page.getPath() + "/target1");
+        Page targetPage2 = context.create().page(page.getPath() + "/target2");
+
+        // set up redirects
+        Objects.requireNonNull(targetPage1.getContentResource().adaptTo(ModifiableValueMap.class)).put(PageImpl.PN_REDIRECT_TARGET, targetPage2.getPath());
+
+        // create a link to the first target page
+        Resource linkResource = context.create().resource(page, "link",
+            Link.PN_LINK_URL, targetPage1.getPath(),
+            ResourceResolver.PROPERTY_RESOURCE_TYPE, "/placeholder"
+        );
+        this.context.contentPolicyMapping("/placeholder", ImmutableMap.of(
+            LinkHandler.PN_DISABLE_SHADOWING, Boolean.TRUE
+        ));
+        Optional<Link> link = getLinkUnderTest(linkResource);
+
+        assertTrue(link.isPresent());
+        assertValidLink(link.get(), targetPage1.getPath() + ".html");
+        assertEquals("https://example.org" + targetPage1.getPath() + ".html", link.map(Link::getExternalizedURL).orElse(null));
+        assertEquals(targetPage1, link.map(Link::getReference).orElse(null));
+    }
+
+    /**
+     * Tests the ability to resolve a link when the link points to a redirect page that subsequently redirects to
+     * an external site. This external link is discovered during link shadowing resolution, and is thus a different
+     * test than when the link its self points to an external site.
+     */
+    @Test
+    void testLinkWithRedirectToExternal() {
+        // set up target pages
+        Page targetPage1 = context.create().page(page.getPath() + "/target1");
+
+        // set up redirects
+        Objects.requireNonNull(targetPage1.getContentResource().adaptTo(ModifiableValueMap.class)).put(PageImpl.PN_REDIRECT_TARGET, "http://myhost");
+
+        // create a link to the first target page
+        Resource linkResource = context.create().resource(page, "link",
+            Link.PN_LINK_URL, targetPage1.getPath()
+        );
+
+        Optional<Link> link = getLinkUnderTest(linkResource);
+
+        assertTrue(link.isPresent());
+        assertValidLink(link.get(), "http://myhost");
+        assertEquals(targetPage1, link.map(Link::getReference).orElse(null));
+    }
+
+    /**
+     * Tests that link shadowing does not get stuck when the link target page is a redirect loop.
+     */
+    @Test
+    void testLinkWithRedirectLoop() {
+        // create three pages
+        Page targetPage1 = context.create().page(page.getPath() + "/target1");
+        Page targetPage2 = context.create().page(page.getPath() + "/target2");
+        Page targetPage3 = context.create().page(page.getPath() + "/target3");
+
+        // set up a redirect loop. The cycle between two and three is intentional to prevent false
+        // positive test if shadowing becomes disabled.
+        Objects.requireNonNull(targetPage1.getContentResource().adaptTo(ModifiableValueMap.class)).put(PageImpl.PN_REDIRECT_TARGET, targetPage2.getPath());
+        Objects.requireNonNull(targetPage2.getContentResource().adaptTo(ModifiableValueMap.class)).put(PageImpl.PN_REDIRECT_TARGET, targetPage3.getPath());
+        Objects.requireNonNull(targetPage3.getContentResource().adaptTo(ModifiableValueMap.class)).put(PageImpl.PN_REDIRECT_TARGET, targetPage2.getPath());
+
+        // create a link to the first target page
+        Resource linkResource = context.create().resource(page, "link", Link.PN_LINK_URL, targetPage1.getPath());
+        Optional<Link> link = getLinkUnderTest(linkResource);
+
+        assertTrue(link.isPresent());
+        assertEquals(targetPage2, link.get().getReference());
     }
 
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandlerImplTest.java
@@ -36,7 +36,7 @@ import static com.adobe.cq.wcm.core.components.internal.link.LinkTestUtils.asser
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(AemContextExtension.class)
-class LinkHandlerTest {
+class LinkHandlerImplTest {
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImplTest.java
@@ -34,6 +34,7 @@ import com.adobe.cq.export.json.SlingModelFilter;
 import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.internal.link.LinkHandlerImpl;
 import com.adobe.cq.wcm.core.components.models.form.Container;
 import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.foundation.forms.FormStructureHelper;
@@ -88,7 +89,7 @@ public class ContainerImplTest {
                         .collect(Collectors.toList());
             }
         });
-        context.registerAdapter(MockSlingHttpServletRequest.class, LinkHandler.class, new LinkHandler());
+        context.registerAdapter(MockSlingHttpServletRequest.class, LinkHandler.class, new LinkHandlerImpl());
         FormsHelperStubber.createStub();
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/form/ContainerImplTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.servlethelpers.MockRequestDispatcherFactory;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,8 +32,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.adobe.cq.export.json.SlingModelFilter;
 import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandler;
-import com.adobe.cq.wcm.core.components.internal.link.LinkHandlerImpl;
 import com.adobe.cq.wcm.core.components.models.form.Container;
 import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.foundation.forms.FormStructureHelper;
@@ -61,9 +58,6 @@ public class ContainerImplTest {
     @Mock
     private FormStructureHelper formStructureHelper;
 
-    @Mock
-    private MockRequestDispatcherFactory requestDispatcherFactory;
-
     @BeforeEach
     public void setUp() {
         context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, CONTAINING_PAGE);
@@ -89,7 +83,6 @@ public class ContainerImplTest {
                         .collect(Collectors.toList());
             }
         });
-        context.registerAdapter(MockSlingHttpServletRequest.class, LinkHandler.class, new LinkHandlerImpl());
         FormsHelperStubber.createStub();
     }
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1863
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

This pull request is in response to the comments left on PR #1851 . 
Functionally, this is the same PR with the key exception of _not_ exporting the interface.


- `LinkHandler` interface is added (but not exported). The old implementation is renamed to `LinkHandlerImpl`
- Removing the raw `Link` return types from the `LinkHandler` interface, and replacing them with `Link<Page>`
- Updating model implementations that use the `LinkHandler` to be compatible with this change (where required). Other exported interfaces that return a raw `Link` are *not* modified so as to retain backwards compatibility for the time being.
- Adding additional tests for the `LinkHandlerImpl`. Specifically, tests for redirect chains and shadowing. 
- Correcting a testing bug where the resource injected into the `LinkHandlerImpl` is not the correct resource - this issue only surfaces once you start testing the ability to disable redirect shadowing in the link handler.
- Significantly reworking `LinkHandlerImpl` so as to:
  - apply consistent formatting
  - add `@Override` annotations where appropriate
  - add JavaDoc comments to all non-override methods/fields
  - make private methods static where possible
  - Update the `LinkHandlerImpl#getLink(String, String)` method to reduce duplication of code
  - Avoid computing fall-back values before they are needed,

There is one change that might be contentious. The `LinkHandlerImpl` class has been changed from field injection to constructor injection. I understand that constructor injection is not the typical pattern for this project; however, the benefit of this change is that it permits (internally) the direct instantiation of a `LinkHandlerImpl` without having to rely on a model - as long as you can satisfy the constructor requirements.

 In truth, the `LinkHandler` feels more like a service than a model to me, and so using constructor injection allows it to continue functioning as a model for backwards compatibility, but also opens up the possibility (in the future) for creating a `LinkHandlerFactory` service that can provide `LinkHandler`s as a factory service that can be used outside the context of sling models. If constructor injection is used (as it is in this PR) then the link handler _can_ function both ways (i.e. instantiated by the sling model service, or manually by a service). 