### PR TITLE
Cannot mock some models with mockito

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Component.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Component.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ConsumerType;
 
 import com.adobe.cq.export.json.ComponentExporter;
-import com.adobe.cq.wcm.core.components.internal.jackson.ComponentDataModelSerializer;
+import com.adobe.cq.wcm.core.components.models.datalayer.jackson.ComponentDataModelSerializer;
 import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/package-info.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("1.5.0")
+@Version("1.5.1")
 package com.adobe.cq.wcm.core.components.models.contentfragment;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/jackson/ComponentDataModelSerializer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/jackson/ComponentDataModelSerializer.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-package com.adobe.cq.wcm.core.components.internal.jackson;
+package com.adobe.cq.wcm.core.components.models.datalayer.jackson;
 
 import java.io.IOException;
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/jackson/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/jackson/package-info.java
@@ -13,7 +13,11 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("1.1.1")
-package com.adobe.cq.wcm.core.components.models.embeddable;
+/**
+ * This packages provides a jackson specific serializer for component data which is used by the
+ * <a href="https://github.com/adobe/adobe-client-data-layer">Adobe Client Data Layer</a>.
+ */
+@Version("1.0.0")
+package com.adobe.cq.wcm.core.components.models.datalayer.jackson;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/embeddable/Embeddable.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/embeddable/Embeddable.java
@@ -18,7 +18,7 @@ package com.adobe.cq.wcm.core.components.models.embeddable;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ConsumerType;
 
-import com.adobe.cq.wcm.core.components.internal.jackson.ComponentDataModelSerializer;
+import com.adobe.cq.wcm.core.components.models.datalayer.jackson.ComponentDataModelSerializer;
 import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.23.0")
+@Version("12.23.1")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
- move ComponentDataModelSerializer to an exported package as it is used by the Component interface

fixes #1834

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1834 
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
