### PR TITLE
#1882 [Teaser] Teaser description inherited from page properties needs to be HTML-escaped

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImpl.java
@@ -56,6 +56,7 @@ import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.components.Component;
 import com.day.cq.wcm.api.designer.Style;
+import com.day.text.Text;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -366,7 +367,12 @@ public class TeaserImpl extends AbstractImageDelegatingModel implements Teaser {
     public String getDescription() {
         if (this.description == null && !this.descriptionHidden) {
             if (this.descriptionFromPage) {
-                this.description = this.getTargetPage().map(Page::getDescription).orElse(null);
+                this.description = this.getTargetPage()
+                        .map(Page::getDescription)
+                        // page properties uses a plain text field - which may contain special chars that need to be escaped in HTML
+                        // because the resulting description from the teaser is expected to be HTML produced by the RTE editor
+                        .map(Text::escapeXml)
+                        .orElse(null);
             } else {
                 this.description = this.resource.getValueMap().get(JcrConstants.JCR_DESCRIPTION, String.class);
             }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/TeaserImplTest.java
@@ -134,7 +134,8 @@ public class TeaserImplTest {
     protected void testPageInheritedProperties() {
         Teaser teaser = getTeaserUnderTest(TEASER_6);
         assertEquals("Teasers Test", teaser.getTitle());
-        assertEquals("Teasers description", teaser.getDescription());
+        // < and > are expected escaped, because the page properties provide only a plain text field for the page description
+        assertEquals("Teasers description from &lt;page properties&gt;", teaser.getDescription());
     }
 
     @Test
@@ -208,7 +209,8 @@ public class TeaserImplTest {
         assertTrue(teaser.isActionsEnabled(), "Expected teaser with actions");
         assertEquals(2, teaser.getActions().size(), "Expected to find two Actions");
         assertEquals("Teasers Test", teaser.getTitle());
-        assertEquals("Teasers description", teaser.getDescription());
+        // < and > are expected escaped, because the page properties provide only a plain text field for the page description
+        assertEquals("Teasers description from &lt;page properties&gt;", teaser.getDescription());
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(testBase, "teaser11"));
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImplTest.java
@@ -51,7 +51,8 @@ public class TeaserImplTest extends com.adobe.cq.wcm.core.components.internal.mo
         assertTrue(teaser.isActionsEnabled(), "Expected teaser with actions");
         assertEquals(2, teaser.getActions().size(), "Expected to find two Actions");
         assertEquals("Teasers Test", teaser.getTitle());
-        assertEquals("Teasers description", teaser.getDescription());
+        // < and > are expected escaped, because the page properties provide only a plain text field for the page description
+        assertEquals("Teasers description from &lt;page properties&gt;", teaser.getDescription());
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(testBase, "teaser11"));
     }
 

--- a/bundles/core/src/test/resources/teaser/exporter-teaser11.json
+++ b/bundles/core/src/test/resources/teaser/exporter-teaser11.json
@@ -1,6 +1,6 @@
 {
   "title": "Teasers Test",
-  "description": "Teasers description",
+  "description": "Teasers description from &lt;page properties&gt;",
   "linkURL": "/core/content/teasers.html",
   "actionsEnabled": true,
   "imageLinkHidden": false,
@@ -38,7 +38,7 @@
   "dataLayer": {
     "teaser-84f85e5d32": {
       "xdm:linkURL": "/core/content/teasers.html",
-      "dc:description": "Teasers description",
+      "dc:description": "Teasers description from &lt;page properties&gt;",
       "@type": "core/wcm/components/teaser/v1/teaser",
       "dc:title": "Teasers Test"
     }

--- a/bundles/core/src/test/resources/teaser/test-content.json
+++ b/bundles/core/src/test/resources/teaser/test-content.json
@@ -5,7 +5,7 @@
             "jcr:primaryType"   : "cq:PageContent",
             "jcr:title"         : "Teasers Test",
             "sling:resourceType": "core/wcm/components/page/v2/page",
-            "jcr:description"   : "Teasers description",
+            "jcr:description"   : "Teasers description from <page properties>",
             "root"              : {
                 "jcr:primaryType"   : "nt:unstructured",
                 "sling:resourceType": "wcm/foundation/components/responsivegrid",

--- a/bundles/core/src/test/resources/teaser/v2/exporter-teaser11.json
+++ b/bundles/core/src/test/resources/teaser/v2/exporter-teaser11.json
@@ -1,6 +1,6 @@
 {
   "title": "Teasers Test",
-  "description": "Teasers description",
+  "description": "Teasers description from &lt;page properties&gt;",
   "link": {
     "valid": true,
     "url": "/core/content/teasers.html"
@@ -47,7 +47,7 @@
   "dataLayer": {
     "teaser-84f85e5d32": {
       "xdm:linkURL": "/core/content/teasers.html",
-      "dc:description": "Teasers description",
+      "dc:description": "Teasers description from &lt;page properties&gt;",
       "@type": "core/wcm/components/teaser/v2/teaser",
       "dc:title": "Teasers Test"
     }

--- a/bundles/core/src/test/resources/teaser/v2/test-content.json
+++ b/bundles/core/src/test/resources/teaser/v2/test-content.json
@@ -5,7 +5,7 @@
       "jcr:primaryType"   : "cq:PageContent",
       "jcr:title"         : "Teasers Test",
       "sling:resourceType": "core/wcm/components/page/v2/page",
-      "jcr:description"   : "Teasers description",
+      "jcr:description"   : "Teasers description from <page properties>",
       "cq:featuredimage"    : {
         "jcr:primaryType"   : "nt:unstructured",
         "jcr:createdBy"     : "admin",


### PR DESCRIPTION
Fixes #1882 

It would be nicer to use StringEscapeUtils.escapeHtml, but this method is deprecated in commons-lang, and common-text is not shipped by default in AEM.