### PR TITLE
[ContainerUtils] Scroll to anchor logic fails for invalid ID hashes

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/site/clientlibs/container/js/containerUtils.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/site/clientlibs/container/js/containerUtils.js
@@ -79,9 +79,9 @@
          */
         scrollToAnchor: function() {
             setTimeout(function() {
-                if (location.hash && location.hash !== "#") {
-                    var anchorLocation = decodeURIComponent(location.hash);
-                    var anchorElement = document.querySelector(anchorLocation);
+                if (window.location.hash) {
+                    var id = decodeURIComponent(window.location.hash.substring(1));
+                    var anchorElement = document.getElementById(id);
                     if (anchorElement && anchorElement.offsetTop) {
                         anchorElement.scrollIntoView();
                     }


### PR DESCRIPTION
- uses getElementById, which is more forgiving - it returns null if the passed ID is non-conforming to the standard

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1900` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      |
| Documentation Provided   | 
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
