### PR TITLE
[Page][v3] Featured Image properties are overwritten after rollout

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/_cq_dialog/.content.xml
@@ -120,7 +120,11 @@
                                                 fileNameParameter="./cq:featuredimage/fileName"
                                                 fileReferenceParameter="./cq:featuredimage/fileReference"
                                                 mimeTypes="[image/gif,image/jpeg,image/png,image/tiff,image/svg+xml]"
-                                                name="./cq:featuredimage/file"/>
+                                                name="./cq:featuredimage/file">
+                                                <granite:data
+                                                    jcr:primaryType="nt:unstructured"
+                                                    cq-msm-lockable="/cq:featuredimage"/>
+                                            </file>
                                             <type
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
@@ -137,7 +141,11 @@
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                         fieldDescription="Textual alternative of the meaning or function of the image, for visually impaired readers."
                                                         fieldLabel="Alternative Text"
-                                                        name="./cq:featuredimage/alt"/>
+                                                        name="./cq:featuredimage/alt">
+                                                        <granite:data
+                                                            jcr:primaryType="nt:unstructured"
+                                                            cq-msm-lockable="/cq:featuredimage"/>
+                                                    </alt>
                                                     <altValueFromDAM
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
@@ -146,7 +154,11 @@
                                                         name="./cq:featuredimage/altValueFromDAM"
                                                         text="Inherit - Value taken from the DAM asset"
                                                         uncheckedValue="false"
-                                                        value="{Boolean}true"/>
+                                                        value="{Boolean}true">
+                                                        <granite:data
+                                                            jcr:primaryType="nt:unstructured"
+                                                            cq-msm-lockable="/cq:featuredimage"/>
+                                                    </altValueFromDAM>
                                                 </items>
                                             </alternativeGroup>
                                         </items>


### PR DESCRIPTION
- adding absolute cq-msm-lockable to featured image file and alt text widget

fixes #2166

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #12166
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
