### PR TITLE
GH-1727 - [Accessibility][Progress Bar][Sample CSS] Background colors…

### DIFF
--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/progressbar.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/progressbar.less
@@ -23,14 +23,14 @@
     font-size: @cmp-examples-font-size-m;
     justify-content: center;
     overflow: hidden;
-    color: @cmp-examples-color-white;
     text-align: center;
     white-space: nowrap;
-    background-color: @cmp-examples-color-gray-700;
+    background-color: @cmp-examples-color-gray-300;
     border-radius: 5*@px;
 
     .cmp-progressbar__label--completed {
         float: left;
+        color: @cmp-examples-color-gray-300;
         padding-left: 5*@px;
         font-weight: bold;
         &:after {
@@ -40,6 +40,7 @@
 
     .cmp-progressbar__label--remaining {
         float: right;
+        color: rgb(46,108,163);
         padding-right: 5*@px;
         &:after {
             content: '%';
@@ -50,6 +51,6 @@
         display: block;
         height: 100%;
         font-size: 0;
-        background-color: rgb(51,122,183);
+        background-color: rgb(46,108,163);
     }
 }

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/progressbar/clientlibs/amp/css/progressbar.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/progressbar/clientlibs/amp/css/progressbar.less
@@ -21,14 +21,14 @@
     font-size: 16px;
     justify-content: center;
     overflow: hidden;
-    color: rgb(255, 255, 255);
     text-align: center;
     white-space: nowrap;
-    background-color: rgb(116, 116, 116);
+    background-color: @cmp-examples-color-gray-300;
     border-radius: 5px;
 
     .cmp-progressbar__label--completed {
         float: left;
+        color: @cmp-examples-color-gray-300;
         padding-left: 5px;
         font-weight: bold;
         &:after {
@@ -38,6 +38,7 @@
 
     .cmp-progressbar__label--remaining {
         float: right;
+        color: rgb(46,108,163);
         padding-right: 5px;
         &:after {
             content: '%';
@@ -48,6 +49,6 @@
         display: block;
         height: 100%;
         font-size: 0;
-        background-color: rgb(51,122,183);
+        background-color: rgb(46,108,163);
     }
 }


### PR DESCRIPTION
… of the progress bar have insufficient color contrast

- use colours and background colours so that the contrast ratio is bigger than 4.5 to be WCAG (accessibility standard) compliant

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1727 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | No
| Documentation Provided   | No
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

**Current vs Updated comparison**

![Screenshot 2022-03-10 at 17 42 31](https://user-images.githubusercontent.com/6152300/157736979-fe1984d7-1a91-4223-876f-66bddbdea865.png)
