### PR TITLE
[Release Engineering] Reconsider how we organise our code and cut ourreleases [Release Engineering] Reconsider how we organise our code and cut our releases #1996

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -31,8 +31,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Only release from master branch
-    if: github.ref == 'refs/heads/master'
+    # Only release from `release/...` branch
+    if: startsWith(github.ref, 'refs/head/release/')
     steps:
       # Check out Git repository
       - uses: actions/checkout@v2
@@ -76,4 +76,4 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           X_GITHUB_USERNAME: ${{ secrets.ADOBE_BOT_GITHUB_USERNAME  }}
           X_GITHUB_PASSWORD: ${{ secrets.ADOBE_BOT_GITHUB_PASSWORD }}
-        run: mvn -B -Prelease,cloud,ossrh,adobe-public -s ./.github/workflows/settings.xml clean release:prepare release:perform -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdryRun=${{ github.event.inputs.dryRun }} -Dbaseline.skip=true
+        run: mvn -B -Prelease,cloud,ossrh,adobe-public -s ./.github/workflows/settings.xml clean release:prepare release:perform -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdryRun=${{ github.event.inputs.dryRun }}

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -32,7 +32,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     # Only release from `release/...` branch
-    if: startsWith(github.ref, 'refs/head/release/')
+    if: startsWith(github.ref, 'refs/heads/release/')
     steps:
       # Check out Git repository
       - uses: actions/checkout@v2


### PR DESCRIPTION
Updated release action to allow releasing only from release branches (ie. `release/....`)
