### PR TITLE
SITES-7428: mask Adobe Campaign expression before decoding URLs

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkBuilderImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkBuilderImpl.java
@@ -16,12 +16,18 @@
 package com.adobe.cq.wcm.core.components.internal.link;
 
 import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -54,7 +60,7 @@ import static com.adobe.cq.wcm.core.components.internal.link.LinkImpl.ATTR_TITLE
 public class LinkBuilderImpl implements LinkBuilder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LinkBuilderImpl.class);
-
+    private final static List<Pattern> PATTERNS = Collections.singletonList(Pattern.compile("(<%[=@].*?%>)"));
     public static final String HTML_EXTENSION = ".html";
 
     SlingHttpServletRequest request;
@@ -156,7 +162,12 @@ public class LinkBuilderImpl implements LinkBuilder {
     private @NotNull Link buildLink(String path, SlingHttpServletRequest request, Map<String, String> htmlAttributes) {
         if (StringUtils.isNotEmpty(path)) {
             try {
-                path = URLDecoder.decode(path, StandardCharsets.UTF_8.name());
+                // The link contain character sequences that are not well formatted and cannot be decoded, for example
+                // Adobe Campaign expressions like: /content/path/to/page.html?recipient=<%= recipient.id %>
+                Map<String, String> placeholders = new LinkedHashMap<>();
+                String maskedPath = mask(path, placeholders);
+                maskedPath = URLDecoder.decode(maskedPath, StandardCharsets.UTF_8.name());
+                path = unmask(maskedPath, placeholders);
             } catch (UnsupportedEncodingException e) {
                 LOGGER.warn(e.getMessage());
             }
@@ -292,6 +303,65 @@ public class LinkBuilderImpl implements LinkBuilder {
         }
         Page resolved = Optional.ofNullable(pair.getLeft()).orElse(page);
         return new ImmutablePair<>(resolved, getPageLinkURL(resolved));
+    }
+
+    /**
+     * Masks a given {@link String} by replacing all occurrences of {@link LinkBuilderImpl#PATTERNS} with a placeholder.
+     * The generated placeholders are put into the given {@link Map} and can be used to unmask a {@link String} later on.
+     *
+     * @param original     the original {@link String}
+     * @param placeholders a {@link Map} the generated placeholders will be put in
+     * @return the masked {@link String}
+     * @see LinkBuilderImpl#unmask(String, Map)
+     */
+    private static String mask(String original, Map<String, String> placeholders) {
+        String masked = original;
+        for (Pattern pattern : PATTERNS) {
+            Matcher matcher = pattern.matcher(masked);
+            while (matcher.find()) {
+                String expression = matcher.group(1);
+                String placeholder = newPlaceholder(masked);
+                masked = masked.replaceFirst(Pattern.quote(expression), placeholder);
+                placeholders.put(placeholder, expression);
+            }
+        }
+        return masked;
+    }
+
+    /**
+     * Unmasks the given {@link String} by replacing the given placeholders with their original value.
+     *
+     * @param masked       the masked {@link String}
+     * @param placeholders the {@link Map} of placeholders to replace
+     * @return the unmasked {@link String}
+     */
+    private static String unmask(String masked, Map<String, String> placeholders) {
+        String unmasked = masked;
+        for (Map.Entry<String, String> placeholder : placeholders.entrySet()) {
+            unmasked = unmasked.replaceFirst(placeholder.getKey(), placeholder.getValue());
+        }
+        return unmasked;
+    }
+
+    /**
+     * Generate a new random placeholder that is not conflicting with any character sequence in the the given {@link String}.
+     *
+     * @param str the given {@link String}
+     * @return the placeholder name
+     */
+    private static String newPlaceholder(String str) {
+        SecureRandom random = new SecureRandom();
+        StringBuilder placeholderBuilder = new StringBuilder(5);
+
+        do {
+            placeholderBuilder.setLength(0);
+            placeholderBuilder
+                .append("_")
+                .append(new BigInteger(16, random).toString(16))
+                .append("_");
+        } while (str.contains(placeholderBuilder));
+
+        return placeholderBuilder.toString();
     }
 
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkBuilderImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkBuilderImplTest.java
@@ -1,0 +1,98 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.link;
+
+import java.util.Collections;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.adobe.cq.wcm.core.components.commons.link.Link;
+import com.adobe.cq.wcm.core.components.services.link.PathProcessor;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({ AemContextExtension.class})
+class LinkBuilderImplTest {
+
+    public final AemContext context = new AemContext();
+    private PathProcessor pathProcessor = mock(PathProcessor.class);
+
+    @BeforeEach
+    void setup() {
+        when(pathProcessor.accepts(any(), any())).thenReturn(Boolean.TRUE);
+        when(pathProcessor.map(any(), any())).then(returnsFirstArg());
+        when(pathProcessor.sanitize(any(), any())).then(returnsFirstArg());
+        when(pathProcessor.externalize(any(), any())).then(returnsFirstArg());
+    }
+
+    @Test
+    void testEmptyLink() {
+        Link link = new LinkBuilderImpl("" ,context.request(), Collections.singletonList(pathProcessor), false)
+            .build();
+
+        assertNotNull(link);
+        assertNull(link.getExternalizedURL());
+        assertNull(link.getURL());
+        assertNull(link.getMappedURL());
+        assertFalse(link.isValid());
+
+        verify(pathProcessor, never()).map(any(), any());
+        verify(pathProcessor, never()).externalize(any(), any());
+        verify(pathProcessor, never()).sanitize(any(), any());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "/content/path/to/page, /content/path/to/page.html, /content/path/to/page.html",
+        "/content/path/to/page.html, /content/path/to/page.html,",
+        "/content/path/to/page.html?recipient=<%= recipient.id %>, /content/path/to/page.html?recipient=<%= recipient.id %>,",
+    })
+    void testLinkToPage(String given, String expected, String passedDownToPathProcessor) {
+        context.create().page("/content/path/to/page");
+
+        Link link = new LinkBuilderImpl(given, context.request(), Collections.singletonList(pathProcessor), false)
+            .build();
+
+        assertNotNull(link);
+        assertEquals(expected, link.getURL());
+        assertEquals(expected, link.getMappedURL());
+        assertEquals(expected, link.getExternalizedURL());
+
+        passedDownToPathProcessor = StringUtils.defaultIfEmpty(passedDownToPathProcessor, given);
+
+        verify(pathProcessor).map(eq(passedDownToPathProcessor), any());
+        verify(pathProcessor).externalize(eq(passedDownToPathProcessor), any());
+        verify(pathProcessor).sanitize(eq(passedDownToPathProcessor), any());
+    }
+
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkBuilderImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkBuilderImplTest.java
@@ -75,7 +75,12 @@ class LinkBuilderImplTest {
     @CsvSource({
         "/content/path/to/page, /content/path/to/page.html, /content/path/to/page.html",
         "/content/path/to/page.html, /content/path/to/page.html,",
+        // with Adobe Campaign expressions
         "/content/path/to/page.html?recipient=<%= recipient.id %>, /content/path/to/page.html?recipient=<%= recipient.id %>,",
+        // with Adobe Campaign expressions and other encoded character sequences
+        "https://foo.bar/%E9%A1%B5.html?recipient=<%= recipient.id %>, https://foo.bar/页.html?recipient=<%= recipient.id %>, https://foo.bar/页.html?recipient=<%= recipient.id %>",
+        // malformed url
+        "/content/path/to/page.html?campaign=%%PLACEHOLDER%%, /content/path/to/page.html?campaign=%%PLACEHOLDER%%,",
     })
     void testLinkToPage(String given, String expected, String passedDownToPathProcessor) {
         context.create().page("/content/path/to/page");
@@ -94,5 +99,4 @@ class LinkBuilderImplTest {
         verify(pathProcessor).externalize(eq(passedDownToPathProcessor), any());
         verify(pathProcessor).sanitize(eq(passedDownToPathProcessor), any());
     }
-
 }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2271
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes 
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

With #2196 urls get decoded before they are passed to the `PathProcessor`. This fails for links that are not well formed with an `IllegalArgumentException`, for example when they contain Adobe Campaign expressions. While it makes sense to decode urls before processing them, this may be a regression for email components.

With this PR all Adobe Campaign expressions in an url are replaced with placeholders before the url gets decoded. Afterwards the original expressions get restored. This preserves the original behaviour for links that contain Adobe Campaign expressions and still does the decoding.