### PR TITLE
SITES-6256 [Image] Improve error message when "Get alternative text from DAM" is used on an image bound to an asset not having a description

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/editor/js/image.js
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-(function($) {
+(function($, Granite) {
     "use strict";
 
     var dialogContentSelector = ".cmp-image__editor";
@@ -30,6 +30,8 @@
     var $dynamicMediaGroup;
     var areDMFeaturesEnabled;
     var fileReference;
+    var altInputSelector = 'input[name="./alt"]';
+    var altCheckboxSelector = 'coral-checkbox[name="./altValueFromDAM"]';
     var presetTypeSelector = ".cmp-image__editor-dynamicmedia-presettype";
     var imagePresetDropDownSelector = ".cmp-image__editor-dynamicmedia-imagepreset";
     var smartCropRenditionDropDownSelector = ".cmp-image__editor-dynamicmedia-smartcroprendition";
@@ -44,7 +46,7 @@
         var dialogContent  = $dialogContent.length > 0 ? $dialogContent[0] : undefined;
         if (dialogContent) {
             isDecorative = dialogContent.querySelector('coral-checkbox[name="./isDecorative"]');
-            altTuple = new CheckboxTextfieldTuple(dialogContent, 'coral-checkbox[name="./altValueFromDAM"]', 'input[name="./alt"]');
+            altTuple = new CheckboxTextfieldTuple(dialogContent, altCheckboxSelector, altInputSelector);
             $altGroup = $dialogContent.find(".cmp-image__editor-alt");
             $altTextField = $dialogContent.find(".cmp-image__editor-alt-text");
             $linkURLGroup = $dialogContent.find(".cmp-image__editor-link");
@@ -119,6 +121,18 @@
     $(window).on("focus", function() {
         if (fileReference) {
             retrieveDAMInfo(fileReference);
+        }
+    });
+
+    $(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
+        selector: altInputSelector,
+        validate: function() {
+            var seededValue = $(altInputSelector).attr("data-seeded-value");
+            var isAltCheckboxChecked = $(altCheckboxSelector).attr("checked");
+            var assetWithoutDescriptionErrorMessage = "Error: Please provide an asset which has a description that can be used as alt text.";
+            if (isAltCheckboxChecked && !seededValue) {
+                return Granite.I18n.get(assetWithoutDescriptionErrorMessage);
+            }
         }
     });
 
@@ -346,4 +360,4 @@
         }
     }
 
-})(jQuery);
+})(jQuery, Granite);

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-(function($) {
+(function($, Granite) {
     "use strict";
 
     var dialogContentSelector = ".cmp-image__editor";
@@ -154,6 +154,18 @@
     $(window).on("focus", function() {
         if (fileReference) {
             retrieveDAMInfo(fileReference);
+        }
+    });
+
+    $(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
+        selector: altInputSelector,
+        validate: function() {
+            var seededValue = $(altInputSelector).attr("data-seeded-value");
+            var isAltCheckboxChecked = $(altCheckboxSelector).attr("checked");
+            var assetWithoutDescriptionErrorMessage = "Error: Please provide an asset which has a description that can be used as alt text.";
+            if (isAltCheckboxChecked && !seededValue) {
+                return Granite.I18n.get(assetWithoutDescriptionErrorMessage);
+            }
         }
     });
 
@@ -476,4 +488,4 @@
         }
     }
 
-})(jQuery);
+})(jQuery, Granite);

--- a/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/image/ImageTests.java
+++ b/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/image/ImageTests.java
@@ -19,6 +19,7 @@ package com.adobe.cq.wcm.core.components.it.seljup.tests.image;
 import java.util.HashMap;
 import java.util.concurrent.TimeoutException;
 
