### PR TITLE
[DataLayer] Add a configuration to not include the data layer client …

### DIFF
--- a/DATA_LAYER_INTEGRATION.md
+++ b/DATA_LAYER_INTEGRATION.md
@@ -28,11 +28,11 @@ To enable the data layer for your site:
 1. Add the `enabled` boolean property and set it to `true`.
 1. Add a `sling:configRef` property to the `jcr:content` node of your site below `/content` (e.g. `/content/<my-site>/jcr:content`) and set it to `/conf/<my-site>`
 
-## Preventing the Data Layer client library to be included
+## Preventing the Data Layer client library from being included
 
 The data layer client library is included by default by the Page component. As there are other ways to include this library (e.g. through Adobe Launch), it might be needed to prevent its inclusion through the Page component.
 
-To prevent the data layer client library to be included by the Page component:
+To prevent the data layer client library from being included by the Page component:
 1. Create the following structure below the `/conf` node:
    `/conf/<my-site>/sling:configs/com.adobe.cq.wcm.core.components.internal.DataLayerConfig`
 1. Add the `skipClientlibInclude` boolean property and set it to `true`.

--- a/DATA_LAYER_INTEGRATION.md
+++ b/DATA_LAYER_INTEGRATION.md
@@ -28,6 +28,16 @@ To enable the data layer for your site:
 1. Add the `enabled` boolean property and set it to `true`.
 1. Add a `sling:configRef` property to the `jcr:content` node of your site below `/content` (e.g. `/content/<my-site>/jcr:content`) and set it to `/conf/<my-site>`
 
+## Preventing the Data Layer client library to be included
+
+The data layer client library is included by default by the Page component. As there are other ways to include this library (e.g. through Adobe Launch), it might be needed to prevent its inclusion through the Page component.
+
+To prevent the data layer client library to be included by the Page component:
+1. Create the following structure below the `/conf` node:
+   `/conf/<my-site>/sling:configs/com.adobe.cq.wcm.core.components.internal.DataLayerConfig`
+1. Add the `skipClientlibInclude` boolean property and set it to `true`.
+1. Add a `sling:configRef` property to the `jcr:content` node of your site below `/content` (e.g. `/content/<my-site>/jcr:content`) and set it to `/conf/<my-site>`
+
 ## Data Layer State Structure
 
 When the data layer is enabled, the javascript `adobeDataLayer` object is available on the page and is populated with the components and their properties that are used on the page.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/DataLayerConfig.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/DataLayerConfig.java
