### PR TITLE
[TOC] TableOfContentsFilter causing NPE

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/TableOfContentsFilter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/TableOfContentsFilter.java
@@ -86,7 +86,7 @@ public class TableOfContentsFilter implements Filter {
         chain.doFilter(request, responseWrapper);
         String originalContent = responseWrapper.toString();
         Boolean containsTableOfContents = (Boolean) request.getAttribute(TableOfContentsImpl.TOC_REQUEST_ATTR_FLAG);
-        if (responseWrapper.getContentType().contains("text/html") &&
+        if (responseWrapper.getContentType() != null && responseWrapper.getContentType().contains("text/html") &&
             (containsTableOfContents != null && containsTableOfContents)) {
 
             Document document = Jsoup.parse(originalContent);

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/TableOfContentsFilterTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/TableOfContentsFilterTest.java
@@ -150,6 +150,22 @@ public class TableOfContentsFilterTest {
         );
     }
 
+    /**
+     * Checks no NPE is thrown if response content type is null
+     * @throws Exception
+     */
+    @Test
+    void testNoNpeIfContentTypeIsNull() throws Exception {
+        MockSlingHttpServletRequest request = context.request();
+        HttpServletResponseWrapper response = Mockito.mock(HttpServletResponseWrapper.class);
+        Mockito.when(response.getContentType())
+            .thenReturn(null);
+        Mockito.when(response.getWriter())
+            .thenReturn(new PrintWriter(new StringWriter()));
+        FilterChain filterChain = (servletRequest, servletResponse) -> {};
+        tableOfContentsFilter.doFilter(request, response, filterChain);
+    }
+
     private void checkFilterResponse(String htmlContentPagePath, String expectedHtmlContentPagePath, boolean setTocFlag,
                                      String errorMessage)
         throws Exception {


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | fixes #2229 ([SITES-6826](https://jira.corp.adobe.com/browse/SITES-6826))
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

If pages do not have contentType set a NPE can be caused on line 89:

https://github.com/adobe/aem-core-wcm-components/blob/main/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/TableOfContentsFilter.java#L89
