### PR TITLE
 Check for react router default hash in location.hash checks

### DIFF
--- a/content/package-lock.json
+++ b/content/package-lock.json
@@ -3055,8 +3055,7 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -3077,14 +3076,12 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -3099,20 +3096,17 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -3229,14 +3223,12 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -3251,7 +3243,6 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -3259,14 +3250,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -3285,7 +3274,6 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3366,8 +3354,7 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3379,7 +3366,6 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3465,8 +3451,7 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3502,7 +3487,6 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3522,7 +3506,6 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3566,14 +3549,12 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 }
             }
         },

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ******************************************************************************/
-(function() {
+(function () {
     "use strict";
 
     var dataLayerEnabled;
@@ -31,28 +31,28 @@
         ARROW_LEFT: 37,
         ARROW_UP: 38,
         ARROW_RIGHT: 39,
-        ARROW_DOWN: 40
+        ARROW_DOWN: 40,
     };
 
     var selectors = {
-        self: "[data-" + NS + '-is="' + IS + '"]'
+        self: "[data-" + NS + '-is="' + IS + '"]',
     };
 
     var cssClasses = {
         button: {
             disabled: "cmp-accordion__button--disabled",
-            expanded: "cmp-accordion__button--expanded"
+            expanded: "cmp-accordion__button--expanded",
         },
         panel: {
             hidden: "cmp-accordion__panel--hidden",
-            expanded: "cmp-accordion__panel--expanded"
-        }
+            expanded: "cmp-accordion__panel--expanded",
+        },
     };
 
     var dataAttributes = {
         item: {
-            expanded: "data-cmp-expanded"
-        }
+            expanded: "data-cmp-expanded",
+        },
     };
 
     var properties = {
@@ -64,12 +64,12 @@
          * @type {Boolean}
          * @default false
          */
-        "singleExpansion": {
-            "default": false,
-            "transform": function(value) {
+        singleExpansion: {
+            default: false,
+            transform: function (value) {
                 return !(value === null || typeof value === "undefined");
-            }
-        }
+            },
+        },
     };
 
     /**
@@ -111,13 +111,28 @@
 
             if (that._elements["item"]) {
                 // ensures multiple element types are arrays.
-                that._elements["item"] = Array.isArray(that._elements["item"]) ? that._elements["item"] : [that._elements["item"]];
-                that._elements["button"] = Array.isArray(that._elements["button"]) ? that._elements["button"] : [that._elements["button"]];
-                that._elements["panel"] = Array.isArray(that._elements["panel"]) ? that._elements["panel"] : [that._elements["panel"]];
+                that._elements["item"] = Array.isArray(that._elements["item"])
+                    ? that._elements["item"]
+                    : [that._elements["item"]];
+                that._elements["button"] = Array.isArray(
+                    that._elements["button"]
+                )
+                    ? that._elements["button"]
+                    : [that._elements["button"]];
+                that._elements["panel"] = Array.isArray(that._elements["panel"])
+                    ? that._elements["panel"]
+                    : [that._elements["panel"]];
 
                 // Expand the item based on deep-link-id if it matches with any existing accordion item id
-                var deepLinkItem = window.CQ.CoreComponents.container.utils.getDeepLinkItem(that, "item");
-                if (deepLinkItem && !deepLinkItem.hasAttribute(dataAttributes.item.expanded)) {
+                var deepLinkItem =
+                    window.CQ.CoreComponents.container.utils.getDeepLinkItem(
+                        that,
+                        "item"
+                    );
+                if (
+                    deepLinkItem &&
+                    !deepLinkItem.hasAttribute(dataAttributes.item.expanded)
+                ) {
                     setItemExpanded(deepLinkItem, true);
                 }
 
@@ -136,10 +151,22 @@
                     } else {
                         // Deep link case
                         // Collapse the items other than which is deep linked
-                        for (var j = 0; j < that._elements["item"].length; j++) {
-                            if (that._elements["item"][j].id !== deepLinkItem.id &&
-                                that._elements["item"][j].hasAttribute(dataAttributes.item.expanded)) {
-                                setItemExpanded(that._elements["item"][j], false);
+                        for (
+                            var j = 0;
+                            j < that._elements["item"].length;
+                            j++
+                        ) {
+                            if (
+                                that._elements["item"][j].id !==
+                                    deepLinkItem.id &&
+                                that._elements["item"][j].hasAttribute(
+                                    dataAttributes.item.expanded
+                                )
+                            ) {
+                                setItemExpanded(
+                                    that._elements["item"][j],
+                                    false
+                                );
                             }
                         }
                     }
@@ -148,27 +175,48 @@
                 refreshItems();
                 bindEvents();
 
-                if (window.Granite && window.Granite.author && window.Granite.author.MessageChannel) {
+                if (
+                    window.Granite &&
+                    window.Granite.author &&
+                    window.Granite.author.MessageChannel
+                ) {
                     /*
                      * Editor message handling:
                      * - subscribe to "cmp.panelcontainer" message requests sent by the editor frame
                      * - check that the message data panel container type is correct and that the id (path) matches this specific Accordion component
                      * - if so, route the "navigate" operation to enact a navigation of the Accordion based on index data
                      */
-                    window.CQ.CoreComponents.MESSAGE_CHANNEL = window.CQ.CoreComponents.MESSAGE_CHANNEL || new window.Granite.author.MessageChannel("cqauthor", window);
-                    window.CQ.CoreComponents.MESSAGE_CHANNEL.subscribeRequestMessage("cmp.panelcontainer", function(message) {
-                        if (message.data && message.data.type === "cmp-accordion" && message.data.id === that._elements.self.dataset["cmpPanelcontainerId"]) {
-                            if (message.data.operation === "navigate") {
-                                // switch to single expansion mode when navigating in edit mode.
-                                var singleExpansion = that._properties.singleExpansion;
-                                that._properties.singleExpansion = true;
-                                toggle(message.data.index);
+                    window.CQ.CoreComponents.MESSAGE_CHANNEL =
+                        window.CQ.CoreComponents.MESSAGE_CHANNEL ||
+                        new window.Granite.author.MessageChannel(
+                            "cqauthor",
+                            window
+                        );
+                    window.CQ.CoreComponents.MESSAGE_CHANNEL.subscribeRequestMessage(
+                        "cmp.panelcontainer",
+                        function (message) {
+                            if (
+                                message.data &&
+                                message.data.type === "cmp-accordion" &&
+                                message.data.id ===
+                                    that._elements.self.dataset[
+                                        "cmpPanelcontainerId"
+                                    ]
+                            ) {
+                                if (message.data.operation === "navigate") {
+                                    // switch to single expansion mode when navigating in edit mode.
+                                    var singleExpansion =
+                                        that._properties.singleExpansion;
+                                    that._properties.singleExpansion = true;
+                                    toggle(message.data.index);
 
-                                // revert to the configured state.
-                                that._properties.singleExpansion = singleExpansion;
+                                    // revert to the configured state.
+                                    that._properties.singleExpansion =
+                                        singleExpansion;
+                                }
                             }
                         }
-                    });
+                    );
                 }
             }
         }
