### PR TITLE
Fix console error when accessing the Page Properties of a Page

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/editor/js/image.js
@@ -422,9 +422,12 @@
             });
         });
 
-        observer.observe(document.querySelector(altInputSelector), {
-            attributeFilter: ["data-seeded-value", "disabled", "invalid"]
-        });
+        var altInput = document.querySelector(altInputSelector);
+        if (altInput) {
+            observer.observe(altInput, {
+                attributeFilter: ["data-seeded-value", "disabled", "invalid"]
+            });
+        }
     }
 
 })(jQuery, Granite);

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
@@ -550,9 +550,12 @@
             });
         });
 
-        observer.observe(document.querySelector(altInputSelector), {
-            attributeFilter: ["data-seeded-value", "disabled", "invalid"]
-        });
+        var altInput = document.querySelector(altInputSelector);
+        if (altInput) {
+            observer.observe(altInput, {
+                attributeFilter: ["data-seeded-value", "disabled", "invalid"]
+            });
+        }
     }
 
 })(jQuery, Granite);


### PR DESCRIPTION
Fixes the following error introduced by this [PR](https://github.com/adobe/aem-core-wcm-components/pull/2188) in the  Page Properties of a Page.

```
Uncaught TypeError: Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'.
    at improveAltTextValidation (editor.lc-0ffd9019bdf8ca41494ce305191bd7ca-lc.js:553:18)
    at HTMLDocument.<anonymous> (editor.lc-0ffd9019bdf8ca41494ce305191bd7ca-lc.js:156:9)
    at HTMLDocument.dispatch (jquery.lc-676f843463ac676e1918c97ea7dc1a20-lc.js:5232:27)
    at HTMLDocument.elemData.handle (jquery.lc-676f843463ac676e1918c97ea7dc1a20-lc.js:4884:28)
    at Object.trigger (jquery.lc-676f843463ac676e1918c97ea7dc1a20-lc.js:5136:12)
    at HTMLDocument.<anonymous> (jquery.lc-676f843463ac676e1918c97ea7dc1a20-lc.js:5866:17)
    at Function.each (jquery.lc-676f843463ac676e1918c97ea7dc1a20-lc.js:371:19)
    at jQuery.fn.init.each (jquery.lc-676f843463ac676e1918c97ea7dc1a20-lc.js:137:17)
    at jQuery.fn.init.trigger (jquery.lc-676f843463ac676e1918c97ea7dc1a20-lc.js:5865:15)
    at HTMLDocument.<anonymous> (dialog.lc-b78ac31dca3aafef84952ff128880d7b-lc.js:8:180)

```