+import com.codeborne.selenide.WebDriverRunner;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.sling.testing.clients.ClientException;
@@ -32,28 +33,30 @@ import com.adobe.cq.wcm.core.components.it.seljup.util.components.image.BaseImag
 import com.adobe.cq.wcm.core.components.it.seljup.util.components.image.ImageEditDialog;
 import com.adobe.cq.wcm.core.components.it.seljup.util.constant.RequestConstants;
 import com.codeborne.selenide.SelenideElement;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
 
 import static com.adobe.cq.testing.selenium.utils.ElementUtils.clickableClick;
 import static com.adobe.cq.wcm.core.components.it.seljup.AuthorBaseUITest.adminClient;
 import static com.codeborne.selenide.Selenide.$;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ImageTests {
 
-    private static String testAssetsPath         = "/content/dam/core-components";
-    private static String testImagePath          = testAssetsPath + "/core-comp-test-image.jpg";
-    private static String altText                = "Return to Arkham";
-    private static String captionText            = "The Last Guardian";
-    private static String originalDamTitle       = "Beach house";
+    private static String testAssetsPath = "/content/dam/core-components";
+    private static String testImagePath = testAssetsPath + "/core-comp-test-image.jpg";
+    private static String testImageWithoutDescriptionPath = testAssetsPath + "/Adobe_Systems_logo_and_wordmark.png";
+    private static String altText = "Return to Arkham";
+    private static String captionText = "The Last Guardian";
+    private static String originalDamTitle = "Beach house";
     private static String originalDamDescription = "House on a beach with blue sky";
-    private static String logoNodeName           = "Adobe_Systems_logo_and_wordmark.png";
-    private static String logoFileName           = "adobe-systems-logo-and-wordmark.png";
-    private static String imageFileName          = "core-comp-test-image.jpeg";
-    private static String pageImageAlt           = "page image alt";
-    private static String climbingAsset          = "AdobeStock_140634652_climbing.jpeg";
+    private static String logoNodeName = "Adobe_Systems_logo_and_wordmark.png";
+    private static String logoFileName = "adobe-systems-logo-and-wordmark.png";
+    private static String imageFileName = "core-comp-test-image.jpeg";
+    private static String pageImageAlt = "page image alt";
+    private static String climbingAsset = "AdobeStock_140634652_climbing.jpeg";
     private static String climbingAssetFormatted = StringUtils.lowerCase(climbingAsset).replace("_", "-");
-    private static String climbingAssetAltText   = "Rock Climbing and Bouldering above the lake and mountains";
+    private static String climbingAssetAltText = "Rock Climbing and Bouldering above the lake and mountains";
 
     private String testPage;
     private String proxyPath;
@@ -195,6 +198,27 @@ public class ImageTests {
         Commons.switchContext("ContentFrame");
         assertTrue(image.isImagePresentWithAltTextAndTitle(testPage, altText, captionText), "Image should be present with alt text " + altText
                 + " and title " + captionText);
+    }
+
+    public void testSetAssetWithoutDescription() throws InterruptedException, TimeoutException {
+        Commons.openSidePanel();
+        dragImageWithoutDescription();
+        ImageEditDialog editDialog = image.getEditDialog();
+        editDialog.openMetadataTab();
+        Commons.saveConfigureDialog();
+        String assetWithoutDescriptionErrorMessageSelector = "coral-tooltip[variant='error'] coral-tooltip-content";
+        assertEquals("Error: Please provide an asset which has a description that can be used as alt text.", $(assetWithoutDescriptionErrorMessageSelector).innerText());
+    }
+
+    public void testSetAssetWithoutDescriptionV3() throws InterruptedException, TimeoutException {
+        Commons.openSidePanel();
+        dragImageWithoutDescription();
+        Commons.saveConfigureDialog();
+        String assetWithoutDescriptionErrorMessageSelector = "coral-tooltip[variant='error'] coral-tooltip-content";
+        String errorIcon = "input[name='./alt'] + coral-icon[icon='alert']";
+        final WebDriver webDriver = WebDriverRunner.getWebDriver();
+        ((JavascriptExecutor) webDriver).executeScript("arguments[0].scrollIntoView(true);", $(errorIcon));
+        assertEquals("Error: Please provide an asset which has a description that can be used as alt text.", $(assetWithoutDescriptionErrorMessageSelector).innerText());
     }
 
     public void testAddAltTextAndTitleV3() throws TimeoutException, InterruptedException {
@@ -427,6 +451,14 @@ public class ImageTests {
         Commons.openEditDialog(editorPage, compPath);
         editDialog.checkImageFromPageImage();
         editDialog.uploadImageFromSidePanel(testImagePath);
+    }
+
+    private void dragImageWithoutDescription() throws TimeoutException, InterruptedException {
+        ImageEditDialog editDialog = image.getEditDialog();
+        editDialog.setAssetFilter(testAssetsPath);
+        Commons.openEditDialog(editorPage, compPath);
+        editDialog.checkImageFromPageImage();
+        editDialog.uploadImageFromSidePanel(testImageWithoutDescriptionPath);
     }
 
     /**

--- a/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/image/v2/ImageIT.java
+++ b/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/image/v2/ImageIT.java
@@ -105,4 +105,13 @@ public class ImageIT extends AuthorBaseUITest {
         imageTests.testCheckMapAreaNavigationAndResponsiveResize(authorClient);
     }
 
+    /**
+     * Test: set asset from DAM without description
+     */
+    @Test
+    @DisplayName("Test: set asset from DAM without description")
+    public void testSetAssetWithoutDescription() throws TimeoutException, InterruptedException {
+        imageTests.testSetAssetWithoutDescription();
+    }
+
 }

--- a/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/image/v3/ImageIT.java
+++ b/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/image/v3/ImageIT.java
@@ -205,4 +205,14 @@ public class ImageIT extends com.adobe.cq.wcm.core.components.it.seljup.tests.im
         imageTests.testSetLinkWithTarget();
     }
 
+    /**
+     * Test: set asset from DAM without description
+     */
+    @Test
+    @Override
+    @DisplayName("Test: set asset from DAM without description")
+    public void testSetAssetWithoutDescription() throws TimeoutException, InterruptedException {
+        imageTests.testSetAssetWithoutDescriptionV3();
+    }
+
 }

--- a/testing/it/it.ui.apps/package-lock.json
+++ b/testing/it/it.ui.apps/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "com.adobe.cq.core.wcm.components.it.content",
-    "version": "2.19.1-SNAPSHOT",
+    "version": "2.19.3-SNAPSHOT",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "com.adobe.cq.core.wcm.components.it.content",
-            "version": "2.19.1-SNAPSHOT",
+            "version": "2.19.3-SNAPSHOT",
             "license": "Apache-2.0",
             "devDependencies": {
                 "sync-pom-version-to-package": "^1.6.1"

--- a/testing/it/it.ui.apps/package.json
+++ b/testing/it/it.ui.apps/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.adobe.cq.core.wcm.components.it.ui.apps",
-    "version": "2.19.1-SNAPSHOT",
+    "version": "2.19.3-SNAPSHOT",
     "description": "Adobe Experience Manager Core WCM Components IT Immutable Content",
     "license": "Apache-2.0",
     "private": false,


### PR DESCRIPTION
Fixes #1276 