### PR TITLE
FIX: Issue 2099 - Prevents Accordion to throw an error when selecting an element by URL hash

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
@@ -506,7 +506,11 @@
      */
     function onHashChange() {
         if (location.hash && location.hash !== "#") {
+            var unvalidSelectorRegex = /^#[0-9]/;
             var anchorLocation = decodeURIComponent(location.hash);
+            if (unvalidSelectorRegex.test(anchorLocation)) {
+                return;
+            }
             var anchorElement = document.querySelector(anchorLocation);
             if (anchorElement && anchorElement.classList.contains("cmp-accordion__item") && !anchorElement.hasAttribute("data-cmp-expanded")) {
                 var anchorElementButton = document.querySelector(anchorLocation + "-button");


### PR DESCRIPTION

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2099  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
I've add a check if the hash starts with a number, if so, it will not go ahead with the `onHashChange` function and will avoid the error on try to select a element with a invalid CSS selector.
