### PR TITLE
GH-1880 - [Page] Load all clienlibs with async

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/v1/templates/clientlib.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/v1/templates/clientlib.html
@@ -1,0 +1,38 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2021 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<!--/*
+    Template used for including CSS client libraries
+*/-->
+<template data-sly-template.css="${@ categories='Client Library categories', media='media attribute, String'}"
+          data-sly-use.clientlib="${'com.adobe.cq.wcm.core.components.models.ClientLibraries' @ categories=categories, media=media}">
+    ${clientlib.cssIncludes @ context="unsafe"}
+</template>
+
+<!--/*
+    Template used for including JS client libraries
+*/-->
+<template data-sly-template.js="${@ categories='Client Library categories', async='async attribute, boolean', defer='defer attribute, boolean', crossorigin='crossorigin attribute, String', onload='onload attribute, String'}"
+          data-sly-use.clientlib="${'com.adobe.cq.wcm.core.components.models.ClientLibraries' @ categories=categories, async=async, defer=defer, crossorigin=crossorigin, onload=onload}">
+    ${clientlib.jsIncludes @ context="unsafe"}
+</template>
+
+<!--/*
+    Template used for including ALL client libraries
+*/-->
+<template data-sly-template.all="${@ categories='Client Library categories', media='media attribute, String', async='async attribute, boolean', defer='defer attribute, boolean', crossorigin='crossorigin attribute, String', onload='onload attribute, String'}"
+          data-sly-use.clientlib="${'com.adobe.cq.wcm.core.components.models.ClientLibraries' @ categories=categories, media=media, async=async, defer=defer, crossorigin=crossorigin, onload=onload}">
+    ${clientlib.jsAndCssIncludes @ context="unsafe"}
+</template>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/body.skiptomaincontent.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/body.skiptomaincontent.html
@@ -16,7 +16,7 @@
 
 <div class="cmp-page__skiptomaincontent"
      data-sly-use.page="com.adobe.cq.wcm.core.components.models.Page"
-     data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
+     data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html"
      data-sly-test="${page.mainContentSelector}">
     <a class="cmp-page__skiptomaincontent-link"
        href="#${page.mainContentSelector}">${'Skip to main content' @ i18n}</a>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/body.socialmedia_begin.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/body.socialmedia_begin.html
@@ -15,5 +15,5 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div id="fb-root" data-sly-use.socialMedia="com.adobe.cq.wcm.core.components.models.SocialMediaHelper"
      data-sly-test.facebookSharing="${socialMedia.hasFacebookSharing}"
-     data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"></div>
-<sly data-sly-call="${clientlib.js @ categories='core.wcm.components.page.v2.sharing'}" data-sly-test="${facebookSharing}"></sly>
+     data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html"></div>
+<sly data-sly-call="${clientlib.js @ categories='core.wcm.components.page.v2.sharing', async=true}" data-sly-test="${facebookSharing}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/footer.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/footer.html
@@ -14,9 +14,9 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <template data-sly-template.footer="${ @ page, pwa }">
-    <sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
+    <sly data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html"
          data-sly-test.clientlibCategoriesJsBody="${page.clientLibCategoriesJsBody}"
-         data-sly-call="${clientlib.js @ categories=clientlibCategoriesJsBody}"></sly>
+         data-sly-call="${clientlib.js @ categories=clientlibCategoriesJsBody, async=true}"></sly>
     <sly data-sly-include="customfooterlibs.html"></sly>
     <sly data-sly-resource="${'cloudservices' @ resourceType='cq/cloudserviceconfigs/components/servicecomponents'}"></sly>
     <sly data-sly-test="${page.hasCloudconfigSupport}" data-sly-resource="${'cloudconfig-footer' @ resourceType='cq/cloudconfig/components/scripttags/footer'}"></sly>
@@ -25,6 +25,6 @@
     </sly>
     <sly data-sly-test="${pwa.enabled}">
         <div class="cmp-page__toastmessagehide"></div>
-        <sly data-sly-call="${clientlib.js @ categories='core.wcm.components.page.v2.pwa'}"></sly>
+        <sly data-sly-call="${clientlib.js @ categories='core.wcm.components.page.v2.pwa', async=true}"></sly>
     </sly>
 </template>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/head.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/head.html
