### PR TITLE
#2236 Remove Granite.I18n.get usage

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/site/clientlibs/link/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/site/clientlibs/link/.content.xml
@@ -2,5 +2,4 @@
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     categories="[core.wcm.components.commons.site.link]"
-    dependencies="[granite.utils]"
     allowProxy="{Boolean}true"/>


### PR DESCRIPTION
This is more like a quick fix to get rid of the jQuery being loaded on the site - removing the i18n string translation that shall only be used on author - but not on publish.