### PR TITLE
Add validation in order to prevent same HTML-ID on page

### DIFF
--- a/content/pom.xml
+++ b/content/pom.xml
@@ -61,6 +61,9 @@
                         <filter>
                             <root>/apps/core/wcm/components</root>
                         </filter>
+						<filter>
+                            <root>/apps/core/wcm/clientlibs</root>
+                        </filter>
                     </filters>
                     <packageType>application</packageType>
                     <dependencies>

--- a/content/src/content/jcr_root/apps/core/wcm/clientlibs/authoring/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/clientlibs/authoring/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[cq.authoring.dialog]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/clientlibs/authoring/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/clientlibs/authoring/.content.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
-    categories="[cq.authoring.dialog]"/>
+    categories="[cq.authoring.dialog.all,cq.siteadmin.admin.properties]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/clientlibs/authoring/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/clientlibs/authoring/js.txt
@@ -1,0 +1,18 @@
+###############################################################################
+# Copyright 2016 Adobe Systems Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=./js
+htmlIdValidation.js

--- a/content/src/content/jcr_root/apps/core/wcm/clientlibs/authoring/js/htmlIdValidation.js
+++ b/content/src/content/jcr_root/apps/core/wcm/clientlibs/authoring/js/htmlIdValidation.js
@@ -14,26 +14,38 @@
  *  limitations under the License.
  **************************************************************************/
 (function($, window, document) {
-
+    "use strict";
     /* Adapting window object to foundation-registry */
     var registry = $(window).adaptTo("foundation-registry");
 
-    /*Validator for TextField - Validation for duplicate HTML ID authored through dialog */
+    /* Validator for TextField - Validation for duplicate HTML ID authored through dialog */
     registry.register("foundation.validation.validator", {
         selector: "[data-validation=html-unique-id-validator]",
         validate: function(el) {
-            var compPath = $(el.closest(".foundation-layout-form")).attr("action");
-            var jsonData = CQ.shared.HTTP.get(compPath+'.json');
-            var preConfiguredVal = CQ.shared.HTTP.eval(jsonData)['id'];
+            var compPath = $(el.closest("form")).attr("action");
+            var pagePath = compPath.split("/_jcr_content")[0];
+            var preConfiguredVal;
+            /* Get the pre configured value if any */
+            $.ajax({
+                type: "GET",
+                url: compPath + ".json",
+                dataType: "json",
+                async: false,
+                success: function(data) {
+                    if (data) {
+                        preConfiguredVal = data.id;
+                    }
+                }
+            });
             var element = $(el);
             var currentVal = element.val();
-            /* Handle re dialog submission */
-            if(currentVal === preConfiguredVal){
+            /* Handle dialog re-submission */
+            if (currentVal === preConfiguredVal) {
                 return;
             }
-            var url = window.location.pathname + "?wcmmode=disabled";
-            url = url.replace("/editor.html", "");
+            var url = pagePath + ".html?wcmmode=disabled";
             var idCount = 0;
+            /* Check if same ID already exist on the page */
             $.ajax({
                 type: "GET",
                 url: url,
@@ -43,7 +55,7 @@
                     var idList;
                     if (data) {
                         idList = $(data).find("[id='" + currentVal + "']");
-                        if(idList) {
+                        if (idList) {
                             idCount = idList.length;
                         }
                     }
@@ -54,5 +66,4 @@
             }
         }
     });
-})
-($, window, document);
+})($, window, document);

--- a/content/src/content/jcr_root/apps/core/wcm/clientlibs/authoring/js/htmlIdValidation.js
+++ b/content/src/content/jcr_root/apps/core/wcm/clientlibs/authoring/js/htmlIdValidation.js
@@ -1,0 +1,58 @@
+/***************************************************************************
+ *  Copyright 2016 Adobe Systems Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ **************************************************************************/
+(function($, window, document) {
+
+    /* Adapting window object to foundation-registry */
+    var registry = $(window).adaptTo("foundation-registry");
+
+    /*Validator for TextField - Validation for duplicate HTML ID authored through dialog */
+    registry.register("foundation.validation.validator", {
+        selector: "[data-validation=html-unique-id-validator]",
+        validate: function(el) {
+            var compPath = $(el.closest(".foundation-layout-form")).attr("action");
+            var jsonData = CQ.shared.HTTP.get(compPath+'.json');
+            var preConfiguredVal = CQ.shared.HTTP.eval(jsonData)['id'];
+            var element = $(el);
+            var currentVal = element.val();
+            /* Handle re dialog submission */
+            if(currentVal === preConfiguredVal){
+                return;
+            }
+            var url = window.location.pathname + "?wcmmode=disabled";
+            url = url.replace("/editor.html", "");
+            var idCount = 0;
+            $.ajax({
+                type: "GET",
+                url: url,
+                dataType: "html",
+                async: false,
+                success: function(data) {
+                    var idList;
+                    if (data) {
+                        idList = $(data).find("[id='" + currentVal + "']");
+                        if(idList) {
+                            idCount = idList.length;
+                        }
+                    }
+                }
+            });
+            if (idCount > 0) {
+                return "This ID already exist on the page, please enter a unique ID.";
+            }
+        }
+    });
+})
+($, window, document);

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/_cq_dialog/.content.xml
@@ -129,7 +129,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v1/breadcrumb/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v1/breadcrumb/_cq_dialog/.content.xml
@@ -51,7 +51,8 @@
                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                 fieldDescription="HTML ID attribute to apply to the component."
                                 fieldLabel="ID"
-                                name="./id"/>
+                                name="./id"
+								validation="html-unique-id-validator"/>
                         </items>
                     </properties>
                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/_cq_dialog/.content.xml
@@ -88,7 +88,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v3/breadcrumb/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v3/breadcrumb/_cq_dialog/.content.xml
@@ -88,7 +88,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/button/v1/button/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/button/v1/button/_cq_dialog/.content.xml
@@ -53,7 +53,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/button/v2/button/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/button/v2/button/_cq_dialog/.content.xml
@@ -77,7 +77,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -106,7 +106,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/_cq_dialog/.content.xml
@@ -118,7 +118,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                             <accessibilityLabel
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/_cq_dialog/.content.xml
@@ -139,7 +139,8 @@
                                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                         fieldDescription="HTML ID attribute to apply to the component."
                                         fieldLabel="ID"
-                                        name="./id"/>
+                                        name="./id"
+										validation="html-unique-id-validator"/>
                                 </items>
                             </column>
                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/_cq_dialog/.content.xml
@@ -101,7 +101,8 @@
                                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                         fieldDescription="HTML ID attribute to apply to the component."
                                         fieldLabel="ID"
-                                        name="./id"/>
+                                        name="./id"
+										validation="html-unique-id-validator"/>
                                 </items>
                             </column>
                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v2/contentfragmentlist/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v2/contentfragmentlist/_cq_dialog/.content.xml
@@ -101,7 +101,8 @@
                                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                         fieldDescription="HTML ID attribute to apply to the component."
                                         fieldLabel="ID"
-                                        name="./id"/>
+                                        name="./id"
+										validation="html-unique-id-validator"/>
                                 </items>
                             </column>
                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/_cq_dialog/.content.xml
@@ -252,7 +252,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v2/download/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v2/download/_cq_dialog/.content.xml
@@ -251,7 +251,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/_cq_dialog/.content.xml
@@ -165,7 +165,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v2/embed/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v2/embed/_cq_dialog/.content.xml
@@ -165,7 +165,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_dialog/.content.xml
@@ -63,7 +63,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v2/experiencefragment/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v2/experiencefragment/_cq_dialog/.content.xml
@@ -63,7 +63,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/button/v1/button/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/button/v1/button/_cq_dialog/.content.xml
@@ -64,7 +64,8 @@
                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                         fieldDescription="HTML ID attribute to apply to the component."
                         fieldLabel="ID"
-                        name="./id"/>
+                        name="./id"
+						validation="html-unique-id-validator"/>
                 </items>
             </column>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/button/v2/button/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/button/v2/button/_cq_dialog/.content.xml
@@ -97,7 +97,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/container/v1/container/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/container/v1/container/_cq_dialog/.content.xml
@@ -88,7 +88,8 @@
                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                 fieldDescription="HTML ID attribute to apply to the component."
                                 fieldLabel="ID"
-                                name="./id"/>
+                                name="./id"
+								validation="html-unique-id-validator"/>
                         </items>
                     </column>
                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/_cq_dialog/.content.xml
@@ -115,7 +115,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v1/hidden/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v1/hidden/_cq_dialog/.content.xml
@@ -32,7 +32,8 @@
                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                         fieldDescription="HTML ID attribute to apply to the component."
                         fieldLabel="ID"
-                        name="./id"/>
+                        name="./id"
+						validation="html-unique-id-validator"/>
                 </items>
             </main>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v2/hidden/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v2/hidden/_cq_dialog/.content.xml
@@ -64,7 +64,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/options/v1/options/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/options/v1/options/_cq_dialog/.content.xml
@@ -196,7 +196,8 @@
                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                 fieldDescription="HTML ID attribute to apply to the component."
                                 fieldLabel="ID"
-                                name="./id"/>
+                                name="./id"
+								validation="html-unique-id-validator"/>
                         </items>
                     </columns>
                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/options/v2/options/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/options/v2/options/_cq_dialog/.content.xml
@@ -223,7 +223,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/text/v1/text/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/text/v1/text/_cq_dialog/.content.xml
@@ -105,7 +105,8 @@
                                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                         fieldDescription="HTML ID attribute to apply to the component."
                                         fieldLabel="ID"
-                                        name="./id"/>
+                                        name="./id"
+										validation="html-unique-id-validator"/>
                                 </items>
                             </column>
                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/_cq_dialog/.content.xml
@@ -129,7 +129,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_dialog/.content.xml
@@ -75,7 +75,8 @@
                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                 fieldDescription="HTML ID attribute to apply to the component."
                                 fieldLabel="ID"
-                                name="./id"/>
+                                name="./id"
+								validation="html-unique-id-validator"/>
                         </items>
                     </column>
                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_dialog/.content.xml
@@ -214,7 +214,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/_cq_dialog/.content.xml
@@ -238,7 +238,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v1/languagenavigation/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v1/languagenavigation/_cq_dialog/.content.xml
@@ -70,7 +70,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v2/languagenavigation/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v2/languagenavigation/_cq_dialog/.content.xml
@@ -70,7 +70,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/list/v1/list/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/list/v1/list/_cq_dialog/.content.xml
@@ -272,7 +272,8 @@
                                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                         fieldDescription="HTML ID attribute to apply to the component."
                                         fieldLabel="ID"
-                                        name="./id"/>
+                                        name="./id"
+										validation="html-unique-id-validator"/>
                                 </items>
                             </column>
                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/list/v2/list/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/list/v2/list/_cq_dialog/.content.xml
@@ -292,7 +292,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/list/v3/list/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/list/v3/list/_cq_dialog/.content.xml
@@ -292,7 +292,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/_cq_dialog/.content.xml
@@ -100,7 +100,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v2/navigation/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v2/navigation/_cq_dialog/.content.xml
@@ -100,7 +100,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v1/page/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v1/page/_cq_dialog/.content.xml
@@ -55,7 +55,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </htmlid>
                                     <moretitles

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_dialog/.content.xml
@@ -72,7 +72,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </htmlid>
                                     <moretitles

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/_cq_dialog/.content.xml
@@ -74,7 +74,8 @@
                                                 cq:showOnCreate="true"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </htmlid>
                                     <moretitles

--- a/content/src/content/jcr_root/apps/core/wcm/components/progressbar/v1/progressbar/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/progressbar/v1/progressbar/_cq_dialog/.content.xml
@@ -62,7 +62,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/_cq_dialog/.content.xml
@@ -60,7 +60,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v2/search/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v2/search/_cq_dialog/.content.xml
@@ -60,7 +60,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/_cq_dialog/.content.xml
@@ -53,7 +53,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/sharing/v1/sharing/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/sharing/v1/sharing/_cq_dialog/.content.xml
@@ -53,7 +53,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tableofcontents/v1/tableofcontents/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tableofcontents/v1/tableofcontents/_cq_dialog/.content.xml
@@ -140,7 +140,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the table of contents component"
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                             <restrictedstartlevel
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/hidden"

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/_cq_dialog/.content.xml
@@ -73,7 +73,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -259,7 +259,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
@@ -308,7 +308,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/text/v1/text/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/text/v1/text/_cq_dialog/.content.xml
@@ -173,7 +173,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/_cq_dialog/.content.xml
@@ -173,7 +173,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v1/title/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v1/title/_cq_dialog/.content.xml
@@ -60,7 +60,8 @@
                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                         fieldDescription="HTML ID attribute to apply to the component."
                         fieldLabel="ID"
-                        name="./id"/>
+                        name="./id"
+						validation="html-unique-id-validator"/>
                 </items>
             </column>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_dialog/.content.xml
@@ -97,7 +97,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                             <linkAccessibilityLabel
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/form/textfield"

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v3/title/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v3/title/_cq_dialog/.content.xml
@@ -104,7 +104,8 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                 fieldDescription="HTML ID attribute to apply to the component."
                                                 fieldLabel="ID"
-                                                name="./id"/>
+                                                name="./id"
+												validation="html-unique-id-validator"/>
                                         </items>
                                     </column>
                                 </items>


### PR DESCRIPTION


| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | Fixes #1041
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
AEM author is able to add HTML IDs to all components but by this author can add duplicate IDs on the page which leads to a invalid HTML.

With this PR, a custom validation on client side is added. A custom validator is registered and a Unique validation selector is added to id field in the dialog for each component. In the htmlIdValidation JS logic is implemented to check duplicated IDs in the DOM by making ajax calls to the page.