@@ -28,7 +28,7 @@
         <link rel="manifest" href="${pwa.manifestPath}" crossorigin="use-credentials"/>
         <meta name="theme-color" content="${pwa.themeColor}"/>
         <link rel="apple-touch-icon" href="${pwa.iconPath}"/>
-        <sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"
+        <sly data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html"
              data-sly-call="${clientlib.css @ categories='core.wcm.components.page.v2.pwa'}"></sly>
         <meta name="cq:sw_path" content="${pwa.serviceWorkerPath @ context ='text'}"/>
     </sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/headlibs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/headlibs.html
@@ -14,18 +14,18 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <template data-sly-template.headlibs="${@ page, designPath, staticDesignPath, clientLibCategories, clientLibCategoriesJsHead, hasCloudconfigSupport}"
-          data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
+          data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html">
     <sly data-sly-test="${!wcmmode.disabled}" data-sly-call="${clientlib.all @ categories = [
         'cq.pagetypes.html5page',
         'cq.authoring.page',
         'cq.wcm.foundation-main',
         'cq.shared'
-        ]
-    }"></sly>
+        ],
+        async=true}"></sly>
     <sly data-sly-include="/libs/cq/cloudserviceconfigs/components/servicelibs/servicelibs.jsp"></sly>
     <sly data-sly-test="${hasCloudconfigSupport}" data-sly-resource="${'cloudconfig-header' @ resourceType='cq/cloudconfig/components/scripttags/header'}"></sly>
-    <sly data-sly-test="${clientLibCategoriesJsHead}" data-sly-call="${clientlib.js @ categories=clientLibCategoriesJsHead}"></sly>
+    <sly data-sly-test="${clientLibCategoriesJsHead}" data-sly-call="${clientlib.js @ categories=clientLibCategoriesJsHead, async=true}"></sly>
     <sly data-sly-test="${clientLibCategories}" data-sly-call="${clientlib.css @ categories=clientLibCategories}"></sly>
     <link data-sly-test="${staticDesignPath}" href="${staticDesignPath}" rel="stylesheet" type="text/css" />
-    <sly data-sly-test="${page.data}" data-sly-use.clientlibs="${'com.adobe.cq.wcm.core.components.models.ClientLibraries' @ categories='core.wcm.components.commons.datalayer.v1', async=true}">${clientlibs.jsIncludes @ context="unsafe"}</sly>
+    <sly data-sly-test="${page.data}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.v1', async=true}"></sly>
 </template>

--- a/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/ClientlibsIncludeIT.java
+++ b/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/ClientlibsIncludeIT.java
@@ -22,6 +22,7 @@ import org.junit.*;
 import org.junit.rules.ErrorCollector;
 
 import com.adobe.cq.testing.client.CQClient;
+import com.adobe.cq.testing.junit.assertion.GraniteAssert;
 import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
 import com.adobe.cq.testing.junit.rules.CQRule;
 
