### PR TITLE
[Teaser] The setting of "Title Type" disappeared from Configure Dialog of Teaser component after #2142

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -83,7 +83,7 @@
                                                         name="./jcr:title"
                                                         value="${cqDesign._jcr_description}"/>
                                                     <titleType
-                                                        granite:hide="${!cqDesign.showTitleType}"
+                                                        granite:hide="${!cqDesign.showTitleType or (empty cqDesign.allowedHeadingElements and empty cqDesign.allowedTypes)}"
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                                         fieldDescription="The heading HTML element used for the teaser's title type."
@@ -95,6 +95,44 @@
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="core/wcm/components/title/v1/datasource/allowedtypes"/>
                                                     </titleType>
+                                                    <titleTypeBackwardsCompatibility
+                                                            granite:hide="${!cqDesign.showTitleType or not empty cqDesign.allowedHeadingElements or not empty cqDesign.allowedTypes}"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                            fieldLabel="Title Type"
+                                                            name="./titleType"
+                                                            granite:class="foundation-toggleable">
+                                                        <items jcr:primaryType="nt:unstructured">
+                                                            <def
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="(default)"
+                                                                value=""/>
+                                                            <h1
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H1"
+                                                                value="h1"/>
+                                                            <h2
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H2"
+                                                                value="h2"/>
+                                                            <h3
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H3"
+                                                                value="h3"/>
+                                                            <h4
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H4"
+                                                                value="h4"/>
+                                                            <h5
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H5"
+                                                                value="h5"/>
+                                                            <h6
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H6"
+                                                                value="h6"/>
+                                                        </items>
+                                                    </titleTypeBackwardsCompatibility>
                                                     <titleFromLinkedPage
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
@@ -132,7 +132,7 @@
                                                         name="./jcr:title"
                                                         value="${cqDesign._jcr_description}"/>
                                                     <titleType
-                                                        granite:hide="${!cqDesign.showTitleType}"
+                                                        granite:hide="${!cqDesign.showTitleType or (empty cqDesign.allowedHeadingElements and empty cqDesign.allowedTypes)}"
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                                         fieldDescription="The heading HTML element used for the teaser's title type."
@@ -144,6 +144,44 @@
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="core/wcm/components/title/v1/datasource/allowedtypes"/>
                                                     </titleType>
+                                                    <titleTypeBackwardsCompatibility
+                                                            granite:hide="${!cqDesign.showTitleType or not empty cqDesign.allowedHeadingElements or not empty cqDesign.allowedTypes}"
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                            fieldLabel="Title Type"
+                                                            name="./titleType"
+                                                            granite:class="foundation-toggleable">
+                                                        <items jcr:primaryType="nt:unstructured">
+                                                            <def
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="(default)"
+                                                                value=""/>
+                                                            <h1
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H1"
+                                                                value="h1"/>
+                                                            <h2
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H2"
+                                                                value="h2"/>
+                                                            <h3
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H3"
+                                                                value="h3"/>
+                                                            <h4
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H4"
+                                                                value="h4"/>
+                                                            <h5
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H5"
+                                                                value="h5"/>
+                                                            <h6
+                                                                jcr:primaryType="nt:unstructured"
+                                                                text="H6"
+                                                                value="h6"/>
+                                                        </items>
+                                                    </titleTypeBackwardsCompatibility>
                                                     <titleFromLinkedPage
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -66,7 +66,7 @@
         <maven.compiler.source>${aem.java.version}</maven.compiler.source>
         <maven.compiler.target>${aem.java.version}</maven.compiler.target>
         <jackson.version>2.11.3</jackson.version>
-        <aem.selenium.base.it.version>0.2.33-SNAPSHOT</aem.selenium.base.it.version>
+        <aem.selenium.base.it.version>0.2.34</aem.selenium.base.it.version>
     </properties>
 
     <!-- ======================================================================= -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -66,6 +66,7 @@
         <maven.compiler.source>${aem.java.version}</maven.compiler.source>
         <maven.compiler.target>${aem.java.version}</maven.compiler.target>
         <jackson.version>2.11.3</jackson.version>
