### PR TITLE
SITES-6179-Form Container dialog issues

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/form/container/v1/container/clientlibs/editor/js/container.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/container/v1/container/clientlibs/editor/js/container.js
@@ -19,6 +19,9 @@
     var ACTION_TYPE_SETTINGS_SELECTOR = "#cmp-action-type-settings";
     var ACTION_TYPE_ELEMENT_SELECTOR  = ".cmp-action-type-selection";
     var WORKFLOW_SELECT_ELEMENT_SELECTOR = ".cmp-workflow-container coral-select";
+    var EMAIL_ADDRESS_SENDER_SELECTOR = "input[name='./from']";
+    var EMAIL_ADDRESS_RECEIVER_SELECTOR = "coral-multifield-item-content input[name='./mailto']";
+    var EMAIL_ADDRESS_CC_SELECTOR = "coral-multifield-item-content input[name='./cc']";
 
     $(document).on("foundation-contentloaded", function(e) {
         if ($(e.target).find(ACTION_TYPE_ELEMENT_SELECTOR).length > 0) {
@@ -141,6 +144,40 @@
                 api.checkValidity();
             }
             api.updateUI();
+        }
+    }
+
+    $(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
+        selector: EMAIL_ADDRESS_SENDER_SELECTOR,
+        validate: function(element) {
+            return validateEmail(element);
+        }
+    });
+
+    $(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
+        selector: EMAIL_ADDRESS_RECEIVER_SELECTOR,
+        validate: function(element) {
+            return validateEmail(element, true);
+        }
+    });
+
+    $(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
+        selector: EMAIL_ADDRESS_CC_SELECTOR,
+        validate: function(element) {
+            return validateEmail(element, true);
+        }
+    });
+
+    function validateEmail(element, addEmptyFieldValidation) {
+        var emptyFieldErrorMessage = Granite.I18n.get("Error: Please fill out this field.");
+        var invalidEmailErrorMessage = Granite.I18n.get("Error: Invalid Email Address.");
+        var validEmailRegex = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
+        var input =  element.value;
+        if (input && !input.match(validEmailRegex)) {
+            return invalidEmailErrorMessage;
+        }
+        if (addEmptyFieldValidation && !input) {
+            return emptyFieldErrorMessage;
         }
     }
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/clientlibs/editor/js/container.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/clientlibs/editor/js/container.js
@@ -19,6 +19,9 @@
     var ACTION_TYPE_SETTINGS_SELECTOR = "#cmp-action-type-settings";
     var ACTION_TYPE_ELEMENT_SELECTOR  = ".cmp-action-type-selection";
     var WORKFLOW_SELECT_ELEMENT_SELECTOR = ".cmp-workflow-container coral-select";
+    var EMAIL_ADDRESS_SENDER_SELECTOR = "input[name='./from']";
+    var EMAIL_ADDRESS_RECEIVER_SELECTOR = "coral-multifield-item-content input[name='./mailto']";
+    var EMAIL_ADDRESS_CC_SELECTOR = "coral-multifield-item-content input[name='./cc']";
 
     $(document).on("foundation-contentloaded", function(e) {
         if ($(e.target).find(ACTION_TYPE_ELEMENT_SELECTOR).length > 0) {
@@ -141,6 +144,40 @@
                 api.checkValidity();
             }
             api.updateUI();
+        }
+    }
+
+    $(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
+        selector: EMAIL_ADDRESS_SENDER_SELECTOR,
+        validate: function(element) {
+            return validateEmail(element);
+        }
+    });
+
+    $(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
+        selector: EMAIL_ADDRESS_RECEIVER_SELECTOR,
+        validate: function(element) {
+            return validateEmail(element, true);
+        }
+    });
+
+    $(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
+        selector: EMAIL_ADDRESS_CC_SELECTOR,
+        validate: function(element) {
+            return validateEmail(element, true);
+        }
+    });
+
+    function validateEmail(element, addEmptyFieldValidation) {
+        var emptyFieldErrorMessage = Granite.I18n.get("Error: Please fill out this field.");
+        var invalidEmailErrorMessage = Granite.I18n.get("Error: Invalid Email Address.");
+        var validEmailRegex = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
+        var input =  element.value;
+        if (input && !input.match(validEmailRegex)) {
+            return invalidEmailErrorMessage;
+        }
+        if (addEmptyFieldValidation && !input) {
+            return emptyFieldErrorMessage;
         }
     }
 

