### PR TITLE
[Download] Wrong download filename on AEMaaCS environments

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -47,7 +47,6 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.api.resource.external.ExternalizableInputStream;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.apache.sling.commons.metrics.Timer;
@@ -698,11 +697,6 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
     private void stream(@NotNull SlingHttpServletResponse response, @NotNull InputStream inputStream, @NotNull String contentType,
                         String imageName)
             throws IOException {
-        // similar to what is done in https://github.com/apache/sling-org-apache-sling-servlets-get/blob/edfaf307e4257dd34cc5b71121dfb8dfc43c12cb/src/main/java/org/apache/sling/servlets/get/impl/helpers/StreamRenderer.java#L159-L162
-        if (inputStream instanceof ExternalizableInputStream) {
-            response.sendRedirect(ExternalizableInputStream.class.cast(inputStream).getURI().toString());
-            return;
-        }
         response.setContentType(contentType);
         response.setHeader("Content-Disposition", "inline; filename=" + URLEncoder.encode(imageName, CharEncoding.UTF_8));
         IOUtils.copy(inputStream, response.getOutputStream());

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/DownloadServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/DownloadServlet.java
@@ -41,7 +41,6 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.api.resource.external.ExternalizableInputStream;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.osgi.service.component.annotations.Component;
@@ -184,11 +183,6 @@ public class DownloadServlet extends SlingAllMethodsServlet {
 
     private void sendResponse(InputStream stream, long size, String mimeType, String filename, long lastModifiedDate, SlingHttpServletResponse response,
             boolean inline) throws IOException {
-        // similar to what is done in https://github.com/apache/sling-org-apache-sling-servlets-get/blob/edfaf307e4257dd34cc5b71121dfb8dfc43c12cb/src/main/java/org/apache/sling/servlets/get/impl/helpers/StreamRenderer.java#L159-L162
-        if (stream instanceof ExternalizableInputStream) {
-            response.sendRedirect(ExternalizableInputStream.class.cast(stream).getURI().toString());
-            return;
-        }
         response.setContentType(mimeType);
 
         // only set the size contentLength header if we have valid data
@@ -203,7 +197,9 @@ public class DownloadServlet extends SlingAllMethodsServlet {
         if (lastModifiedDate > 0) {
             response.setHeader(HttpConstants.HEADER_LAST_MODIFIED, getLastModifiedDate(lastModifiedDate));
         }
-        IOUtils.copy(stream, response.getOutputStream());
+        try (ServletOutputStream outputStream = response.getOutputStream()) {
+            IOUtils.copy(stream, outputStream);
+        }
     }
 
     private String getLastModifiedDate(long lastModifiedDate) {

--- a/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/Commons.java
+++ b/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/Commons.java
@@ -160,6 +160,8 @@ public class Commons {
     // hidden field
     public static String RT_FORMHIDDEN_V1 = "core-component/components/formhidden-v1";
     public static String RT_FORMHIDDEN_V2 = "core-component/components/formhidden-v2";
+    // download component
+    public static final String RT_DOWNLOAD_V1 = "core-component/components/download-v1";
 
     /**
      * Creates form entity builder

--- a/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/components/download/DownloadEditDialog.java
+++ b/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/components/download/DownloadEditDialog.java
@@ -1,0 +1,37 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+
+package com.adobe.cq.wcm.core.components.it.seljup.util.components.download;
+
+import com.adobe.cq.testing.selenium.pagewidgets.coral.Dialog;
+
+import static com.codeborne.selenide.Selenide.$;
+
+public class DownloadEditDialog extends Dialog {
+
+    private static String assetInSidePanel = "coral-card.cq-draggable[data-path=\"%s\"]";
+    private static String fileUpload = "coral-fileupload[name='./file']";
+    private static final String CSS_SELECTOR = "coral-dialog";
+
+    public DownloadEditDialog() {
+        super(CSS_SELECTOR);
+    }
+
+    public void uploadAssetFromSidePanel(String assetPath) {
+        $(String.format(assetInSidePanel,assetPath)).dragAndDropTo(fileUpload);
+    }
+}

--- a/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/components/download/v1/Download.java
+++ b/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/components/download/v1/Download.java
@@ -1,0 +1,37 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.it.seljup.util.components.download.v1;
+
+import com.adobe.cq.testing.selenium.pagewidgets.common.BaseComponent;
+import com.adobe.cq.wcm.core.components.it.seljup.util.components.download.DownloadEditDialog;
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.SelenideElement;
+
+public class Download extends BaseComponent {
+
+    public Download() {
+        super(".cmp-download");
+    }
+
+    public String getDownloadTitleLink() {
+        SelenideElement downloadAction = element().find(".cmp-download__title-link").shouldBe(Condition.visible);
+        return downloadAction.getAttribute("href").trim();
+    }
+
+    public DownloadEditDialog getEditDialog() {
+        return new DownloadEditDialog();
+    }
+}

--- a/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/download/v1/DownloadIT.java
+++ b/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/download/v1/DownloadIT.java
@@ -1,0 +1,106 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+package com.adobe.cq.wcm.core.components.it.seljup.tests.download.v1;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.SlingClient;
+import org.apache.sling.testing.clients.SlingHttpResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.adobe.cq.testing.selenium.pageobject.EditorPage;
+import com.adobe.cq.testing.selenium.pageobject.PageEditorPage;
+import com.adobe.cq.wcm.core.components.it.seljup.AuthorBaseUITest;
+import com.adobe.cq.wcm.core.components.it.seljup.util.Commons;
+import com.adobe.cq.wcm.core.components.it.seljup.util.components.download.DownloadEditDialog;
+import com.adobe.cq.wcm.core.components.it.seljup.util.components.download.v1.Download;
+import com.adobe.cq.wcm.core.components.it.seljup.util.constant.RequestConstants;
+import com.google.common.net.HttpHeaders;
+
+import static com.adobe.cq.wcm.core.components.it.seljup.util.Commons.RT_DOWNLOAD_V1;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DownloadIT extends AuthorBaseUITest {
+
+    private static String assetFilter = "[name='assetfilter_image_path']";
+    private static String componentName = "download";
+    private static String testAssetsPath = "/content/dam/core-components";
+    private static String testAssetName = "core-comp-test-image.jpg";
+    private static String testAssetPath = testAssetsPath + "/" + testAssetName;
+
+    protected EditorPage editorPage;
+    protected String testPage;
+    protected String cmpPath;
+    protected Download download;
+    protected String downloadRT;
+
+    private void setupResources() {
+        downloadRT = RT_DOWNLOAD_V1;
+    }
+
+    protected void setup() throws ClientException {
+        testPage = authorClient.createPage("testPage", "Test Page", rootPage, defaultPageTemplate, 200, 201).getSlingPath();
+
+        addPathtoComponentPolicy(responsiveGridPath, downloadRT);
+        cmpPath = Commons.addComponentWithRetry(authorClient, downloadRT, testPage + Commons.relParentCompPath, componentName);
+
+        editorPage = new PageEditorPage(testPage);
+        editorPage.open();
+
+        download = new Download();
+    }
+
+    @BeforeEach
+    public void setupBefore() throws Exception {
+        setupResources();
+        setup();
+    }
+
+    @AfterEach
+    public void cleanup() throws ClientException, InterruptedException {
+        authorClient.deletePageWithRetry(testPage, true, false, RequestConstants.TIMEOUT_TIME_MS, RequestConstants.RETRY_TIME_INTERVAL,
+                HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void downloadFile() throws TimeoutException, InterruptedException, ClientException, URISyntaxException {
+        Commons.openSidePanel();
+        Commons.selectInAutocomplete(assetFilter, testAssetsPath);
+        Commons.openEditDialog(editorPage, cmpPath);
+        DownloadEditDialog downloadEditDialog = download.getEditDialog();
+        downloadEditDialog.uploadAssetFromSidePanel(testAssetPath);
+        Commons.saveConfigureDialog();
+        Commons.switchContext("ContentFrame");
+        Commons.webDriverWait(RequestConstants.WEBDRIVER_WAIT_TIME_MS);
+        String url = download.getDownloadTitleLink();
+        SlingClient slingClient = new SlingClient(new URI(url), authorClient.getUser(), authorClient.getPassword());
+        SlingHttpResponse response = slingClient.doGet(url, Collections.EMPTY_LIST, Collections.EMPTY_LIST, HttpStatus.SC_OK);
+        Header headers[] = response.getHeaders(HttpHeaders.CONTENT_DISPOSITION);
+        assertTrue(headers.length > 0);
+        assertEquals("attachment; filename=\"" + testAssetName + "\"", headers[0].getValue());
+    }
+}

--- a/testing/it/it.ui.apps/src/content/jcr_root/apps/core-component/components/download-v1/.content.xml
+++ b/testing/it/it.ui.apps/src/content/jcr_root/apps/core-component/components/download-v1/.content.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2022 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+        jcr:primaryType="cq:Component"
+        jcr:title="Downlaod V1"
+        sling:resourceSuperType="core/wcm/components/download/v1/download"
+        componentGroup=".test"/>


### PR DESCRIPTION
- revert changes from #1932
- add e2e test to prevent future regressions

fixes #2161

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2161 
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | 👎
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
