### PR TITLE
SITES-4621 Keep access to unused in between content

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/ContentFragment.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/ContentFragment.java
@@ -118,4 +118,15 @@ public interface ContentFragment extends DAMContentFragment, ContainerExporter, 
     default String[] getParagraphs() {
         return null;
     }
+
+    /**
+     * Returns the remaining unused par# for in-between-content.
+     *
+     * @return an array containing par# labels
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.6.0
+     */
+    @Nullable
+    default Integer[] getRemainingInBetweenContent() {
+        return null;
+    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/package-info.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("1.5.1")
+@Version("1.6.0")
 package com.adobe.cq.wcm.core.components.models.contentfragment;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/AbstractContentFragmentTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/AbstractContentFragmentTest.java
@@ -59,6 +59,7 @@ public abstract class AbstractContentFragmentTest<T> {
     static final String CF_STRUCTURED_NESTED_MODEL = "structured-nested-model";
     static final String CF_STRUCTURED_SINGLE_ELEMENT = "structured-single-element";
     static final String CF_STRUCTURED_SINGLE_ELEMENT_MAIN = "structured-single-element-main";
+    static final String CF_STRUCTURED_SINGLE_ELEMENT_MAIN_REMAINING_IN_BETWEEN_CONTENT = "structured-single-element-main-remaining-in-between";
     static final String CF_STRUCTURED_MULTIPLE_ELEMENTS = "structured-multiple-elements";
 
     /* contents of the text-only and structured content fragments referenced by the above components */

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
@@ -188,6 +188,14 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
     }
 
     @Test
+    void structuredSingleElementMainRemainingInBetweenContent() {
+        when(fragmentRenderService.render(any(Resource.class))).thenReturn(MAIN_CONTENT);
+        ContentFragment fragment = getModelInstanceUnderTest(CF_STRUCTURED_SINGLE_ELEMENT_MAIN_REMAINING_IN_BETWEEN_CONTENT);
+        assertContentFragment(fragment, TITLE, DESCRIPTION, STRUCTURED_TYPE, STRUCTURED_NAME, ASSOCIATED_CONTENT, MAIN);
+        Utils.testJSONExport(fragment, Utils.getTestExporterJSONPath(TEST_BASE, CF_STRUCTURED_SINGLE_ELEMENT_MAIN_REMAINING_IN_BETWEEN_CONTENT));
+    }
+
+    @Test
     void getExportedType() {
         ContentFragment fragment = getModelInstanceUnderTest(CF_TEXT_ONLY);
         assertEquals(ContentFragmentImpl.RESOURCE_TYPE, fragment.getExportedType());

--- a/bundles/core/src/test/resources/contentfragment/exporter-structured-multiple-elements.json
+++ b/bundles/core/src/test/resources/contentfragment/exporter-structured-multiple-elements.json
@@ -1,5 +1,6 @@
 {
     "id": "contentfragment-b6b8c19a20",
+    "remainingInBetweenContent":[],
     "title": "Test Content Fragment",
     "description": "This is a test content fragment.",
     "model": "global/models/test",

--- a/bundles/core/src/test/resources/contentfragment/exporter-structured-nested-model.json
+++ b/bundles/core/src/test/resources/contentfragment/exporter-structured-nested-model.json
@@ -1,5 +1,6 @@
 {
     "id": "contentfragment-84f882bb92",
+    "remainingInBetweenContent":[],
     "description": "This is a test content fragment.",
     "title": "Test Content Fragment",
     "model": "global/nested/models/test",

--- a/bundles/core/src/test/resources/contentfragment/exporter-structured-single-element-main-remaining-in-between.json
+++ b/bundles/core/src/test/resources/contentfragment/exporter-structured-single-element-main-remaining-in-between.json
@@ -1,12 +1,17 @@
 {
-    "id": "contentfragment-a68b9c84f9",
-    "remainingInBetweenContent":[],
+    "id": "contentfragment-d3375413df",
     "description": "This is a test content fragment.",
+    "remainingInBetweenContent":[3, 6, 8],
     "paragraphs": [
         "<p>Main content</p>"
     ],
     "title": "Test Content Fragment",
     "model": "global/models/test",
+    ":items": {},
+    ":itemsOrder": [],
+    "elementsOrder": [
+        "main"
+    ],
     ":type": "core/wcm/components/contentfragment/v1/contentfragment",
     "elements": {
         "main": {
@@ -14,21 +19,6 @@
             "title": "Main",
             "multiValue": false,
             ":type": "text/html"
-        },
-        "second": {
-            "value": [
-                "one",
-                "two",
-                "three"
-            ],
-            "title": "Second",
-            "multiValue": true
         }
-    },
-    ":items": {},
-    ":itemsOrder": [],
-    "elementsOrder": [
-        "main",
-        "second"
-    ]
+    }
 }

--- a/bundles/core/src/test/resources/contentfragment/exporter-structured-single-element-main.json
+++ b/bundles/core/src/test/resources/contentfragment/exporter-structured-single-element-main.json
@@ -1,5 +1,6 @@
 {
     "id": "contentfragment-693827d63c",
+    "remainingInBetweenContent":[],
     "description": "This is a test content fragment.",
     "paragraphs": [
         "<p>Main content</p>"

--- a/bundles/core/src/test/resources/contentfragment/exporter-structured-single-element.json
+++ b/bundles/core/src/test/resources/contentfragment/exporter-structured-single-element.json
@@ -1,5 +1,6 @@
 {
     "id": "contentfragment-0ddb9b4c75",
+    "remainingInBetweenContent":[],
     "title": "Test Content Fragment",
     "description": "This is a test content fragment.",
     "model": "global/models/test",

--- a/bundles/core/src/test/resources/contentfragment/exporter-structured-variation.json
+++ b/bundles/core/src/test/resources/contentfragment/exporter-structured-variation.json
@@ -1,5 +1,6 @@
 {
     "id": "contentfragment-a8af0bfdae",
+    "remainingInBetweenContent":[],
     "title": "Test Content Fragment",
     "description": "This is a test content fragment.",
     "model": "global/models/test",

--- a/bundles/core/src/test/resources/contentfragment/exporter-structured.json
+++ b/bundles/core/src/test/resources/contentfragment/exporter-structured.json
@@ -1,5 +1,6 @@
 {
     "id": "contentfragment-a9d49ab72f",
+    "remainingInBetweenContent":[],
     "description": "This is a test content fragment.",
     "title": "Test Content Fragment",
     "model": "global/models/test",

--- a/bundles/core/src/test/resources/contentfragment/exporter-text-only-multiple-elements.json
+++ b/bundles/core/src/test/resources/contentfragment/exporter-text-only-multiple-elements.json
@@ -1,5 +1,6 @@
 {
     "id": "contentfragment-2204dfcbac",
+    "remainingInBetweenContent":[],
     "title": "Test Content Fragment",
     "description": "This is a test content fragment.",
     "model": "/content/dam/contentfragments/text-only/jcr:content/model",

--- a/bundles/core/src/test/resources/contentfragment/exporter-text-only-non-existing-variation.json
+++ b/bundles/core/src/test/resources/contentfragment/exporter-text-only-non-existing-variation.json
@@ -1,5 +1,6 @@
 {
     "id": "contentfragment-d88c46402d",
+    "remainingInBetweenContent":[],
     "description": "This is a test content fragment.",
     "title": "Test Content Fragment",
     "model": "/content/dam/contentfragments/text-only/jcr:content/model",

--- a/bundles/core/src/test/resources/contentfragment/exporter-text-only-single-element.json
+++ b/bundles/core/src/test/resources/contentfragment/exporter-text-only-single-element.json
@@ -1,5 +1,6 @@
 {
     "id": "contentfragment-aca8901d9b",
+    "remainingInBetweenContent":[],
     "description": "This is a test content fragment.",
     "title": "Test Content Fragment",
     "model": "/content/dam/contentfragments/text-only/jcr:content/model",

--- a/bundles/core/src/test/resources/contentfragment/exporter-text-only-variation.json
+++ b/bundles/core/src/test/resources/contentfragment/exporter-text-only-variation.json
@@ -1,5 +1,6 @@
 {
     "id": "contentfragment-2b056e758c",
+    "remainingInBetweenContent":[],
     "description": "This is a test content fragment.",
     "title": "Test Content Fragment",
     "model": "/content/dam/contentfragments/text-only/jcr:content/model",

--- a/bundles/core/src/test/resources/contentfragment/exporter-text-only.json
+++ b/bundles/core/src/test/resources/contentfragment/exporter-text-only.json
@@ -1,5 +1,6 @@
 {
     "id": "contentfragment-bb4058160c",
+    "remainingInBetweenContent":[],
     "title": "Test Content Fragment",
     "description": "This is a test content fragment.",
     "model": "/content/dam/contentfragments/text-only/jcr:content/model",

--- a/bundles/core/src/test/resources/contentfragment/test-content.json
+++ b/bundles/core/src/test/resources/contentfragment/test-content.json
@@ -110,6 +110,22 @@
                         "elementNames"      : ["main"],
                         "displayMode"       : "singleText"
                     },
+                    "structured-single-element-main-remaining-in-between"       : {
+                        "jcr:primaryType"   : "nt:unstructured",
+                        "sling:resourceType": "core/wcm/components/contentfragment/v1/contentfragment",
+                        "fragmentPath"      : "/content/dam/contentfragments/structured",
+                        "elementNames"      : ["main"],
+                        "displayMode"       : "singleText",
+                        "par6": {
+                            "jcr:primaryType"   : "nt:unstructured"
+                        },
+                        "par8": {
+                            "jcr:primaryType"   : "nt:unstructured"
+                        },
+                        "par3": {
+                            "jcr:primaryType"   : "nt:unstructured"
+                        }
+                    },
                     "structured-multiple-elements"         : {
                         "jcr:primaryType"   : "nt:unstructured",
                         "sling:resourceType": "core/wcm/components/contentfragment/v1/contentfragment",

--- a/bundles/core/src/test/resources/findbugs-exclude.xml
+++ b/bundles/core/src/test/resources/findbugs-exclude.xml
@@ -29,7 +29,7 @@
     </Match>
     <Match>
         <Class name="com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment.ContentFragmentImpl" />
-        <Method name="getParagraphs" />
+        <Method name="computeParagraphs" />
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
     </Match>
 </FindBugsFilter>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/templates.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/templates.html
@@ -43,6 +43,9 @@
             ${item @ context="html"}
             <div data-sly-resource="${'par{0}' @ format=itemList.count, resourceType=fragment.gridResourceType}"></div>
         </div>
+        <div data-sly-list="${fragment.remainingInBetweenContent}">
+            <div data-sly-resource="${'par{0}' @ format=item, resourceType=fragment.gridResourceType}"></div>
+        </div>
     </div>
 </template>
 


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

- Updated ContentFragment model API to expose the list of "par#" that are not displayed anymore when content structure changed (usually when paragraphs are removed).
- Updated the ContentFragmentImpl to compute paragraphs and remainingInBetweenContent information
- Update "templates.html" in order to output remaining in between content at the end.
- Updated all the related tests

Feel free to commit , reuse this code.