### PR TITLE
CIF-2419: remove ignore65 for seo related integration tests

### DIFF
--- a/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/components/page/v1/Page.java
+++ b/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/components/page/v1/Page.java
@@ -28,6 +28,7 @@ import com.adobe.cq.testing.selenium.pagewidgets.cq.tabs.AdvancedTab;
 import com.adobe.cq.testing.selenium.pagewidgets.cq.tabs.ThumbnailTab;
 import com.adobe.cq.wcm.core.components.it.seljup.constant.CoreComponentConstants;
 import com.adobe.cq.wcm.core.components.it.seljup.util.Commons;
+import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.WebDriverRunner;
 
@@ -184,8 +185,14 @@ public class Page {
     }
 
     public void setRobotsTags(String... values) {
-        CoralSelect selectList = new CoralSelect(robotsTags);
-        CoralSelectList coralSelectList = selectList.openSelectList();
+        Selenide.$("[" + robotsTags + "] > button").click();
+        CoralSelectList coralSelectList = new CoralSelectList(Selenide.$("[" + robotsTags + "]"));
+
+        if (!coralSelectList.isVisible()) {
+            CoralSelect selectList = new CoralSelect(robotsTags);
+            coralSelectList = selectList.openSelectList();
+        }
+
         for (String value : values) {
             coralSelectList.selectByValue(value);
         }

--- a/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/page/v2/PageIT.java
+++ b/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/page/v2/PageIT.java
@@ -138,7 +138,6 @@ public class PageIT extends AdminBaseUITest {
      * Test: Check the Advanced Seo options of a page properties
      * @throws InterruptedException
      */
-    @Tag("IgnoreOn65")
     @Tag("IgnoreOn64")
     @Test
     @DisplayName("Test: Check the Advanced SEO options of a page properties.")

--- a/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/page/v3/PageIT.java
+++ b/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/page/v3/PageIT.java
@@ -138,7 +138,6 @@ public class PageIT extends AdminBaseUITest {
      * Test: Check the Advanced Seo options of a page properties
      * @throws InterruptedException
      */
-    @Tag("IgnoreOn65")
     @Tag("IgnoreOn64")
     @Test
     @DisplayName("Test: Check the Advanced SEO options of a page properties.")

--- a/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/SeoIT.java
+++ b/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/SeoIT.java
@@ -109,7 +109,7 @@ public class SeoIT {
     }
 
     @Test
-    @Category({IgnoreOn64.class, IgnoreOn65.class})
+    @Category({IgnoreOn64.class})
     public void testRobotsTagRenderedToPage() throws ClientException {
         String content = publish.doGet("/content/core-components/seo-site/gb/en/child.html", 200).getContent();
         MatcherAssert.assertThat(content, CoreMatchers.not(CoreMatchers.containsString("<meta name=\"robots\"")));
@@ -118,7 +118,7 @@ public class SeoIT {
     }
 
     @Test
-    @Category({IgnoreOn64.class, IgnoreOn65.class})
+    @Category({IgnoreOn64.class})
     public void testCanonicalLinkRenderedToPage() throws ClientException {
         String content = publish.doGet("/content/core-components/seo-site/gb/en/child.html", 200).getContent();
         MatcherAssert.assertThat(content, CoreMatchers.containsString(
@@ -126,7 +126,7 @@ public class SeoIT {
     }
 
     @Test
-    @Category({IgnoreOn64.class, IgnoreOn65.class})
+    @Category({IgnoreOn64.class})
     public void testLanguageAlternatesRenderedToPage() throws ClientException {
         String content = publish.doGet("/content/core-components/seo-site/gb/en/child.html", 200).getContent();
         MatcherAssert.assertThat(content, CoreMatchers.not(CoreMatchers.containsString(
@@ -138,7 +138,7 @@ public class SeoIT {
     }
 
     @Test
-    @Category({IgnoreOn64.class, IgnoreOn65.class})
+    @Category({IgnoreOn64.class})
     public void testSitemapAndSitemapIndexGeneration() throws ClientException, InterruptedException, TimeoutException {
         try {
             publish.setPageProperty("/content/core-components/seo-site/gb/en", "sling:sitemapRoot", "true", HttpStatus.SC_OK);


### PR DESCRIPTION
This PR enables the SEO related integration tests for 6.5. It is part of the initiative to back port the feature to one of the next service packs.
