### PR TITLE
Main navigation on mobile with aria attributes in components library

### DIFF
--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/scripts/aside.js
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/scripts/aside.js
@@ -18,7 +18,7 @@
 
     var selectors = {
         self: '.cmp-examples-structure__aside',
-        menuContainer: '#mainNavigation', 
+        menuContainer: '#mainNavigation',
         showMenu: '[data-cmp-examples-is="showMenu"]'
     };
 
@@ -36,10 +36,11 @@
         var showMenuActions = document.querySelectorAll(selectors.showMenu);
         var menuContainer = document.querySelector(selectors.menuContainer);
         var aside = document.querySelector(selectors.self);
+        var ariaExpanded = 'aria-expanded';
         mask = document.createElement('div');
         mask.classList.add(cssClasses.mask.self);
         document.body.appendChild(mask);
-        menuContainer.setAttribute('aria-expanded', 'false');
+        menuContainer.setAttribute(ariaExpanded, 'false');
 
         if (aside) {
             for (var i = 0; i < showMenuActions.length; ++i) {
@@ -47,7 +48,7 @@
                     event.stopPropagation();
                     aside.classList.add(cssClasses.open);
                     mask.classList.add(cssClasses.mask.open);
-                    menuContainer.setAttribute('aria-expanded', 'true');
+                    menuContainer.setAttribute(ariaExpanded, 'true');
                     this.setAttribute('aria-hidden', 'true');
                 });
             }
@@ -55,10 +56,10 @@
             mask.addEventListener('click', function (event) {
                 aside.classList.remove(cssClasses.open);
                 mask.classList.remove(cssClasses.mask.open);
-                menuContainer.setAttribute('aria-expanded', 'false');
+                menuContainer.setAttribute(ariaExpanded, 'false');
 
-                for (var i = 0; i < showMenuActions.length; ++i) {
-                    showMenuActions[i].removeAttribute('aria-hidden');
+                for (var button of showMenuActions) {
+                    button.removeAttribute('aria-hidden');
                 }
             }, false);
 

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/scripts/aside.js
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/scripts/aside.js
@@ -18,6 +18,7 @@
 
     var selectors = {
         self: '.cmp-examples-structure__aside',
+        menuContainer: '#mainNavigation', 
         showMenu: '[data-cmp-examples-is="showMenu"]'
     };
 
@@ -33,10 +34,12 @@
 
     ready(function() {
         var showMenuActions = document.querySelectorAll(selectors.showMenu);
+        var menuContainer = document.querySelector(selectors.menuContainer);
         var aside = document.querySelector(selectors.self);
         mask = document.createElement('div');
         mask.classList.add(cssClasses.mask.self);
         document.body.appendChild(mask);
+        menuContainer.setAttribute('aria-expanded', 'false');
 
         if (aside) {
             for (var i = 0; i < showMenuActions.length; ++i) {
@@ -44,12 +47,19 @@
                     event.stopPropagation();
                     aside.classList.add(cssClasses.open);
                     mask.classList.add(cssClasses.mask.open);
+                    menuContainer.setAttribute('aria-expanded', 'true');
+                    this.setAttribute('aria-hidden', 'true');
                 });
             }
 
             mask.addEventListener('click', function (event) {
                 aside.classList.remove(cssClasses.open);
                 mask.classList.remove(cssClasses.mask.open);
+                menuContainer.setAttribute('aria-expanded', 'false');
+
+                for (var i = 0; i < showMenuActions.length; ++i) {
+                    showMenuActions[i].removeAttribute('aria-hidden');
+                }
             }, false);
 
             aside.addEventListener('click', function (event) {


### PR DESCRIPTION
Components Library provides additional aria attributes for main navigation on mobile:
- `aria-hidden` for button when it is disabled / when menu aside is visible
- `aria-expanded` for main navigation container to indicate its state