### PR TITLE
Teaser v2 fix for image overlapping link from the title (#2012)

### DIFF
--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/teaser.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/teaser.less
@@ -56,7 +56,6 @@
         position: absolute;
         top: -@cmp-examples-teaser-border-width;
         left: -@cmp-examples-teaser-border-width;
-        bottom: -@cmp-examples-teaser-border-width;
         right: -@cmp-examples-teaser-border-width;
  
         .cmp-image {

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/teaser.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/teaser.less
@@ -54,7 +54,6 @@
         position: absolute;
         top: -@cmp-examples-teaser-border-width;
         left: -@cmp-examples-teaser-border-width;
-        bottom: -@cmp-examples-teaser-border-width;
         right: -@cmp-examples-teaser-border-width;
 
         .cmp-image {


### PR DESCRIPTION
In the teaser v2 removes styling that makes image overlap the title. Due to that issue it was impossible to click on the link in the title of teaser.