### PR TITLE
issue #1960 - setting required attribute on childreneditor input field

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/childreneditor/v1/childreneditor/childreneditor.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/childreneditor/v1/childreneditor/childreneditor.html
@@ -26,7 +26,7 @@
                    data-cmp-hook-childreneditor="itemTitle"
                    name="./${item.name}/cq:panelTitle"
                    value="${item.value}"
-                   placeholder="${item.title}">
+                   placeholder="${item.title}" required>
         </div>
     </coral-multifield-item>
     <button data-cmp-hook-childreneditor="add" type="button" is="coral-button">${'Add' @ i18n}</button>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1960 `
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | 👍
| Documentation Provided   | 
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
The coral-multifield-item in the childreneditor (apps/core/wcm/components/commons/editor/dialog/childreneditor/v1/childreneditor/childreneditor.html) doesn't have the required attribute on the input field with class="cmp-childreneditor__item-title".
I described in the issue why I think the input field should be required.

The only code change I did was setting the required attribute on that specific input field.
