### PR TITLE
GarageWeek2021 - composable components

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_design_dialog/.content.xml
@@ -81,7 +81,7 @@
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                 fieldLabel="Default Title Type"
-                                name="./titleType"
+                                name="./title/type"
                                 granite:class="foundation-toggleable">
                                 <items jcr:primaryType="nt:unstructured">
                                     <def

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
@@ -142,19 +142,29 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/well">
                                                 <items jcr:primaryType="nt:unstructured">
+                                                    <subComponent
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
+                                                        name="./cq:isSubComponent"
+                                                        value="{Boolean}true"/>
+                                                    <titleResourceType
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
+                                                        name="./title/sling:resourceType"
+                                                        value="core-components-examples/components/title"/>
                                                     <title
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                         fieldDescription="A title to display as the headline for the teaser."
                                                         fieldLabel="Title"
-                                                        name="./jcr:title"
+                                                        name="./title/jcr:title"
                                                         value="${cqDesign._jcr_description}"/>
                                                     <titleType
                                                         granite:hide="${!cqDesign.showTitleType}"
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                                         fieldLabel="Title Type"
-                                                        name="./titleType"
+                                                        name="./title/type"
                                                         granite:class="foundation-toggleable">
                                                         <items jcr:primaryType="nt:unstructured">
                                                             <def

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/title.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/title.html
@@ -14,10 +14,5 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <sly data-sly-template.title="${@ teaser}">
-    <h2 class="cmp-teaser__title" data-sly-test.title="${teaser.title}" data-sly-element="${teaser.titleType}">
-        <a class="cmp-teaser__title-link"
-           data-sly-attribute="${teaser.link.htmlAttributes}"
-           data-sly-unwrap="${!teaser.link.valid || teaser.titleLinkHidden}"
-           data-cmp-clickable="${teaser.data ? true : false}">${title}</a>
-    </h2>
+    <div class="cmp-teaser__title" data-sly-resource="./title"></div>
 </sly>


### PR DESCRIPTION
POC to create composable components (e.g. teaser is built with image, title and text components).
See discussion in #1893 

With this approach:
- each sub component (e.g. title) is stored in a dedicated node e.g. teaser/title
- design and edit dialogs of the aggregate cmp (e.g. teaser) need to use the same prefix and same property names as for the sub component (e.g. title)
- the sub component is identified with a `cq:isSubComponent` property set to `true`

See also other approach in #1906 .