@@ -38,9 +39,8 @@ public class ClientlibsIncludeIT {
 
     private static CQClient adminAuthor;
     private String testPage = "/content/core-components/clientlibs-include-page";
-    private final static String CONTAINER_SCRIPT_ELEMENT = "<script async crossorigin=\"anonymous\" onload=\"console.log()\" src=\"/etc.clientlibs/core/wcm/components/commons/site/clientlibs/container.lc-1197d358a0a463b3e0891f4ed50e4864-lc.min.js\"></script>";
-    private final static String ACCORDION_SCRIPT_ELEMENT = "<script async crossorigin=\"anonymous\" onload=\"console.log()\" src=\"/etc.clientlibs/core/wcm/components/accordion/v1/accordion/clientlibs/site.lc-6f3bc8f71dd02924d06d0dfec1aa0b99-lc.min.js\"></script>";
-    private final static String ACCORDION_LINK_ELEMENT = "<link media=\"print\" rel=\"stylesheet\" href=\"/etc.clientlibs/core/wcm/components/accordion/v1/accordion/clientlibs/site.lc-44a1783be8e88dc73188908af6c38c01-lc.min.css\" type=\"text/css\">";
+    private final static String REGEX_SCRIPT_ELEMENT = "<script async crossorigin=\"anonymous\" onload=\"console.log..\" src=\"/etc.clientlibs/core/wcm/tests/components/clientlibs-include/clientlibs/site..*.min.js\"></script>";
+    private final static String REGEX_LINK_ELEMENT = "<link media=\"print\" rel=\"stylesheet\" href=\"/etc.clientlibs/core/wcm/tests/components/clientlibs-include/clientlibs/site..*.min.css\" type=\"text/css\">";
 
     @BeforeClass
     public static void beforeClass() {
@@ -51,23 +51,21 @@ public class ClientlibsIncludeIT {
     public void testJsInclude() throws ClientException {
         String content = adminAuthor.doGet(testPage + ".includejs.html", 200).getContent();
         Assert.assertFalse("The html should not contain any <link> element", StringUtils.contains("<link ", content));
-        Assert.assertTrue("Incorrect script and/or script attributes", StringUtils.contains(content, CONTAINER_SCRIPT_ELEMENT));
-        Assert.assertTrue("Incorrect script and/or script attributes", StringUtils.contains(content, ACCORDION_SCRIPT_ELEMENT));
+        GraniteAssert.assertRegExFind("Incorrect script and/or script attributes", content, REGEX_SCRIPT_ELEMENT);
     }
 
     @Test
     public void testCssInclude() throws ClientException {
         String content = adminAuthor.doGet(testPage + ".includecss.html", 200).getContent();
         Assert.assertFalse("The html should not contain any <script> element", StringUtils.contains("<script ", content));
-        Assert.assertTrue("Incorrect link and/or link attributes", StringUtils.contains(content, ACCORDION_LINK_ELEMENT));
+        GraniteAssert.assertRegExFind("Incorrect script and/or script attributes", content, REGEX_LINK_ELEMENT);
     }
 
     @Test
     public void testAllInclude() throws ClientException {
         String content = adminAuthor.doGet(testPage + ".includeall.html", 200).getContent();
-        Assert.assertTrue("Incorrect script and/or script attributes", StringUtils.contains(content, CONTAINER_SCRIPT_ELEMENT));
-        Assert.assertTrue("Incorrect script and/or script attributes", StringUtils.contains(content, ACCORDION_SCRIPT_ELEMENT));
-        Assert.assertTrue("Incorrect link and/or link attributes", StringUtils.contains(content, ACCORDION_LINK_ELEMENT));
+        GraniteAssert.assertRegExFind("Incorrect script and/or script attributes", content, REGEX_SCRIPT_ELEMENT);
+        GraniteAssert.assertRegExFind("Incorrect script and/or script attributes", content, REGEX_LINK_ELEMENT);
     }
 
 }

--- a/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/ClientlibsIncludeIT.java
+++ b/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/ClientlibsIncludeIT.java
@@ -1,0 +1,73 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+package com.adobe.cq.wcm.core.components.it.http;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.testing.clients.ClientException;
+import org.junit.*;
+import org.junit.rules.ErrorCollector;
+
+import com.adobe.cq.testing.client.CQClient;
+import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
+import com.adobe.cq.testing.junit.rules.CQRule;
+
+public class ClientlibsIncludeIT {
+
+    @ClassRule
+    public static final CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
+
+    @Rule
+    public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule, cqBaseClassRule.publishRule);
+
+    @Rule
+    public ErrorCollector collector = new ErrorCollector();
+
+    private static CQClient adminAuthor;
+    private String testPage = "/content/core-components/clientlibs-include-page";
+    private final static String CONTAINER_SCRIPT_ELEMENT = "<script async crossorigin=\"anonymous\" onload=\"console.log()\" src=\"/etc.clientlibs/core/wcm/components/commons/site/clientlibs/container.lc-1197d358a0a463b3e0891f4ed50e4864-lc.min.js\"></script>";
+    private final static String ACCORDION_SCRIPT_ELEMENT = "<script async crossorigin=\"anonymous\" onload=\"console.log()\" src=\"/etc.clientlibs/core/wcm/components/accordion/v1/accordion/clientlibs/site.lc-6f3bc8f71dd02924d06d0dfec1aa0b99-lc.min.js\"></script>";
+    private final static String ACCORDION_LINK_ELEMENT = "<link media=\"print\" rel=\"stylesheet\" href=\"/etc.clientlibs/core/wcm/components/accordion/v1/accordion/clientlibs/site.lc-44a1783be8e88dc73188908af6c38c01-lc.min.css\" type=\"text/css\">";
+
+    @BeforeClass
+    public static void beforeClass() {
+        adminAuthor = cqBaseClassRule.authorRule.getAdminClient(CQClient.class);
+    }
+
+    @Test
+    public void testJsInclude() throws ClientException {
+        String content = adminAuthor.doGet(testPage + ".includejs.html", 200).getContent();
+        Assert.assertFalse("The html should not contain any <link> element", StringUtils.contains("<link ", content));
+        Assert.assertTrue("Incorrect script and/or script attributes", StringUtils.contains(content, CONTAINER_SCRIPT_ELEMENT));
+        Assert.assertTrue("Incorrect script and/or script attributes", StringUtils.contains(content, ACCORDION_SCRIPT_ELEMENT));
+    }
+
+    @Test
+    public void testCssInclude() throws ClientException {
+        String content = adminAuthor.doGet(testPage + ".includecss.html", 200).getContent();
+        Assert.assertFalse("The html should not contain any <script> element", StringUtils.contains("<script ", content));
+        Assert.assertTrue("Incorrect link and/or link attributes", StringUtils.contains(content, ACCORDION_LINK_ELEMENT));
+    }
+
+    @Test
+    public void testAllInclude() throws ClientException {
+        String content = adminAuthor.doGet(testPage + ".includeall.html", 200).getContent();
+        Assert.assertTrue("Incorrect script and/or script attributes", StringUtils.contains(content, CONTAINER_SCRIPT_ELEMENT));
+        Assert.assertTrue("Incorrect script and/or script attributes", StringUtils.contains(content, ACCORDION_SCRIPT_ELEMENT));
+        Assert.assertTrue("Incorrect link and/or link attributes", StringUtils.contains(content, ACCORDION_LINK_ELEMENT));
+    }
+
+}

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/.content.xml
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="test-clientlibs-include"/>

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/clientlibs/.content.xml
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/clientlibs/.content.xml
@@ -1,4 +1,5 @@
-<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ~ Copyright 2021 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,14 +13,6 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<!DOCTYPE HTML>
-<html data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html" lang="en">
-<head >
-    <sly data-sly-call="${clientlib.all @ categories = 'core.wcm.components.includetest',
-        media='print', async=true, defer=false, crossorigin='anonymous', onload='console.log()'}"></sly>
-    <title>test page</title>
-</head>
-<body>
-</body>
-</html>
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/clientlibs/site/.content.xml
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/clientlibs/site/.content.xml
@@ -1,4 +1,5 @@
-<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ~ Copyright 2021 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,14 +13,8 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<!DOCTYPE HTML>
-<html data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html" lang="en">
-<head >
-    <sly data-sly-call="${clientlib.all @ categories = 'core.wcm.components.includetest',
-        media='print', async=true, defer=false, crossorigin='anonymous', onload='console.log()'}"></sly>
-    <title>test page</title>
-</head>
-<body>
-</body>
-</html>
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[core.wcm.components.includetest]"/>

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/clientlibs/site/css.txt
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/clientlibs/site/css.txt
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright 2021 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=css
+
+test.less

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/clientlibs/site/css/test.less
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/clientlibs/site/css/test.less
@@ -1,0 +1,19 @@
+/*
+ *  Copyright 2021 Adobe
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+.test {
+    margin: 0;
+}

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/clientlibs/site/js.txt
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/clientlibs/site/js.txt
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright 2021 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=js
+
+test.js

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/clientlibs/site/js/test.js
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/clientlibs/site/js/test.js
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright 2021 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+(function() {
+    "use strict";
+
+    /* eslint-disable no-console */
+    console.log("hello test!");
+
+}());

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includeall.html
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includeall.html
@@ -14,10 +14,11 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <!DOCTYPE HTML>
-<html data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html">
+<html data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html" lang="en">
 <head >
     <sly data-sly-call="${clientlib.all @ categories = 'core.wcm.components.accordion.v1',
         media='print', async=true, defer=false, crossorigin='anonymous', onload='console.log()'}"></sly>