--- a/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/formcontainer/v1/FormContainerIT.java
+++ b/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/formcontainer/v1/FormContainerIT.java
@@ -39,6 +39,7 @@ import com.adobe.cq.testing.selenium.pageobject.PageEditorPage;
 
 import static com.adobe.cq.wcm.core.components.it.seljup.util.Commons.*;
 import static com.codeborne.selenide.Selenide.$;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("group1")
@@ -51,8 +52,12 @@ public class FormContainerIT extends AuthorBaseUITest {
     private static final String subject = "subject line";
     private static final String mailto1 = "mailto1@components.com";
     private static final String mailto2 = "mailto2@components.com";
+    private static final String invalidMailto = "mailto2components";
+    private static final String emptyMailto = "";
     private static final String cc1 = "cc1@components.com";
     private static final String cc2 = "cc2@components.com";
+    private static final String invalidCC = "cc2components.com";
+    private static final String emptyCC = "";
     private String containerPath;
     private EditorPage editorPage;
     private String testPage;
@@ -198,6 +203,42 @@ public class FormContainerIT extends AuthorBaseUITest {
         assertTrue(formContentJson.get("mailto").get(1).toString().equals("\""+mailto2+"\""));
         assertTrue(formContentJson.get("cc").get(0).toString().equals("\""+cc1+"\""));
         assertTrue(formContentJson.get("cc").get(1).toString().equals("\""+cc2+"\""));
+    }
+
+    /**
+     * Test: check if invalid 'Mail' validation messages are displayed.
+     *
+     */
+    @Test
+    @DisplayName("Test: check if invalid 'Mail' validation messages are displayed.")
+    public void testInvalidEmailValidationMessages() throws InterruptedException, ClientException {
+        FormContainerEditDialog dialog = formComponents.openEditDialog(containerPath);
+        dialog.setMailActionFields(from,subject,new String[] {invalidMailto}, new String[] {invalidCC});
+        Commons.saveConfigureDialog();
+        String mailToErrorMessage = "coral-multifield-item-content input[name='./mailto'] + coral-tooltip[variant='error']";
+        String ccErrorMessage = "coral-multifield-item-content input[name='./mailto'] + coral-tooltip[variant='error']";
+        assertTrue($(mailToErrorMessage).isDisplayed());
+        assertEquals($(mailToErrorMessage).getText(), "Error: Invalid Email Address.");
+        assertTrue($(ccErrorMessage).isDisplayed());
+        assertEquals($(ccErrorMessage).getText(), "Error: Invalid Email Address.");
+    }
+
+    /**
+     * Test: check if empty 'Mail' validation messages are displayed.
+     *
+     */
+    @Test
+    @DisplayName("Test: check if empty 'Mail' validation messages are displayed.")
+    public void testEmptyEmailValidationMessages() throws InterruptedException, ClientException {
+        FormContainerEditDialog dialog = formComponents.openEditDialog(containerPath);
+        dialog.setMailActionFields(from,subject,new String[] {emptyMailto}, new String[] {emptyCC});
+        Commons.saveConfigureDialog();
+        String mailToErrorMessage = "coral-multifield-item-content input[name='./mailto'] + coral-tooltip[variant='error']";
+        String ccErrorMessage = "coral-multifield-item-content input[name='./mailto'] + coral-tooltip[variant='error']";
+        assertTrue($(mailToErrorMessage).isDisplayed());
+        assertEquals($(mailToErrorMessage).getText(), "Error: Please fill out this field.");
+        assertTrue($(ccErrorMessage).isDisplayed());
+        assertEquals($(ccErrorMessage).getText(), "Error: Please fill out this field.");
     }
 
 }


### PR DESCRIPTION
Fixes #1634
- adds Granite UI field validation for sender, reciever, cc emails.
- multiplication issue mentioned in #1634, ``The form container dialog duplicates the email in the 'To' multifield everytime you OK the dialog. Based on the ActionType chosen from dropdown, these fields are loaded dynamically. Looks like an issue with the dialog JS.`` couldn't be reproduced.
- AEM 6.5.10 (left) vs AEMaaCS SDK latest(right): it seems that the validation error messages are not displayed on AEMaaCS when hovering or clicking the alert icon for `Subject` or `From *`. This is not something related to this PR, the behaviour can be also observed for example on the `Embed Component ->  Edit Dialog  -> URL validation`.
<img width="1153" alt="Screenshot 2022-05-10 at 09 55 33" src="https://user-images.githubusercontent.com/79856745/167566915-4be190b3-9725-4b79-a3e8-0b3fe287b130.png">

<img width="600" alt="Screenshot 2022-05-10 at 10 01 45" src="https://user-images.githubusercontent.com/79856745/167567988-74635503-bd2c-4aac-aa7c-85f7d9327a66.png">

