### PR TITLE
[Title V3] inline editing adds whitespaces in front in dialog input field

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v3/title/title.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v3/title/title.html
@@ -19,10 +19,10 @@
      data-cmp-data-layer="${title.data.json}"
      id="${title.id}"
      class="cmp-title">
-    <h1 class="cmp-title__text" data-sly-element="${title.type}">
-        <a data-sly-unwrap="${!title.link.valid || title.linkDisabled}"
-           class="cmp-title__link"
-           data-sly-attribute="${title.link.htmlAttributes}">${text}</a>
-    </h1>
+    <h1 class="cmp-title__text" data-sly-element="${title.type}"><a
+            data-sly-unwrap="${!title.link.valid || title.linkDisabled}"
+            class="cmp-title__link"
+            data-sly-attribute="${title.link.htmlAttributes}"
+            data-cmp-clickable="${title.data ? true : false}">${text}</a></h1>
 </div>
 <sly data-sly-call="${template.placeholder @ isEmpty=!text, classAppend='cmp-title'}"></sly>


### PR DESCRIPTION
* Updated HTL markup to avoid spaces and new lines as it confuses the inline editor
* Added clickable data attribute back (needed for datalayer integration)

Fixes #2010

