### PR TITLE
[Title V3]: Link input field still visible/active after disabling it in the policy

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v3/title/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v3/title/_cq_dialog/.content.xml
@@ -95,14 +95,10 @@
                                                 </items>
                                             </defaulttypes>
                                             <link
+                                                granite:hide="${cqDesign.linkDisabled}"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/include"
-                                                path="/mnt/overlay/core/wcm/components/commons/editor/dialog/link/v1/link/edit/link">
-                                                <granite:rendercondition
-                                                    jcr:primaryType="nt:unstructured"
-                                                    sling:resourceType="granite/ui/components/foundation/renderconditions/simple"
-                                                    expression="${!cqDesign.linkDisabled}"/>
-                                            </link>
+                                                path="/mnt/overlay/core/wcm/components/commons/editor/dialog/link/v1/link/edit/link"/>
                                             <id
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"


### PR DESCRIPTION
Fixes #2004 
