### PR TITLE
Style tab is blank on components without styles / policies

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/_cq_dialog/.content.xml
@@ -163,6 +163,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/_cq_dialog/.content.xml
@@ -95,6 +95,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/button/v1/button/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/button/v1/button/_cq_dialog/.content.xml
@@ -88,6 +88,10 @@
                             </columns>
                         </items>
                     </accessibility>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -168,6 +168,10 @@
                             </columns>
                         </items>
                     </accessibility>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/_cq_dialog/.content.xml
@@ -143,6 +143,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/_cq_dialog/.content.xml
@@ -201,6 +201,10 @@
                             </paragraphControls>
                         </items>
                     </paragraphControls>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/_cq_dialog/.content.xml
@@ -141,6 +141,10 @@
                             </column>
                         </items>
                     </elements>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/_cq_dialog/.content.xml
@@ -263,6 +263,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/_cq_dialog/.content.xml
@@ -172,6 +172,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_dialog/.content.xml
@@ -70,6 +70,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/button/v2/button/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/button/v2/button/_cq_dialog/.content.xml
@@ -104,6 +104,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/_cq_dialog/.content.xml
@@ -122,6 +122,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v2/hidden/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v2/hidden/_cq_dialog/.content.xml
@@ -71,6 +71,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/options/v2/options/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/options/v2/options/_cq_dialog/.content.xml
@@ -230,6 +230,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/text/v1/text/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/text/v1/text/_cq_dialog/.content.xml
@@ -197,6 +197,10 @@
                             </column>
                         </items>
                     </Constraints>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/_cq_dialog/.content.xml
@@ -233,6 +233,10 @@
                             </columns>
                         </items>
                     </constraints>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_dialog/.content.xml
@@ -226,6 +226,10 @@
                             </columns>
                         </items>
                     </metadata>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v1/languagenavigation/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v1/languagenavigation/_cq_dialog/.content.xml
@@ -105,6 +105,10 @@
                             </columns>
                         </items>
                     </accessibility>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/list/v1/list/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/list/v1/list/_cq_dialog/.content.xml
@@ -318,6 +318,10 @@
                             </column>
                         </items>
                     </itemSettings>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/list/v2/list/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/list/v2/list/_cq_dialog/.content.xml
@@ -347,6 +347,10 @@
                             </columns>
                         </items>
                     </itemSettings>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
@@ -135,6 +135,10 @@
                             </columns>
                         </items>
                     </accessibility>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/pdfviewer/v1/pdfviewer/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/pdfviewer/v1/pdfviewer/_cq_dialog/.content.xml
@@ -214,6 +214,10 @@
                             </columns>
                         </items>
                     </customize>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/progressbar/v1/progressbar/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/progressbar/v1/progressbar/_cq_dialog/.content.xml
@@ -69,6 +69,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/_cq_dialog/.content.xml
@@ -67,6 +67,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/_cq_dialog/.content.xml
@@ -60,6 +60,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/sharing/v1/sharing/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/sharing/v1/sharing/_cq_dialog/.content.xml
@@ -60,6 +60,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/_cq_dialog/.content.xml
@@ -135,6 +135,10 @@
                             </columns>
                         </items>
                     </accessibility>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -390,6 +390,10 @@
                             </columns>
                         </items>
                     </actions>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/text/v1/text/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/text/v1/text/_cq_dialog/.content.xml
@@ -180,6 +180,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_dialog/.content.xml
@@ -130,6 +130,10 @@
                             </columns>
                         </items>
                     </properties>
+                    <cq:styles
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
                 </items>
             </tabs>
         </items>


### PR DESCRIPTION
- add styles tab with ns to old components

fixes #2045

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2045 
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
