### PR TITLE
Use `npm ci` instead of `npm install` (#1865)

### DIFF
--- a/content/pom.xml
+++ b/content/pom.xml
@@ -120,6 +120,9 @@
                         <goals>
                             <goal>npm</goal>
                         </goals>
+                        <configuration>
+                            <arguments>ci</arguments>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>lint</id>

--- a/extensions/amp/content/pom.xml
+++ b/extensions/amp/content/pom.xml
@@ -120,6 +120,9 @@
                         <goals>
                             <goal>npm</goal>
                         </goals>
+                        <configuration>
+                            <arguments>ci</arguments>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>lint</id>

--- a/testing/it/it-content/pom.xml
+++ b/testing/it/it-content/pom.xml
@@ -139,6 +139,9 @@
                         <goals>
                             <goal>npm</goal>
                         </goals>
+                        <configuration>
+                            <arguments>ci</arguments>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>sync pom version to package.json</id>

--- a/testing/it/ui-js/pom.xml
+++ b/testing/it/ui-js/pom.xml
@@ -140,6 +140,9 @@
                         <goals>
                             <goal>npm</goal>
                         </goals>
+                        <configuration>
+                            <arguments>ci</arguments>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>lint</id>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1865 
| Patch: Bug Fix?          | yes
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | N/A
| Documentation Provided   | N/A
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

Updates the `frontend-maven-plugin` configurations to use `npm ci` instead of `npm install` when installing dependencies defined in the `package-lock.json` file to ensure reproducible builds and to validate the integrity of dependencies.

----
refs #1865
