### PR TITLE
[AEM Core Components Form Action Dialog] fix required validation for property on Form Action dialog and also fix the issue of saving the property as multiarray when the same name exists in diff form action dialog

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/clientlibs/editor/js/container.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/clientlibs/editor/js/container.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ******************************************************************************/
-(function(document, $, Coral) {
+ (function(document, $, Coral) {
     "use strict";
 
     var ACTION_TYPE_SETTINGS_SELECTOR = "#cmp-action-type-settings";
@@ -109,16 +109,37 @@
     function setVisibilityAndHandleFieldValidation($element, show) {
         if (show) {
             $element.removeClass("hide");
-            $element.find("input[aria-required=false], coral-multifield[aria-required=false]").
-                filter(":not(.hide>input)").filter(":not(input.hide)").
-                filter(":not(.hide>coral-multifield)").filter(":not(input.coral-multifield)").each(function(index, field) {
-                    toggleValidation($(field));
-                });
+            // for preventing storing as string[], if same name is present in other form dialog
+            $element.find("input").filter(":not(.hide>input)").filter(":not(input.hide)").each(function (index, field) {
+                toggleDisable($(field), false);
+            });
+            // for handling textbox, textarea, select, checkbox, pathfield etc
+            $element.find("[aria-required=false]").filter(":not(.hide>*)").each(function (index, field) {
+                toggleValidation($(field), true);
+            });
         } else {
             $element.addClass("hide");
-            $element.find("input[aria-required=true], coral-multifield[aria-required=true]").each(function(index, field) {
-                toggleValidation($(field));
+            // for preventing storing as string[], if same name is present in other form dialog
+            $element.find("input").each(function (index, field) {
+                toggleDisable($(field), true);
             });
+            // for handling textbox, textarea, select, checkbox, pathfield etc
+            $element.find("[aria-required=true],[required]").each(function (index, field) {
+                toggleValidation($(field), false);
+            });
+        }
+    }
+
+    /**
+     * If the form actions have same name for 2 different form action, we need to disable the form dialog properties from actions which are not selected in the dropdown
+     *
+     * @param {jQuery} $field To disable
+     */
+     function toggleDisable($field, disable) {
+        if (disable) {
+            $field.prop("disabled", true);
+        } else {
+            $field.prop("disabled", false);
         }
     }
 
@@ -127,13 +148,19 @@
      *
      * @param {jQuery} $field To disable / enable required validation.
      */
-    function toggleValidation($field) {
+     function toggleValidation($field, show) {
         var notRequired = false;
-        if ($field.attr("aria-required") === "true") {
+        if (!show) {
             notRequired = true;
             $field.attr("aria-required", "false");
-        } else if ($field.attr("aria-required") === "false") {
-            $field.attr("aria-required", "true");
+            /** Custom AMD Code Starts */
+			$field.removeAttr("required");
+ 			/** Custom AMD Code ends */
+        } else {
+			$field.attr("aria-required", "true");
+			/** Custom AMD Code Starts */
+            $field.attr("required", "required");
+		/** Custom AMD Code ends */
         }
         var api = $field.adaptTo("foundation-validation");
         if (api) {


### PR DESCRIPTION
issue#2052: Instead of targeting just the input[aria-required=true], coral-multifield[aria-required=true] selectors, we need to genralize and target all [aria-required=true],[required] so that other sling:resourceTypes are also covered

issue#2056: Enable only the input forms which is selected in the dropdown, Make the rest of them disabled so that it doesn't save as string[] if the same name exists in another form action

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | #2052  #2056 
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      |
| Documentation Provided   |
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