+    <title>test page</title>
 </head>
 <body>
 </body>

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includeall.html
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includeall.html
@@ -1,0 +1,24 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2021 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<!DOCTYPE HTML>
+<html data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html">
+<head >
+    <sly data-sly-call="${clientlib.all @ categories = 'core.wcm.components.accordion.v1',
+        media='print', async=true, defer=false, crossorigin='anonymous', onload='console.log()'}"></sly>
+</head>
+<body>
+</body>
+</html>

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includecss.html
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includecss.html
@@ -16,7 +16,7 @@
 <!DOCTYPE HTML>
 <html data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html" lang="en">
 <head >
-    <sly data-sly-call="${clientlib.css @ categories = 'core.wcm.components.accordion.v1',
+    <sly data-sly-call="${clientlib.css @ categories = 'core.wcm.components.includetest',
         media='print'}"></sly>
     <title>test page</title>
 </head>

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includecss.html
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includecss.html
@@ -1,0 +1,24 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2021 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<!DOCTYPE HTML>
+<html data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html">
+<head >
+    <sly data-sly-call="${clientlib.css @ categories = 'core.wcm.components.accordion.v1',
+        media='print'}"></sly>
+</head>
+<body>
+</body>
+</html>

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includecss.html
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includecss.html
@@ -14,10 +14,11 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <!DOCTYPE HTML>
-<html data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html">
+<html data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html" lang="en">
 <head >
     <sly data-sly-call="${clientlib.css @ categories = 'core.wcm.components.accordion.v1',
         media='print'}"></sly>
