### PR TITLE
[Button] Web links with encoded characters are breaking due to double…

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkHandler.java
@@ -15,6 +15,9 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.link;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -211,10 +214,16 @@ public class LinkHandler {
     private Optional<Link<Page>> buildLink(String path, SlingHttpServletRequest request, Page page,
                                            Map<String, String> htmlAttributes) {
         if (StringUtils.isNotEmpty(path)) {
+            try {
+                path = URLDecoder.decode(path, StandardCharsets.UTF_8.name());
+            } catch (UnsupportedEncodingException e) {
+                LOGGER.warn(e.getMessage());
+            }
+            String decodedPath = path;
             return pathProcessors.stream()
-                    .filter(pathProcessor -> pathProcessor.accepts(path, request))
-                    .findFirst().map(pathProcessor -> new LinkImpl<>(pathProcessor.sanitize(path, request), pathProcessor.map(path,
-                            request), pathProcessor.externalize(path, request), page, pathProcessor.processHtmlAttributes(path, htmlAttributes)));
+                    .filter(pathProcessor -> pathProcessor.accepts(decodedPath, request))
+                    .findFirst().map(pathProcessor -> new LinkImpl<>(pathProcessor.sanitize(decodedPath, request), pathProcessor.map(decodedPath,
+                            request), pathProcessor.externalize(decodedPath, request), page, pathProcessor.processHtmlAttributes(decodedPath, htmlAttributes)));
         } else {
             return Optional.of(new LinkImpl<>(path, path, path, page, htmlAttributes));
         }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ButtonImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ButtonImplTest.java
@@ -33,6 +33,7 @@ class ButtonImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1
 
     private static final String TEST_BASE = "/button/v2";
     private static final String BUTTON_2 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/button-2";
+    private static final String BUTTON_3 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/button-3";
 
     @BeforeEach
     protected void setUp() {
@@ -57,6 +58,13 @@ class ButtonImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1
         assertEquals("https://www.adobe.com", button.getLink());
         assertValidLink(button.getButtonLink(), "https://www.adobe.com", "_blank");
         Utils.testJSONExport(button, Utils.getTestExporterJSONPath(testBase, "button2"));
+    }
+
+    @Test
+    void testLinkWhichIsAlreadyEncoded() {
+        Button button = getButtonUnderTest(BUTTON_3);
+        assertEquals("https://www.adobe.com/content/dam/test/docs/pdfs/test/360/360%20Test%20Test%20Test%20123.pdf.coredownload.inline.pdf", button.getButtonLink().getHtmlAttributes().get("href"));
+        Utils.testJSONExport(button, Utils.getTestExporterJSONPath(testBase, "button3"));
     }
 
 }

--- a/bundles/core/src/test/resources/button/v2/exporter-button3.json
+++ b/bundles/core/src/test/resources/button/v2/exporter-button3.json
@@ -1,0 +1,24 @@
+{
+    "id": "button-5d8a0e1742",
+    "text": "Adobe",
+    "icon": "adobe",
+    "buttonLink":
+    {
+        "valid": true,
+        "attributes":
+        {
+            "target": "_blank"
+        },
+        "url": "https://www.adobe.com/content/dam/test/docs/pdfs/test/360/360%20Test%20Test%20Test%20123.pdf.coredownload.inline.pdf"
+    },
+    ":type": "core/wcm/components/button/v2/button",
+    "dataLayer":
+    {
+        "button-5d8a0e1742":
+        {
+            "@type": "core/wcm/components/button/v2/button",
+            "dc:title": "Adobe",
+            "xdm:linkURL": "https://www.adobe.com/content/dam/test/docs/pdfs/test/360/360%20Test%20Test%20Test%20123.pdf.coredownload.inline.pdf"
+        }
+    }
+}

--- a/bundles/core/src/test/resources/button/v2/test-content.json
+++ b/bundles/core/src/test/resources/button/v2/test-content.json
@@ -26,6 +26,14 @@
                     "link"              : "https://www.adobe.com",
                     "linkTarget"        : "_blank",
                     "icon"              : "adobe"
+                  },
+                  "button-3"          : {
+                  "jcr:primaryType"   : "nt:unstructured",
+                  "jcr:title"         : "Adobe",
+                  "sling:resourceType": "core/wcm/components/button/v2/button",
+                  "linkURL"           : "https://www.adobe.com/content/dam/test/docs/pdfs/test/360/360%20Test%20Test%20Test%20123.pdf.coredownload.inline.pdf",
+                  "linkTarget"        : "_blank",
+                  "icon"              : "adobe"
                   }
                 }
             }


### PR DESCRIPTION
… encoding

- decode path before passing it over to the PathProcessor to make sure the path is always decoded
- add JUnit test to validate changes

fixes #2234

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2234
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | 👎
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
