### PR TITLE
Adding Resource loading attributes to support media="print" for link Stylesheet

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
@@ -458,5 +458,18 @@ public interface Page extends ContainerExporter, Component {
      * @since om.adobe.cq.wcm.core.components.models 12.24.0
      */
     default boolean isClientlibsAsync() {return false;}
+    
+    /**
+     * Returns a list of resource loading attributes configured for the page.
+     * <p>
+     * The list is cleared from duplicates and conflicting combinations.
+     *
+     * @return a list of resource loading attributes
+     * @since om.adobe.cq.wcm.core.components.models 12.22.0
+     */
+    @Nullable
+    default String getResourceAttribute() {
+    	 return null;
+    }
 
 }

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/README.md
@@ -29,6 +29,7 @@ Extensible page component written in HTL.
 * Closed user groups and permissions
 * Cloud services
 * [PWA support](https://experienceleague.adobe.com/docs/experience-manager-cloud-service/sites/authoring/features/enable-pwa.html)
+* Resource loading attributes
 
 ## Loading of CSS/JS
 The page component automatically loads certain client libraries in the head section and at the end of the body section
@@ -103,6 +104,13 @@ The following properties are written to JCR for this Page component and are expe
 22. `./cq:featuredimage/fileReference` property or `./cq:featuredimage/file` child node - will store either a reference to the image file, or the image file of the featured image of the page.
 23. `./cq:featuredimage/alt` - defines the value of the HTML `alt` attribute of the featured image of the page.
 24. `./cq:featuredimage/altValueFromDAM` - if `true`, the HTML `alt` attribute of the featured image of the page is inherited from the DAM asset.
+
+
+New tab 'Page Level Configurations' is added for Resource loading attributes to support media="print" for link Stylesheet. A node 'link' will be created as child to JCR holding the below properties in the hierarchy. It is a multifield to add multiple attributes.
+
+25.  `./linkAttributeName` - defines link attributes name.
+26.  `./linkAttributeValue` - defines link attributes value.
+
 
 ## Web Resources Client Library
 A web resources client library can be defined at the template level (see `./appResourcesClientlib` component policy configuration).

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/_cq_dialog/.content.xml
@@ -199,6 +199,70 @@
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="granite/ui/components/coral/foundation/include"
                         path="/mnt/overlay/wcm/foundation/components/basicpage/v1/basicpage/tabs/pwa"/>
+                  <pagelevelconfig
+                          jcr:primaryType="nt:unstructured"
+                          jcr:title="Page Level Configurations"
+                          sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
+                          <items jcr:primaryType="nt:unstructured">
+                              <column
+                                  jcr:primaryType="nt:unstructured"
+                                  sling:resourceType="granite/ui/components/coral/foundation/container">
+                                  <items jcr:primaryType="nt:unstructured">
+                                      <resourceLoadingAttributes
+                                          jcr:primaryType="nt:unstructured"
+                                          jcr:title="Resource Loading Attributes"
+                                          sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                          <items jcr:primaryType="nt:unstructured">
+                                              <column
+                                                  jcr:primaryType="nt:unstructured"
+                                                  sling:resourceType="granite/ui/components/coral/foundation/container">
+                                                  <items jcr:primaryType="nt:unstructured">
+                                                      <link
+                                                          jcr:primaryType="nt:unstructured"
+                                                          sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                                          composite="{Boolean}true"
+                                                          fieldLabel="Link Details">
+                                                          <field
+                                                              jcr:primaryType="nt:unstructured"
+                                                              sling:resourceType="granite/ui/components/coral/foundation/container"
+                                                              name="./link">
+                                                              <items jcr:primaryType="nt:unstructured">
+                                                                  <resourceloading
+                                                                      jcr:primaryType="nt:unstructured"
+                                                                      sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                                                      composite="{Boolean}true"
+                                                                      fieldLabel="Link Attributes">
+                                                                      <field
+                                                                          jcr:primaryType="nt:unstructured"
+                                                                          sling:resourceType="granite/ui/components/coral/foundation/container"
+                                                                          name="./resourceloading">
+                                                                          <items jcr:primaryType="nt:unstructured">
+                                                                              <linkAttributeName
+                                                                                  jcr:primaryType="nt:unstructured"
+                                                                                  sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                                                  fieldDescription="Ex: href, rel, as, type, crossorigin etc"
+                                                                                  fieldLabel="Link Attribute Name"
+                                                                                  name="./linkAttributeName"/>
+                                                                              <linkAttributeValue
+                                                                                  jcr:primaryType="nt:unstructured"
+                                                                                  sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                                                  fieldDescription="Enter a valid Attribute Value against the Attribute Name"
+                                                                                  fieldLabel="Link Attribute Value"
+                                                                                  name="./linkAttributeValue"/>
+                                                                          </items>
+                                                                      </field>
+                                                                  </resourceloading>
+                                                              </items>
+                                                          </field>
+                                                      </link>
+                                                  </items>
+                                              </column>
+                                          </items>
+                                      </resourceLoadingAttributes>
+                                  </items>
+                              </column>
+                          </items>
+                      </pagelevelconfig>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/head.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/head.html
@@ -32,6 +32,7 @@
              data-sly-call="${clientlib.css @ categories='core.wcm.components.page.v2.pwa'}"></sly>
         <meta name="cq:sw_path" content="${pwa.serviceWorkerPath @ context ='text'}"/>
     </sly>
+    <sly>${page.resourceAttribute @ context = 'unsafe'}</sly>
     <sly data-sly-include="head.links.html"></sly>
     <sly data-sly-include="customheaderlibs.html"></sly>
     <sly data-sly-call="${headlibRenderer.headlibs @

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,8 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0  
+  ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0  ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2183
| Patch: Bug Fix?          | No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
[Resource Loading attributes - issues 2183.docx](https://github.com/adobe/aem-core-wcm-components/files/8715642/Resource.Loading.attributes.-.issues.2183.docx)

