### PR TITLE
[Teaser] Prevent same ID for teaser and teaser image (#2164)

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImpl.java
@@ -42,11 +42,18 @@ import com.day.cq.wcm.foundation.Image;
 import com.day.text.Text;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import static com.adobe.cq.wcm.core.components.util.ComponentUtils.ID_SEPARATOR;
+
 @Model(adaptables = SlingHttpServletRequest.class, adapters = {Teaser.class, ComponentExporter.class}, resourceType = TeaserImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME , extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class TeaserImpl extends com.adobe.cq.wcm.core.components.internal.models.v1.TeaserImpl {
 
     public final static String RESOURCE_TYPE = "core/wcm/components/teaser/v2/teaser";
+
+    /**
+     * Image ID prefix.
+     */
+    private static final String IMAGE_ID_PREFIX = "image";
 
     /**
      * The title.
@@ -73,6 +80,8 @@ public class TeaserImpl extends com.adobe.cq.wcm.core.components.internal.models
     protected void initImage() {
         overriddenImageResourceProperties.put(Image.PN_LINK_URL, getTargetPage().map(Page::getPath).orElse(null));
         overriddenImageResourceProperties.put(Teaser.PN_ACTIONS_ENABLED, Boolean.valueOf(actionsEnabled).toString());
+        overriddenImageResourceProperties.put(PN_ID, String.join(ID_SEPARATOR, this.getId(), IMAGE_ID_PREFIX));
+
         if (StringUtils.isNotEmpty(getTitle()) || getTeaserActions().size() > 0) {
             overriddenImageResourceProperties.put(Teaser.PN_IMAGE_LINK_HIDDEN, Boolean.TRUE.toString());
         }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImplTest.java
@@ -17,6 +17,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v2;
 
 import java.util.Objects;
 
+import com.adobe.cq.wcm.core.components.models.Component;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.junit.jupiter.api.BeforeEach;
@@ -110,6 +111,15 @@ public class TeaserImplTest extends com.adobe.cq.wcm.core.components.internal.mo
         assertEquals("/content/teasers", linkURL, "image resource: linkURL");
         assertNull(fileReference, "image resource: fileReference");
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(testBase, "teaser20"));
+    }
+
+    /**
+     * Asserts that the ID property on the image resource is set to the Teaser ID + `-image`.
+     */
+    @Test
+    protected void testTeaserImageID() {
+        Teaser teaser = getTeaserUnderTest(TEASER_21);
+        assertEquals(teaser.getId() + "-image", teaser.getImageResource().getValueMap().get(Component.PN_ID, String.class));
     }
 
     @Test


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2164
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | N/A
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Changes the ID for the teaser image to be `<teaser_id>-image`.
By doing this there will never be a conflict between the teaser ID and the ID used on the teaser image, regardless of if the teaser's ID is set manually by the author or is generated automatically. 

----
refs #2164