@@ -182,13 +230,18 @@
         function cacheElements(wrapper) {
             that._elements = {};
             that._elements.self = wrapper;
-            var hooks = that._elements.self.querySelectorAll("[data-" + NS + "-hook-" + IS + "]");
+            var hooks = that._elements.self.querySelectorAll(
+                "[data-" + NS + "-hook-" + IS + "]"
+            );
 
             for (var i = 0; i < hooks.length; i++) {
                 var hook = hooks[i];
-                if (hook.closest("." + NS + "-" + IS) === that._elements.self) { // only process own accordion elements
+                if (hook.closest("." + NS + "-" + IS) === that._elements.self) {
+                    // only process own accordion elements
                     var capitalized = IS;
-                    capitalized = capitalized.charAt(0).toUpperCase() + capitalized.slice(1);
+                    capitalized =
+                        capitalized.charAt(0).toUpperCase() +
+                        capitalized.slice(1);
                     var key = hook.dataset[NS + "Hook" + capitalized];
                     if (that._elements[key]) {
                         if (!Array.isArray(that._elements[key])) {
@@ -221,7 +274,10 @@
                         value = options[key];
 
                         // transform the provided option
-                        if (property && typeof property.transform === "function") {
+                        if (
+                            property &&
+                            typeof property.transform === "function"
+                        ) {
                             value = property.transform(value);
                         }
                     }
@@ -245,14 +301,17 @@
             var buttons = that._elements["button"];
             if (buttons) {
                 for (var i = 0; i < buttons.length; i++) {
-                    (function(index) {
-                        buttons[i].addEventListener("click", function(event) {
+                    (function (index) {
+                        buttons[i].addEventListener("click", function (event) {
                             toggle(index);
                             focusButton(index);
                         });
-                        buttons[i].addEventListener("keydown", function(event) {
-                            onButtonKeyDown(event, index);
-                        });
+                        buttons[i].addEventListener(
+                            "keydown",
+                            function (event) {
+                                onButtonKeyDown(event, index);
+                            }
+                        );
                     })(i);
                 }
             }
@@ -315,9 +374,14 @@
                     // ensure only a single item is expanded if single expansion is enabled.
                     for (var i = 0; i < that._elements["item"].length; i++) {
                         if (that._elements["item"][i] !== item) {
-                            var expanded = getItemExpanded(that._elements["item"][i]);
+                            var expanded = getItemExpanded(
+                                that._elements["item"][i]
+                            );
                             if (expanded) {
-                                setItemExpanded(that._elements["item"][i], false);
+                                setItemExpanded(
+                                    that._elements["item"][i],
+                                    false
+                                );
                             }
                         }
                     }
@@ -328,16 +392,19 @@
 
                 if (dataLayerEnabled) {
                     var accordionId = that._elements.self.id;
-                    var expandedItems = getExpandedItems()
-                        .map(function(item) {
-                            return getDataLayerId(item);
-                        });
+                    var expandedItems = getExpandedItems().map(function (item) {
+                        return getDataLayerId(item);
+                    });
 
                     var uploadPayload = { component: {} };
-                    uploadPayload.component[accordionId] = { shownItems: expandedItems };
+                    uploadPayload.component[accordionId] = {
+                        shownItems: expandedItems,
+                    };
 
                     var removePayload = { component: {} };
-                    removePayload.component[accordionId] = { shownItems: undefined };
+                    removePayload.component[accordionId] = {
+                        shownItems: undefined,
+                    };
 
                     dataLayer.push(removePayload);
                     dataLayer.push(uploadPayload);
@@ -359,19 +426,18 @@
                     dataLayer.push({
                         event: "cmp:show",
                         eventInfo: {
-                            path: "component." + getDataLayerId(item)
-                        }
+                            path: "component." + getDataLayerId(item),
+                        },
                     });
                 }
-
             } else {
                 item.removeAttribute(dataAttributes.item.expanded);
                 if (dataLayerEnabled) {
                     dataLayer.push({
                         event: "cmp:hide",
                         eventInfo: {
-                            path: "component." + getDataLayerId(item)
-                        }
+                            path: "component." + getDataLayerId(item),
+                        },
                     });
                 }
             }
@@ -386,7 +452,11 @@
          * @returns {Boolean} true if the item is expanded, false otherwise
          */
         function getItemExpanded(item) {
-            return item && item.dataset && item.dataset["cmpExpanded"] !== undefined;
+            return (
+                item &&
+                item.dataset &&
+                item.dataset["cmpExpanded"] !== undefined
+            );
         }
 
         /**
@@ -450,7 +520,7 @@
                 button.classList.add(cssClasses.button.expanded);
                 // used to fix some known screen readers issues in reading the correct state of the 'aria-expanded' attribute
                 // e.g. https://bugs.webkit.org/show_bug.cgi?id=210934
-                setTimeout(function() {
+                setTimeout(function () {
                     button.setAttribute("aria-expanded", true);
                 }, delay);
                 panel.classList.add(cssClasses.panel.expanded);
@@ -481,7 +551,7 @@
                 button.removeAttribute("aria-disabled");
                 // used to fix some known screen readers issues in reading the correct state of the 'aria-expanded' attribute
                 // e.g. https://bugs.webkit.org/show_bug.cgi?id=210934
-                setTimeout(function() {
+                setTimeout(function () {
                     button.setAttribute("aria-expanded", false);
                 }, delay);
                 panel.classList.add(cssClasses.panel.hidden);
@@ -507,11 +577,18 @@
        and displays its content.
      */
     function onHashChange() {
-        if (location.hash && location.hash !== "#") {
+        // Issue #1661 add check for '#/' to handle SPA routing
+        if (location.hash && location.hash !== "#" && location.hash !== "#/") {
             var anchorLocation = decodeURIComponent(location.hash);
             var anchorElement = document.querySelector(anchorLocation);
-            if (anchorElement && anchorElement.classList.contains("cmp-accordion__item") && !anchorElement.hasAttribute("data-cmp-expanded")) {
-                var anchorElementButton = document.querySelector(anchorLocation + "-button");
+            if (
+                anchorElement &&
+                anchorElement.classList.contains("cmp-accordion__item") &&
+                !anchorElement.hasAttribute("data-cmp-expanded")
+            ) {
+                var anchorElementButton = document.querySelector(
+                    anchorLocation + "-button"
+                );
                 if (anchorElementButton) {
                     anchorElementButton.click();
                 }
@@ -530,7 +607,8 @@
         var data = element.dataset;
         var options = [];
         var capitalized = IS;
-        capitalized = capitalized.charAt(0).toUpperCase() + capitalized.slice(1);
+        capitalized =
+            capitalized.charAt(0).toUpperCase() + capitalized.slice(1);
         var reserved = ["is", "hook" + capitalized];
 
         for (var key in data) {
@@ -572,26 +650,41 @@
      * @private
      */
     function onDocumentReady() {
-        dataLayerEnabled = document.body.hasAttribute("data-cmp-data-layer-enabled");
-        dataLayer = (dataLayerEnabled) ? window.adobeDataLayer = window.adobeDataLayer || [] : undefined;
+        dataLayerEnabled = document.body.hasAttribute(
+            "data-cmp-data-layer-enabled"
+        );
+        dataLayer = dataLayerEnabled
+            ? (window.adobeDataLayer = window.adobeDataLayer || [])
+            : undefined;
 
         var elements = document.querySelectorAll(selectors.self);
         for (var i = 0; i < elements.length; i++) {
-            new Accordion({ element: elements[i], options: readData(elements[i]) });
+            new Accordion({
+                element: elements[i],
+                options: readData(elements[i]),
+            });
         }
 
-        var MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
+        var MutationObserver =
+            window.MutationObserver ||
+            window.WebKitMutationObserver ||
+            window.MozMutationObserver;
         var body = document.querySelector("body");
-        var observer = new MutationObserver(function(mutations) {
-            mutations.forEach(function(mutation) {
+        var observer = new MutationObserver(function (mutations) {
+            mutations.forEach(function (mutation) {
                 // needed for IE
                 var nodesArray = [].slice.call(mutation.addedNodes);
                 if (nodesArray.length > 0) {
-                    nodesArray.forEach(function(addedNode) {
+                    nodesArray.forEach(function (addedNode) {
                         if (addedNode.querySelectorAll) {
-                            var elementsArray = [].slice.call(addedNode.querySelectorAll(selectors.self));
-                            elementsArray.forEach(function(element) {
-                                new Accordion({ element: element, options: readData(element) });
+                            var elementsArray = [].slice.call(
+                                addedNode.querySelectorAll(selectors.self)
+                            );
+                            elementsArray.forEach(function (element) {
+                                new Accordion({
+                                    element: element,
+                                    options: readData(element),
+                                });
                             });
                         }
                     });
@@ -602,7 +695,7 @@
         observer.observe(body, {
             subtree: true,
             childList: true,
-            characterData: true
+            characterData: true,
         });
     }
 
@@ -612,7 +705,10 @@
         document.addEventListener("DOMContentLoaded", onDocumentReady);
     }
 
-    window.addEventListener("load", window.CQ.CoreComponents.container.utils.scrollToAnchor, false);
+    window.addEventListener(
+        "load",
+        window.CQ.CoreComponents.container.utils.scrollToAnchor,
+        false
+    );
     window.addEventListener("hashchange", onHashChange, false);
-
-}());
+})();

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/site/clientlibs/container/js/containerUtils.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/site/clientlibs/container/js/containerUtils.js
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ******************************************************************************/
-(function() {
+(function () {
     "use strict";
 
     window.CQ = window.CQ || {};
     window.CQ.CoreComponents = window.CQ.CoreComponents || {};
-    window.CQ.CoreComponents.container = window.CQ.CoreComponents.container || {};
+    window.CQ.CoreComponents.container =
+        window.CQ.CoreComponents.container || {};
     window.CQ.CoreComponents.container.utils = {};
 
     /**
@@ -29,7 +30,6 @@
      * @type {{}}
      */
     window.CQ.CoreComponents.container.utils = {
-
         /**
          * Returns index of the container component item (accordion, tabs) that corresponds to the deep link in the URL fragment.
          *
@@ -37,15 +37,27 @@
          * @param {String} itemType The type of the item as defined in the component.
          * @returns {Number} the index within the items array if the item exists, -1 otherwise.
          */
-        getDeepLinkItemIdx: function(component, itemType) {
+        getDeepLinkItemIdx: function (component, itemType) {
             if (window.location.hash) {
                 var deepLinkId = window.location.hash.substring(1);
-                if (document.getElementById(deepLinkId) &&
-                    deepLinkId && component &&
-                    component._config && component._config.element && component._config.element.id &&
-                    component._elements && component._elements[itemType] &&
-                    deepLinkId.indexOf(component._config.element.id + "-item-") === 0) {
-                    for (var i = 0; i < component._elements[itemType].length; i++) {
+                if (
+                    document.getElementById(deepLinkId) &&
+                    deepLinkId &&
+                    component &&
+                    component._config &&
+                    component._config.element &&
+                    component._config.element.id &&
+                    component._elements &&
+                    component._elements[itemType] &&
+                    deepLinkId.indexOf(
+                        component._config.element.id + "-item-"
+                    ) === 0
+                ) {
+                    for (
+                        var i = 0;
+                        i < component._elements[itemType].length;
+                        i++
+                    ) {
                         var item = component._elements[itemType][i];
                         if (item.id === deepLinkId) {
                             return i;
@@ -63,9 +75,17 @@
          * @param {String} itemType The type of the item as defined in the component.
          * @returns {Object} the item if it exists, undefined otherwise.
          */
-        getDeepLinkItem: function(component, itemType) {
-            var idx = window.CQ.CoreComponents.container.utils.getDeepLinkItemIdx(component, itemType);
-            if (component && component._elements && component._elements[itemType]) {
+        getDeepLinkItem: function (component, itemType) {
+            var idx =
+                window.CQ.CoreComponents.container.utils.getDeepLinkItemIdx(
+                    component,
+                    itemType
+                );
+            if (
+                component &&
+                component._elements &&
+                component._elements[itemType]
+            ) {
                 return component._elements[itemType][idx];
             }
         },
@@ -77,9 +97,14 @@
            to the element that corresponds to the deep link in the URI fragment.
          * Small setTimeout is needed, otherwise the scrolling will not work on Chrome.
          */
-        scrollToAnchor: function() {
-            setTimeout(function() {
-                if (location.hash && location.hash !== "#") {
+        scrollToAnchor: function () {
+            setTimeout(function () {
+                // Issue #1661 add check for '#/' to handle SPA routing
+                if (
+                    location.hash &&
+                    location.hash !== "#" &&
+                    location.hash !== "#/"
+                ) {
                     var anchorLocation = decodeURIComponent(location.hash);
                     var anchorElement = document.querySelector(anchorLocation);
                     if (anchorElement && anchorElement.offsetTop) {
@@ -87,6 +112,6 @@
                     }
                 }
             }, 100);
-        }
+        },
     };
-}());
+})();

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
@@ -16,7 +16,7 @@
 /* global
     CQ
  */
-(function() {
+(function () {
     "use strict";
 
     var dataLayerEnabled;
@@ -31,15 +31,15 @@
         ARROW_LEFT: 37,
         ARROW_UP: 38,
         ARROW_RIGHT: 39,
-        ARROW_DOWN: 40
+        ARROW_DOWN: 40,
     };
 
     var selectors = {
         self: "[data-" + NS + '-is="' + IS + '"]',
         active: {
             tab: "cmp-tabs__tab--active",
-            tabpanel: "cmp-tabs__tabpanel--active"
-        }
+            tabpanel: "cmp-tabs__tabpanel--active",
+        },
     };
 
     /**
@@ -85,29 +85,55 @@
             }
 
             // Show the tab based on deep-link-id if it matches with any existing tab item id
-            var deepLinkItemIdx = CQ.CoreComponents.container.utils.getDeepLinkItemIdx(that, "tab");
+            var deepLinkItemIdx =
+                CQ.CoreComponents.container.utils.getDeepLinkItemIdx(
+                    that,
+                    "tab"
+                );
             if (deepLinkItemIdx && deepLinkItemIdx !== -1) {
                 var deepLinkItem = that._elements["tab"][deepLinkItemIdx];
-                if (deepLinkItem && that._elements["tab"][that._active].id !== deepLinkItem.id) {
+                if (
+                    deepLinkItem &&
+                    that._elements["tab"][that._active].id !== deepLinkItem.id
+                ) {
                     navigateAndFocusTab(deepLinkItemIdx);
                 }
             }
 
-            if (window.Granite && window.Granite.author && window.Granite.author.MessageChannel) {
+            if (
+                window.Granite &&
+                window.Granite.author &&
+                window.Granite.author.MessageChannel
+            ) {
                 /*
                  * Editor message handling:
                  * - subscribe to "cmp.panelcontainer" message requests sent by the editor frame
                  * - check that the message data panel container type is correct and that the id (path) matches this specific Tabs component
                  * - if so, route the "navigate" operation to enact a navigation of the Tabs based on index data
                  */
-                CQ.CoreComponents.MESSAGE_CHANNEL = CQ.CoreComponents.MESSAGE_CHANNEL || new window.Granite.author.MessageChannel("cqauthor", window);
-                CQ.CoreComponents.MESSAGE_CHANNEL.subscribeRequestMessage("cmp.panelcontainer", function(message) {
-                    if (message.data && message.data.type === "cmp-tabs" && message.data.id === that._elements.self.dataset["cmpPanelcontainerId"]) {
-                        if (message.data.operation === "navigate") {
-                            navigate(message.data.index);
+                CQ.CoreComponents.MESSAGE_CHANNEL =
+                    CQ.CoreComponents.MESSAGE_CHANNEL ||
+                    new window.Granite.author.MessageChannel(
+                        "cqauthor",
+                        window
+                    );
+                CQ.CoreComponents.MESSAGE_CHANNEL.subscribeRequestMessage(
+                    "cmp.panelcontainer",
+                    function (message) {
+                        if (
+                            message.data &&
+                            message.data.type === "cmp-tabs" &&
+                            message.data.id ===
+                                that._elements.self.dataset[
+                                    "cmpPanelcontainerId"
+                                ]
+                        ) {
+                            if (message.data.operation === "navigate") {
+                                navigate(message.data.index);
+                            }
                         }
                     }
-                });
+                );
             }
         }
 
@@ -137,13 +163,18 @@
         function cacheElements(wrapper) {
             that._elements = {};
             that._elements.self = wrapper;
-            var hooks = that._elements.self.querySelectorAll("[data-" + NS + "-hook-" + IS + "]");
+            var hooks = that._elements.self.querySelectorAll(
+                "[data-" + NS + "-hook-" + IS + "]"
+            );
 
             for (var i = 0; i < hooks.length; i++) {
                 var hook = hooks[i];
-                if (hook.closest("." + NS + "-" + IS) === that._elements.self) { // only process own tab elements
+                if (hook.closest("." + NS + "-" + IS) === that._elements.self) {
+                    // only process own tab elements
                     var capitalized = IS;
-                    capitalized = capitalized.charAt(0).toUpperCase() + capitalized.slice(1);
+                    capitalized =
+                        capitalized.charAt(0).toUpperCase() +
+                        capitalized.slice(1);
                     var key = hook.dataset[NS + "Hook" + capitalized];
                     if (that._elements[key]) {
                         if (!Array.isArray(that._elements[key])) {
@@ -167,11 +198,11 @@
             var tabs = that._elements["tab"];
             if (tabs) {
                 for (var i = 0; i < tabs.length; i++) {
-                    (function(index) {
-                        tabs[i].addEventListener("click", function(event) {
+                    (function (index) {
+                        tabs[i].addEventListener("click", function (event) {
                             navigateAndFocusTab(index);
                         });
-                        tabs[i].addEventListener("keydown", function(event) {
+                        tabs[i].addEventListener("keydown", function (event) {
                             onKeyDown(event);
                         });
                     })(i);
@@ -230,13 +261,17 @@
                 if (Array.isArray(tabpanels)) {
                     for (var i = 0; i < tabpanels.length; i++) {
                         if (i === parseInt(that._active)) {
-                            tabpanels[i].classList.add(selectors.active.tabpanel);
+                            tabpanels[i].classList.add(
+                                selectors.active.tabpanel
+                            );
                             tabpanels[i].removeAttribute("aria-hidden");
                             tabs[i].classList.add(selectors.active.tab);
                             tabs[i].setAttribute("aria-selected", true);
                             tabs[i].setAttribute("tabindex", "0");
                         } else {
-                            tabpanels[i].classList.remove(selectors.active.tabpanel);
+                            tabpanels[i].classList.remove(
+                                selectors.active.tabpanel
+                            );
                             tabpanels[i].setAttribute("aria-hidden", true);
                             tabs[i].classList.remove(selectors.active.tab);
                             tabs[i].setAttribute("aria-selected", false);
@@ -286,22 +321,23 @@
             focusWithoutScroll(that._elements["tab"][index]);
 
             if (dataLayerEnabled) {
-
                 var activeItem = getDataLayerId(that._elements.tabpanel[index]);
-                var exActiveItem = getDataLayerId(that._elements.tabpanel[exActive]);
+                var exActiveItem = getDataLayerId(
+                    that._elements.tabpanel[exActive]
+                );
 
                 dataLayer.push({
                     event: "cmp:show",
                     eventInfo: {
-                        path: "component." + activeItem
-                    }
+                        path: "component." + activeItem,
+                    },
                 });
 
                 dataLayer.push({
                     event: "cmp:hide",
                     eventInfo: {
-                        path: "component." + exActiveItem
-                    }
+                        path: "component." + exActiveItem,
+                    },
                 });
 
                 var tabsId = that._elements.self.id;
@@ -322,10 +358,15 @@
        and displays its content.
      */
     function onHashChange() {
-        if (location.hash && location.hash !== "#") {
+        // Issue #1661 add check for '#/' to handle SPA routing
+        if (location.hash && location.hash !== "#" && location.hash !== "#/") {
             var anchorLocation = decodeURIComponent(location.hash);
             var anchorElement = document.querySelector(anchorLocation);
-            if (anchorElement && anchorElement.classList.contains("cmp-tabs__tab") && !anchorElement.classList.contains("cmp-tabs__tab--active")) {
+            if (
+                anchorElement &&
+                anchorElement.classList.contains("cmp-tabs__tab") &&
+                !anchorElement.classList.contains("cmp-tabs__tab--active")
+            ) {
                 anchorElement.click();
             }
         }
@@ -342,7 +383,8 @@
         var data = element.dataset;
         var options = [];
         var capitalized = IS;
-        capitalized = capitalized.charAt(0).toUpperCase() + capitalized.slice(1);
+        capitalized =
+            capitalized.charAt(0).toUpperCase() + capitalized.slice(1);
         var reserved = ["is", "hook" + capitalized];
 
         for (var key in data) {
@@ -384,26 +426,38 @@
      * @private
      */
     function onDocumentReady() {
-        dataLayerEnabled = document.body.hasAttribute("data-cmp-data-layer-enabled");
-        dataLayer = (dataLayerEnabled) ? window.adobeDataLayer = window.adobeDataLayer || [] : undefined;
+        dataLayerEnabled = document.body.hasAttribute(
+            "data-cmp-data-layer-enabled"
+        );
+        dataLayer = dataLayerEnabled
+            ? (window.adobeDataLayer = window.adobeDataLayer || [])
+            : undefined;
 
         var elements = document.querySelectorAll(selectors.self);
         for (var i = 0; i < elements.length; i++) {
             new Tabs({ element: elements[i], options: readData(elements[i]) });
         }
 
-        var MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
+        var MutationObserver =
+            window.MutationObserver ||
+            window.WebKitMutationObserver ||
+            window.MozMutationObserver;
         var body = document.querySelector("body");
-        var observer = new MutationObserver(function(mutations) {
-            mutations.forEach(function(mutation) {
+        var observer = new MutationObserver(function (mutations) {
+            mutations.forEach(function (mutation) {
                 // needed for IE
                 var nodesArray = [].slice.call(mutation.addedNodes);
                 if (nodesArray.length > 0) {
-                    nodesArray.forEach(function(addedNode) {
+                    nodesArray.forEach(function (addedNode) {
                         if (addedNode.querySelectorAll) {
-                            var elementsArray = [].slice.call(addedNode.querySelectorAll(selectors.self));
-                            elementsArray.forEach(function(element) {
-                                new Tabs({ element: element, options: readData(element) });
+                            var elementsArray = [].slice.call(
+                                addedNode.querySelectorAll(selectors.self)
+                            );
+                            elementsArray.forEach(function (element) {
+                                new Tabs({
+                                    element: element,
+                                    options: readData(element),
+                                });
                             });
                         }
                     });
@@ -414,7 +468,7 @@
         observer.observe(body, {
             subtree: true,
             childList: true,
-            characterData: true
+            characterData: true,
         });
     }
 
@@ -424,7 +478,10 @@
         document.addEventListener("DOMContentLoaded", onDocumentReady);
     }
 
-    window.addEventListener("load", window.CQ.CoreComponents.container.utils.scrollToAnchor, false);
+    window.addEventListener(
+        "load",
+        window.CQ.CoreComponents.container.utils.scrollToAnchor,
+        false
+    );
     window.addEventListener("hashchange", onHashChange, false);
-
-}());
+})();

--- a/extensions/amp/content/package-lock.json
+++ b/extensions/amp/content/package-lock.json
@@ -2794,8 +2794,7 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -2816,14 +2815,12 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2838,20 +2835,17 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2968,14 +2962,12 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2990,7 +2982,6 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2998,14 +2989,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -3024,7 +3013,6 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3105,8 +3093,7 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3118,7 +3105,6 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3204,8 +3190,7 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3241,7 +3226,6 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3261,7 +3245,6 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3305,14 +3288,12 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 }
             }
         },

--- a/testing/it/it-content/package-lock.json
+++ b/testing/it/it-content/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "com.adobe.cq.core.wcm.components.it.content",
-  "version": "2.17.9-SNAPSHOT",
+  "version": "2.17.13-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/testing/it/it-content/package.json
+++ b/testing/it/it-content/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.adobe.cq.core.wcm.components.it.content",
-    "version": "2.17.9-SNAPSHOT",
+    "version": "2.17.13-SNAPSHOT",
     "description": "Adobe Experience Manager Core WCM Components IT Content",
     "license": "Apache-2.0",
     "private": false,


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1661 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍 
| Tests Added + Pass?      | N/A
| Documentation Provided   | Yes 
| Any Dependency Changes?  | 👎 
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

Some components (accordion, tabs, componentUtils) check that `location.hash` equals `#`, however in the React Router - the default is `#/`, this is resulting in JS errors when the components try to set the hash.