@@ -31,4 +31,12 @@ public @interface DataLayerConfig {
     @Property(label="Data Layer enabled")
     boolean enabled() default false;
 
+    /**
+     *
+     * @return {@code true} if the data layer client library is not included through the Core Page component,
+     * {@code false} otherwise. It defaults to {@code false} (client library included).
+     */
+    @Property(label="Data Layer client library not included")
+    boolean noClientlibIncluded() default false;
+
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/DataLayerConfig.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/DataLayerConfig.java
@@ -37,6 +37,6 @@ public @interface DataLayerConfig {
      * {@code false} otherwise. It defaults to {@code false} (client library included).
      */
     @Property(label="Data Layer client library not included")
-    boolean noClientlibIncluded() default false;
+    boolean skipClientlibInclude() default false;
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImpl.java
@@ -57,7 +57,7 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     public boolean isDataLayerClientlibIncluded() {
         return Optional.ofNullable(resource.adaptTo(ConfigurationBuilder.class))
                 .map(builder -> builder.as(DataLayerConfig.class))
-                .map(config -> !config.noClientlibIncluded())
+                .map(config -> !config.skipClientlibInclude())
                 .orElse(true);
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImpl.java
@@ -15,7 +15,10 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v3;
 
+import java.util.Optional;
+
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.caconfig.ConfigurationBuilder;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
 import org.jetbrains.annotations.NotNull;
@@ -23,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.commons.link.LinkManager;
+import com.adobe.cq.wcm.core.components.internal.DataLayerConfig;
 import com.adobe.cq.wcm.core.components.internal.models.v2.RedirectItemImpl;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.adobe.cq.wcm.core.components.models.Page;
@@ -46,6 +50,15 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
             return currentStyle.get(PN_CLIENTLIBS_ASYNC, false);
         }
         return false;
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isDataLayerClientlibIncluded() {
+        return Optional.ofNullable(resource.adaptTo(ConfigurationBuilder.class))
+                .map(builder -> builder.as(DataLayerConfig.class))
+                .map(config -> !config.noClientlibIncluded())
+                .orElse(true);
     }
 
     protected NavigationItem newRedirectItem(@NotNull String redirectTarget, @NotNull SlingHttpServletRequest request, @NotNull LinkManager linkManager) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
@@ -459,4 +459,12 @@ public interface Page extends ContainerExporter, Component {
      */
     default boolean isClientlibsAsync() {return false;}
 
+    /**
+     * Checks if the data layer client library should be included.
+     *
+     * {@code true} if the data layer client library should be included.
+     * @since om.adobe.cq.wcm.core.components.models 12.24.0
+     */
+    default boolean isDataLayerClientlibIncluded() {return true;}
+
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.26.0")
+@Version("12.27.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/Utils.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/Utils.java
@@ -154,15 +154,30 @@ public class Utils {
     }
 
     /**
-     * Sets the data layer context aware configuration of the AEM test context to enabled/disabled
+     * Sets the data layer context aware configuration of the AEM test context to enable the data layer.
      *
      * @param context The AEM test context
      * @param enabled {@code true} to enable the data layer, {@code false} to disable it
      */
     public static void enableDataLayer(AemContext context, boolean enabled) {
+        configureDataLayer(context, enabled, false);
+    }
+
+    /**
+     * Sets the data layer context aware configuration of the AEM test context to not include the data layer clientlib.
+     *
+     * @param context The AEM test context
+     * @param skip {@code true} to not include the data layer clientlib, {@code false} to include it
+     */
+    public static void skipDataLayerInclude(AemContext context, boolean skip) {
+        configureDataLayer(context, true, skip);
+    }
+
+    private static void configureDataLayer(AemContext context, boolean enabled, boolean skip) {
         ConfigurationBuilder builder = Mockito.mock(ConfigurationBuilder.class);
         DataLayerConfig dataLayerConfig = Mockito.mock(DataLayerConfig.class);
         lenient().when(dataLayerConfig.enabled()).thenReturn(enabled);
+        lenient().when(dataLayerConfig.skipClientlibInclude()).thenReturn(skip);
         lenient().when(builder.as(DataLayerConfig.class)).thenReturn(dataLayerConfig);
         context.registerAdapter(Resource.class, ConfigurationBuilder.class, builder);
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImplTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.adobe.cq.wcm.core.components.models.Page;
+
+import static com.adobe.cq.wcm.core.components.Utils.skipDataLayerInclude;
 import static com.adobe.cq.wcm.core.components.internal.link.LinkTestUtils.assertValidLink;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -90,8 +92,22 @@ public class PageImplTest extends com.adobe.cq.wcm.core.components.internal.mode
     }
 
     @Test
-    protected void testIsDataLayerClientlibIncluded() {
+    protected void testIsDataLayerClientlibIncluded_caconfig_undefined() {
         Page page = getPageUnderTest(PAGE);
+        assertTrue(page.isDataLayerClientlibIncluded(), "The data layer clientlib should be included.");
+    }
+
+    @Test
+    protected void testIsDataLayerClientlibIncluded_caconfig_true() {
+        Page page = getPageUnderTest(PAGE);
+        skipDataLayerInclude(context,true);
+        assertFalse(page.isDataLayerClientlibIncluded(), "The data layer clientlib should not be included.");
+    }
+
+    @Test
+    protected void testIsDataLayerClientlibIncluded_caconfig_false() {
+        Page page = getPageUnderTest(PAGE);
+        skipDataLayerInclude(context,false);
         assertTrue(page.isDataLayerClientlibIncluded(), "The data layer clientlib should be included.");
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImplTest.java
@@ -89,4 +89,10 @@ public class PageImplTest extends com.adobe.cq.wcm.core.components.internal.mode
         assertFalse(async);
     }
 
+    @Test
+    protected void testIsDataLayerClientlibIncluded() {
+        Page page = getPageUnderTest(PAGE);
+        assertTrue(page.isDataLayerClientlibIncluded(), "The data layer clientlib should be included.");
+    }
+
 }

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/headlibs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/headlibs.html
@@ -26,5 +26,5 @@
     <sly data-sly-test="${clientLibCategoriesJsHead}" data-sly-call="${clientlib.js @ categories=clientLibCategoriesJsHead, async=page.isClientlibsAsync}"></sly>
     <sly data-sly-test="${clientLibCategories}" data-sly-call="${clientlib.css @ categories=clientLibCategories}"></sly>
     <link data-sly-test="${staticDesignPath}" href="${staticDesignPath}" rel="stylesheet" type="text/css" />
-    <sly data-sly-test="${page.data}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.v1', async=true}"></sly>
+    <sly data-sly-test="${page.data && page.dataLayerClientlibIncluded}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.v1', async=true}"></sly>
 </template>


### PR DESCRIPTION
…library

- introduce a context-aware property to the existing DataLayerConfig to disable the inclusion of the data layer client library in the Page component

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2250 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | No
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