+    <title>test page</title>
 </head>
 <body>
 </body>

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includejs.html
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includejs.html
@@ -14,10 +14,11 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <!DOCTYPE HTML>
-<html data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html">
+<html data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html" lang="en">
 <head >
     <sly data-sly-call="${clientlib.js @ categories = 'core.wcm.components.accordion.v1',
         async=true, defer=false, crossorigin='anonymous', onload='console.log()'}"></sly>
+    <title>test page</title>
 </head>
 <body>
 </body>

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includejs.html
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includejs.html
@@ -1,0 +1,24 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2021 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<!DOCTYPE HTML>
+<html data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html">
+<head >
+    <sly data-sly-call="${clientlib.js @ categories = 'core.wcm.components.accordion.v1',
+        async=true, defer=false, crossorigin='anonymous', onload='console.log()'}"></sly>
+</head>
+<body>
+</body>
+</html>

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includejs.html
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/components/clientlibs-include/includejs.html
@@ -16,7 +16,7 @@
 <!DOCTYPE HTML>
 <html data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html" lang="en">
 <head >
-    <sly data-sly-call="${clientlib.js @ categories = 'core.wcm.components.accordion.v1',
+    <sly data-sly-call="${clientlib.js @ categories = 'core.wcm.components.includetest',
         async=true, defer=false, crossorigin='anonymous', onload='console.log()'}"></sly>
     <title>test page</title>
 </head>

--- a/testing/it/ui-js/src/content/jcr_root/content/core-components/clientlibs-include-page/.content.xml
+++ b/testing/it/ui-js/src/content/jcr_root/content/core-components/clientlibs-include-page/.content.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:lastModified="{Date}2021-05-12T13:15:57.599+02:00"
+        cq:lastModifiedBy="admin"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="Test page for clientlibs include"
+        sling:resourceType="core/wcm/tests/components/clientlibs-include">
+    </jcr:content>
+</jcr:root>
+


### PR DESCRIPTION
- introduce a template in commons to include clientlibs with specific attributes (e.g. async, defer, …) based on the `com.adobe.cq.wcm.core.components.models.ClientLibraries` model
- page v3: use this template to include all the client libraries
- page v3: include the JS libraries with the `async` attribute

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1880 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | No
| Documentation Provided   | No
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0