+        <aem.selenium.base.it.version>0.2.33-SNAPSHOT</aem.selenium.base.it.version>
     </properties>
 
     <!-- ======================================================================= -->

--- a/testing/it/e2e-selenium-utils/pom.xml
+++ b/testing/it/e2e-selenium-utils/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>aem-selenium-it-base</artifactId>
-            <version>0.2.32</version>
+            <version>${aem.selenium.base.it.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/components/teaser/v1/TeaserEditDialog.java
+++ b/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/components/teaser/v1/TeaserEditDialog.java
@@ -18,6 +18,7 @@ package com.adobe.cq.wcm.core.components.it.seljup.util.components.teaser.v1;
 
 import com.adobe.cq.testing.selenium.pagewidgets.coral.CoralCheckbox;
 import com.adobe.cq.testing.selenium.pagewidgets.cq.AutoCompleteField;
+import com.codeborne.selenide.DragAndDropOptions;
 
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
@@ -38,7 +39,7 @@ public class TeaserEditDialog {
     private static String imageFromPageImage = "[name='./imageFromPageImage']";
     private static String titleTypeSelectDropdown = "coral-select[name='./titleType']";
     private static String titleTypeSelectDropdownDefaultSelected = "coral-select[name='./titleType'] coral-select-item[selected]";
-    private static String assetWithoutDescriptionErrorMessage = "coral-tooltip[variant='error'] coral-tooltip-content";
+    private static String assetWithoutDescriptionErrorMessage = ".cmp-image__editor-alt .coral-Form-errorlabel";
     private static String altTextFromAssetDescription = ".cmp-teaser__editor input[name='./altValueFromDAM']";
 
     protected String getActionLinkURLSelector() {
@@ -50,7 +51,7 @@ public class TeaserEditDialog {
     }
 
     public void uploadImageFromSidePanel(String imagePath) {
-        $(String.format(imageInSidePanel,imagePath)).dragAndDropTo(assetUpload);
+        $(String.format(imageInSidePanel,imagePath)).dragAndDropTo(assetUpload, DragAndDropOptions.usingActions());
     }
 
     public void setLinkURL(String url) {

--- a/testing/it/e2e-selenium/pom.xml
+++ b/testing/it/e2e-selenium/pom.xml
@@ -266,7 +266,7 @@
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>aem-selenium-it-base</artifactId>
-            <version>0.2.32</version>
+            <version>${aem.selenium.base.it.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/teaser/v1/TeaserIT.java
+++ b/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/teaser/v1/TeaserIT.java
@@ -491,6 +491,22 @@ public class TeaserIT extends AuthorBaseUITest {
         assertTrue(editDialog.isTitleTypeSelectDropdownDisplayed());
         assertEquals(editDialog.getTitleTypeSelectDropdownDefaultSelectedText(), "h3");
     }
+
+    @Test
+    @DisplayName("Test: Check the title type selection when no allowed types are defined (backwards compatibility mode).")
+    public void testTypeTypeSelectDropdownNoAllowedTypes() throws ClientException, InterruptedException, TimeoutException {
+        createComponentPolicy(teaserRT.substring(teaserRT.lastIndexOf("/")), new ArrayList<NameValuePair>() {{
+            add(new BasicNameValuePair("showTitleType", "true"));
+        }});
+
+        editorPage.refresh();
+
+        Commons.openEditDialog(editorPage, cmpPath);
+        TeaserEditDialog editDialog = teaser.getEditDialog();
+        editDialog.openTextTab();
+        assertTrue(editDialog.isTitleTypeSelectDropdownDisplayed());
+        assertEquals("(default)", editDialog.getTitleTypeSelectDropdownDefaultSelectedText());
+    }
     // ----------------------------------------------------------
     // private stuff
     // ----------------------------------------------------------


### PR DESCRIPTION
* Added backwards compatibility fallback to old title type selection in case there are no configured allowed types/headings.
* Updated selenium base and fixed previously failing tests
* Added new IT

Fixes #2266
