### PR TITLE
[ExperienceFragment] Publishing a page that includes Core Components …

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/.content.xml
@@ -19,4 +19,5 @@
     jcr:description="Displays an experience fragment variation"
     jcr:primaryType="cq:Component"
     jcr:title="Experience Fragment (v1)"
+    sling:resourceSuperType="core/wcm/components/experiencefragment"
     componentGroup=".core-wcm"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v2/experiencefragment/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v2/experiencefragment/.content.xml
@@ -19,4 +19,5 @@
     jcr:description="Displays an experience fragment variation"
     jcr:primaryType="cq:Component"
     jcr:title="Experience Fragment (v2)"
+    sling:resourceSuperType="core/wcm/components/experiencefragment"
     componentGroup=".core-wcm"/>


### PR DESCRIPTION
…Experience Fragment (v2) does not publish the referenced fragments

- add resourceSuperType to XF which can be reused by the reference provider.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2123 
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | 👎
| Major: Breaking Change?  | 👎
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
