### PR TITLE
Fixed the required validation issue on form action dialog

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/clientlibs/editor/js/container.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/clientlibs/editor/js/container.js
@@ -109,16 +109,20 @@
     function setVisibilityAndHandleFieldValidation($element, show) {
         if (show) {
             $element.removeClass("hide");
-            $element.find("input[aria-required=false], coral-multifield[aria-required=false]").
-                filter(":not(.hide>input)").filter(":not(input.hide)").
-                filter(":not(.hide>coral-multifield)").filter(":not(input.coral-multifield)").each(function(index, field) {
-                    toggleValidation($(field));
+
+            if($element.hasClass("action-type-dialog")){
+                $element.find("[aria-required=false]").filter(":not(.hide>*)").each(function(index, field) {
+                    toggleValidation($(field));        
                 });
+            }
         } else {
             $element.addClass("hide");
-            $element.find("input[aria-required=true], coral-multifield[aria-required=true]").each(function(index, field) {
-                toggleValidation($(field));
-            });
+
+            if($element.hasClass("action-type-dialog")){
+                $element.find("[aria-required=true],[required]").each(function(index, field) {
+                   toggleValidation($(field));
+                });
+            }
         }
     }
 
@@ -129,11 +133,13 @@
      */
     function toggleValidation($field) {
         var notRequired = false;
-        if ($field.attr("aria-required") === "true") {
+         if ($field.attr("aria-required") === "true" || $field.attr("required") === "required") {
             notRequired = true;
             $field.attr("aria-required", "false");
+            $field.removeAttr("required");
         } else if ($field.attr("aria-required") === "false") {
             $field.attr("aria-required", "true");
+            $field.attr("required", "required");
         }
         var api = $field.adaptTo("foundation-validation");
         if (api) {


### PR DESCRIPTION
Bug Details

- Create 2-3 form actions with dialog and its property, make sure you have required property on one form dialog

```
Form Action1 -> Dialog (textfield(required), pathfield(required),select(required),checkbox(required))
Form Action2 -> Dialog (textfield, pathfield,select,checkbox)
```

- Now in form Container choose Form Action 2 and try to submit the form. It fails.

Fix Details
Since Form Action2 dialog did not have any required field, it was expected to submit successfully.
So instead of filtering just the input[aria-required=true], coral-multifield[aria-required=true], we need to handle all different types of html tags like select, pathfield, checkbox etc

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Yes https://github.com/adobe/aem-core-wcm-components/issues/2052
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      |
| Documentation Provided   | 
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
