### PR TITLE
[Teaser] Image delegation description is not internationalised

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/ImageDelegateRenderCondition.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/ImageDelegateRenderCondition.java
@@ -34,6 +34,7 @@ import com.adobe.cq.wcm.core.components.internal.models.v1.AbstractImageDelegati
 import com.adobe.granite.ui.components.ExpressionCustomizer;
 import com.adobe.granite.ui.components.rendercondition.RenderCondition;
 import com.adobe.granite.ui.components.rendercondition.SimpleRenderCondition;
+import com.day.cq.i18n.I18n;
 import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.api.components.ComponentManager;
 
@@ -48,6 +49,8 @@ import com.day.cq.wcm.api.components.ComponentManager;
 public class ImageDelegateRenderCondition extends SlingSafeMethodsServlet {
 
     public static final String RESOURCE_TYPE = "core/wcm/components/renderconditions/imagedelegate";
+    private static final String IMAGE_DELEGATE_DESCRIPTION = "imageDelegateDescription";
+    private static final String IMAGE_DELEGATE_DESCRIPTION_TEXT = "Image rendering is delegated to the {0} component.";
 
     @Override
     protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response)
@@ -67,8 +70,11 @@ public class ImageDelegateRenderCondition extends SlingSafeMethodsServlet {
                         hasImageDelegation = true;
                         com.day.cq.wcm.api.components.Component delegate = componentManager.getComponent(imageDelegate);
                         if (delegate != null && delegate.isAccessible()) {
+                            I18n i18n = new I18n(request);
                             ExpressionCustomizer customizer = ExpressionCustomizer.from(request);
                             customizer.setVariable(AbstractImageDelegatingModel.IMAGE_DELEGATE, delegate);
+                            customizer.setVariable(IMAGE_DELEGATE_DESCRIPTION, i18n.getVar(IMAGE_DELEGATE_DESCRIPTION_TEXT, null,
+                                    i18n.getVar(delegate.getTitle())));
                         }
                     }
                 }

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_design_dialog/.content.xml
@@ -154,8 +154,7 @@
                                     <text
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/text"
-                                        text="Image rendering is delegated to the ${imageDelegate.title} component.">
-                                    </text>
+                                        text="${imageDelegateDescription}"/>
                                 </items>
                             </imageDelegate>
                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_design_dialog/.content.xml
@@ -130,8 +130,7 @@
                                     <text
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/text"
-                                        text="Image rendering is delegated to the ${imageDelegate.title} component.">
-                                    </text>
+                                        text="${imageDelegateDescription}"/>
                                 </items>
                             </imageDelegate>
                         </items>


### PR DESCRIPTION
- set i18n expression for the image delegation in render condition
- use expression in the design dialog of the teaser component

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2085 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
