### PR TITLE
GH-1966 - [Accessibility] Extend Breadcrumb component with Aria-current attribute for better accessibility

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v3/breadcrumb/breadcrumb.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v3/breadcrumb/breadcrumb.html
@@ -24,6 +24,7 @@
         itemscope itemtype="http://schema.org/BreadcrumbList"
         data-sly-list.navItem="${breadcrumb.items}">
         <li class="cmp-breadcrumb__item${navItem.active ? ' cmp-breadcrumb__item--active' : ''}"
+            aria-current="${navItem.active ? 'page' : false}"
             data-cmp-data-layer="${navItem.data.json}"
             itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
             <a data-sly-attribute="${navItem.link.htmlAttributes}"


### PR DESCRIPTION

- add aria-current="page" for the active breadcrumb item

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1966 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | No
| Documentation Provided   | No
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0


