### PR TITLE
[Navigation:V2][Accessibility] Fix improper `aria-current` attribute

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v2/navigation/itemContent.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v2/navigation/itemContent.html
@@ -15,7 +15,7 @@
   ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <template data-sly-template.itemContent="${@ item='The navigation item'}">
-    <a data-sly-attribute="${item.link.htmlAttributes}" aria-current="${item.active && 'page'}"
+    <a data-sly-attribute="${item.link.htmlAttributes}" aria-current="${item.current && 'page'}"
        data-sly-unwrap="${!item.link.valid}"
        data-cmp-clickable="${item.data ? true : false}"
        class="cmp-navigation__item-link">${item.title}</a>


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2105
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | N/A
| Documentation Provided   | N/A
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Fixes `aria-current` being set to `page` for all navigation links
that point to the current page _or_ an ancestor page. Navigation
links will now only have `aria-current` set to `page` if they point
to the current page (i.e. `current` instead of `active`)
