### PR TITLE
[List] wrong title and link when rendering as teasers #2000

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/ListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/ListImpl.java
@@ -49,7 +49,7 @@ public class ListImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     private boolean displayItemAsTeaser;
 
     protected ListItem newPageListItem(@NotNull LinkHandler linkHandler, @NotNull Page page, String parentId, Component component) {
-        return new PageListItemImpl(linkHandler, page, parentId, component, showDescription, linkItems);
+        return new PageListItemImpl(linkHandler, page, parentId, component, showDescription, linkItems || displayItemAsTeaser);
     }
 
     /**

--- a/content/src/content/jcr_root/apps/core/wcm/components/list/v3/list/teaser.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/list/v3/list/teaser.html
@@ -14,5 +14,5 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <template data-sly-template.teaser="${@ item}">
-    <sly  data-sly-resource="${item.teaserResource}"></sly>
+    <sly  data-sly-resource="${item.teaserResource @ wcmmode='disabled'}"></sly>
 </template>


### PR DESCRIPTION
* Always include the link for teaser list items (is needed for inheritance)
* Disable WCM editing for embedded teaser components

Fixes #2000 
