### PR TITLE
SITES-1858 [Accessibility][Breadcrumb][Sample CSS] Right chevron icons CSS "content" property value is read by NVDA

### DIFF
--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/base.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/base.less
@@ -28,8 +28,6 @@
 
     .cmp-breadcrumb__item {
         &:after {
-            content: 'chevron_right';
-
             display: inline-block;
             margin: 0 4*@px;
             vertical-align: top;

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/dark.skin.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/dark.skin.less
@@ -14,14 +14,13 @@
  *  limitations under the License.
  */
 
-@cmp-clean-dark-breadcrumb-separator-color: @cmp-clean-color-gray-400;
 @cmp-clean-dark-breadcrumb-item-link-color: @cmp-clean-color-gray-400;
 @cmp-clean-dark-breadcrumb-item-link-hover-color: @cmp-clean-color-gray-100;
 
 .t-cmp-clean--dark {
     .cmp-breadcrumb__item {
         &:after {
-            color: @cmp-clean-dark-breadcrumb-separator-color;
+            content: url("../../../resources/images/chevron_right--dark-skin.svg");
         }
     }
 

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/light.skin.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/breadcrumb/light.skin.less
@@ -14,14 +14,13 @@
  *  limitations under the License.
  */
 
-@cmp-clean-light-breadcrumb-separator-color: @cmp-clean-color-gray-600;
 @cmp-clean-light-breadcrumb-item-link-color: @cmp-clean-color-gray-600;
 @cmp-clean-light-breadcrumb-item-link-hover-color: @cmp-clean-color-gray-900;
 
 .t-cmp-clean--light {
     .cmp-breadcrumb__item {
         &:after {
-            color: @cmp-clean-light-breadcrumb-separator-color;
+            content: url("../../../resources/images/chevron_right--light-skin.svg");
         }
     }
 


### PR DESCRIPTION
Fixes #1672
Uses` content: url(../../../resources/images/...)` CSS property for Component Library ->  Breadcrumb's decorative icons.