### PR TITLE
CIF-2748 Ensuring that canonical urls are not rendered when page is m…

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImpl.java
@@ -98,6 +98,11 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     public static final String PN_STYLE_RENDER_ALTERNATE_LANGUAGE_LINKS = "renderAlternateLanguageLinks";
 
     /**
+     * Attribute value for robots noindex
+     */
+    public static final String ROBOTS_TAG_NOINDEX = "noindex";
+
+    /**
      * Flag indicating if cloud configuration support is enabled.
      */
     private Boolean hasCloudconfigSupport;
@@ -335,9 +340,11 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
             } catch (NoClassDefFoundError ex) {
                 canonicalUrl = null;
             }
-            this.canonicalUrl = canonicalUrl != null
-                ? canonicalUrl
-                : linkHandler.getLink(currentPage).map(Link::getExternalizedURL).orElse(null);
+            if (!getRobotsTags().contains(ROBOTS_TAG_NOINDEX)) {
+                this.canonicalUrl = canonicalUrl != null
+                    ? canonicalUrl
+                    : linkHandler.getLink(currentPage).map(Link::getExternalizedURL).orElse(null);
+            }
         }
         return canonicalUrl;
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImplTest.java
@@ -297,6 +297,19 @@ public class PageImplTest extends com.adobe.cq.wcm.core.components.internal.mode
     }
 
     @Test
+    public void testNoCanonicalLinkForNoIndexPage() {
+        context.registerAdapter(Resource.class, SeoTags.class, (Function<Resource, SeoTags>) resource -> {
+            SeoTags seoTags = mock(SeoTags.class, "seoTags of " + resource.getPath());
+            String[] robotsTags = new String[]{"noindex", "nofollow"};
+            when(seoTags.getRobotsTags()).thenReturn(Arrays.asList(robotsTags));
+            return seoTags;
+        });
+        Page page = getPageUnderTest(PAGE);
+        String canonicalLink = page.getCanonicalLink();
+        assertNull(canonicalLink);
+    }
+
+    @Test
     public void testCanonicalLinkWhenSeoApiUnavailable() {
         context.registerAdapter(Resource.class, SeoTags.class, (Function<Resource, SeoTags>) resource -> {
             SeoTags seoTags = mock(SeoTags.class, "seoTags of " + resource.getPath());


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | CIF-2748 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  | 
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Currently each page exposes a canonical link to either itself (absolute mapping from the resource path no matter the requested Host) or another page (without selectors, or without a suffix to carry data).
However [a google representative explained](https://www.reddit.com/r/TechSEO/comments/8yahdr/2_questions_about_the_canonical_tag/e2dey9i/) that both signals (canonical and robots tags) are conflicting and they will "generally pick rel=cannonical [...] over the noindex".
That mean we should not render a canonical link if the page has a noindex tag. 

This fix ensures that canonical links are not added to pages tagged with NOINDEX.

Other product changes will ensure that hreflang tags and sitemaps are rendered correctly.
