### PR TITLE
Updated Image component DM url creation logic to get rid of the 'imageServerUrl' property dependency generated by DMAssetPostProcessor

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
@@ -176,17 +176,20 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
                         dmImage = true;
                         //check for publish side
                         boolean isWCMDisabled =  (com.day.cq.wcm.api.WCMMode.fromRequest(request) == com.day.cq.wcm.api.WCMMode.DISABLED);
+                        //sets to '/is/image/ or '/is/content' based on dam:scene7Type property
+                        String dmServerPath;
+                        if (asset.getMetadataValue(Scene7Constants.PN_S7_TYPE).equals(Scene7AssetType.ANIMATED_GIF.getValue())) {
+                            dmServerPath = DMAssetPostProcessor.CONTENT_SERVER_PATH;
+                        } else {
+                            dmServerPath = DMAssetPostProcessor.IMAGE_SERVER_PATH;
+                        }
                         String dmServerUrl;
                         // for Author
                         if (!isWCMDisabled) {
-                            if (asset.getMetadataValue(Scene7Constants.PN_S7_TYPE).equals(Scene7AssetType.ANIMATED_GIF.getValue())) {
-                                dmServerUrl = DMAssetPostProcessor.CONTENT_SERVER_PATH;
-                            } else {
-                                dmServerUrl = DMAssetPostProcessor.IMAGE_SERVER_PATH;
-                            }
+                            dmServerUrl = dmServerPath;
                         } else {
                             // for Publish
-                            dmServerUrl = (String) properties.get(PN_IMAGE_SERVER_URL);
+                            dmServerUrl = asset.getMetadataValue(Scene7Constants.PN_S7_DOMAIN) + dmServerPath.substring(1);
                         }
                         dmImageUrl = dmServerUrl + dmAssetName;
                     }


### PR DESCRIPTION
Fixes the Issue mentioned on : https://github.com/adobe/aem-core-wcm-components/issues/1884

"If content is transferred to other AEM environments all those properties might need to be updated because the target environment might be configured to a different DM catalog using a different host name. Additionally, this host name is already stored in each DM asset itself and can just be read from there (also on publish instances)."

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/adobe/aem-core-wcm-components/issues/1884 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
