### PR TITLE
[Image] Component should load SVGs as content and not image from dyna…

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
@@ -195,10 +195,14 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
                         boolean isWCMDisabled =  (com.day.cq.wcm.api.WCMMode.fromRequest(request) == com.day.cq.wcm.api.WCMMode.DISABLED);
                         //sets to '/is/image/ or '/is/content' based on dam:scene7Type property
                         String dmServerPath;
-                        if (asset.getMetadataValue(Scene7Constants.PN_S7_TYPE).equals(Scene7AssetType.ANIMATED_GIF.getValue())) {
-                            dmServerPath = DM_CONTENT_SERVER_PATH;
-                        } else {
+                        // '/is/image' DM url is for optimized image delivery supporting run time transformations.
+                        //  Use '/is/image' url if dam:scene7Type is explicitly set to 'Image' or DM processor does not set dam:scene7Type
+                        if (asset.getMetadataValue(Scene7Constants.PN_S7_TYPE).equals(Scene7AssetType.IMAGE.getValue())
+                            || asset.getMetadataValue(Scene7Constants.PN_S7_TYPE).equals(StringUtils.EMPTY)) {
                             dmServerPath = DM_IMAGE_SERVER_PATH;
+                        } else {
+                        // All other file types should be loaded as content via '/is/content'
+                            dmServerPath = DM_CONTENT_SERVER_PATH;
                         }
                         String dmServerUrl;
                         // for Author

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImplTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import javax.json.Json;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,6 +61,8 @@ public class ImageImplTest extends com.adobe.cq.wcm.core.components.internal.mod
     private static final String IMAGE39_PATH = PAGE + "/jcr:content/root/image39";
     private static final String IMAGE40_PATH = PAGE + "/jcr:content/root/image40";
     private static final String IMAGE42_PATH = PAGE + "/jcr:content/root/image42";
+    private static final String IMAGE43_PATH = PAGE + "/jcr:content/root/image43";
+    private static final String IMAGE44_PATH = PAGE + "/jcr:content/root/image44";
 
     @BeforeEach
     @Override
@@ -311,6 +314,21 @@ public class ImageImplTest extends com.adobe.cq.wcm.core.components.internal.mod
         assertEquals(0, image.getWidths().length);
     }
 
+    @Test
+    void testSVGImageSrcOnDM() {
+        context.contentPolicyMapping(resourceType, Image.PN_DESIGN_DYNAMIC_MEDIA_ENABLED, true);
+        Image image = getImageUnderTest(IMAGE43_PATH);
+        assertTrue(image.isDmImage());
+        assertTrue(StringUtils.startsWith(image.getSrc(), "https://s7d9.scene7.com/is/content"));
+    }
+
+    @Test
+    void testImageSrcWithDMFileTypeImage() {
+        context.contentPolicyMapping(resourceType, Image.PN_DESIGN_DYNAMIC_MEDIA_ENABLED, true);
+        Image image = getImageUnderTest(IMAGE44_PATH);
+        assertTrue(image.isDmImage());
+        assertTrue(StringUtils.startsWith(image.getSrc(), "https://s7d9.scene7.com/is/image"));
+    }
 
     @Test
     void testImageWithLazyThreshold() {

--- a/bundles/core/src/test/resources/image/test-content-dam.json
+++ b/bundles/core/src/test/resources/image/test-content-dam.json
@@ -1087,6 +1087,158 @@
             }
         }
     },
+    "Adobe_Systems_logo_and_wordmark_DM.svg": {
+        "jcr:primaryType": "dam:Asset",
+        "jcr:mixinTypes" : [
+            "mix:referenceable"
+        ],
+        "jcr:createdBy"  : "admin",
+        "jcr:created"    : "Mon Mar 20 2017 11:20:37 GMT+0100",
+        "jcr:uuid"       : "60a1a56e-f3f4-4021-a7bf-ac7a51f0ffe5",
+        "jcr:content"    : {
+            "jcr:primaryType"   : "dam:AssetContent",
+            "jcr:lastModifiedBy": "admin",
+            "dam:assetState"    : "processed",
+            "jcr:lastModified"  : "Mon Mar 20 2017 11:20:39 GMT+0100",
+            "dam:relativePath"  : "core/images/Adobe_Systems_logo_and_wordmark.svg",
+            "renditions"        : {
+                "jcr:primaryType"         : "nt:folder",
+                "jcr:createdBy"           : "admin",
+                "jcr:created"             : "Mon Mar 20 2017 11:20:37 GMT+0100",
+                "cq5dam.web.1280.1280.png": {
+                    "jcr:primaryType": "nt:file",
+                    "jcr:createdBy"  : "workflow-process-service",
+                    "jcr:created"    : "Mon Mar 20 2017 11:20:39 GMT+0100",
+                    "jcr:content"    : {
+                        "jcr:primaryType"   : "oak:Resource",
+                        "jcr:lastModifiedBy": "workflow-process-service",
+                        "jcr:mimeType"      : "image/svg+xml",
+                        "jcr:lastModified"  : "Mon Mar 20 2017 11:20:39 GMT+0100",
+                        ":jcr:data"         : 27795
+                    }
+                },
+                "original"                : {
+                    "jcr:primaryType": "nt:file",
+                    "jcr:createdBy"  : "admin",
+                    "jcr:created"    : "Mon Mar 20 2017 11:20:37 GMT+0100",
+                    "jcr:content"    : {
+                        "jcr:primaryType"   : "oak:Resource",
+                        "jcr:lastModifiedBy": "admin",
+                        "jcr:mimeType"      : "image/svg+xml",
+                        "jcr:lastModified"  : "Mon Mar 20 2017 11:20:37 GMT+0100",
+                        ":jcr:data"         : 49069
+                    }
+                }
+            },
+            "related"           : {
+                "jcr:primaryType": "nt:unstructured"
+            },
+            "metadata"          : {
+                "jcr:primaryType"            : "nt:unstructured",
+                "jcr:mixinTypes"             : [
+                    "cq:Taggable"
+                ],
+                "dam:Physicalheightininches" : "27.77777862548828",
+                "dam:Physicalwidthininches"  : "27.77777862548828",
+                "dam:Fileformat"             : "SVG",
+                "dam:Progressive"            : "no",
+                "tiff:ImageLength"           : 2000,
+                "dam:extracted"              : "Mon Mar 20 2017 11:20:38 GMT+0100",
+                "dc:format"                  : "image/svg+xml",
+                "dam:Bitsperpixel"           : 8,
+                "dam:MIMEtype"               : "image/svg+xml",
+                "dam:Physicalwidthindpi"     : 72,
+                "dam:Physicalheightindpi"    : 72,
+                "dam:Numberofimages"         : 1,
+                "dam:Numberoftextualcomments": 0,
+                "dam:scene7Domain"           : "https://s7d9.scene7.com/",
+                "dam:scene7File"             : "dmtestcompany/Adobe_Systems_logo_and_wordmark_DM",
+                "dam:scene7Folder"           : "dmtestcompany/Adobe/logos",
+                "dam:scene7Type"             : "Generic",
+                "tiff:ImageWidth"            : 2000,
+                "dam:sha1"                   : "bb3aa5c9b452b04808006037911705d3592bfd71",
+                "dam:size"                   : 49069,
+                "dc:title": "Adobe Systems Logo and Wordmark",
+                "dc:description": "Adobe Systems Logo and Wordmark in SVG format"
+            }
+        }
+    },
+    "Adobe_Systems_logo_and_wordmark_DM.jpg": {
+        "jcr:primaryType": "dam:Asset",
+        "jcr:mixinTypes" : [
+            "mix:referenceable"
+        ],
+        "jcr:createdBy"  : "admin",
+        "jcr:created"    : "Mon Mar 20 2017 11:20:37 GMT+0100",
+        "jcr:uuid"       : "60a1a56e-f3f4-4021-a7bf-ac7a51f0ffe5",
+        "jcr:content"    : {
+            "jcr:primaryType"   : "dam:AssetContent",
+            "jcr:lastModifiedBy": "admin",
+            "dam:assetState"    : "processed",
+            "jcr:lastModified"  : "Mon Mar 20 2017 11:20:39 GMT+0100",
+            "dam:relativePath"  : "core/images/Adobe_Systems_logo_and_wordmark.jpg",
+            "renditions"        : {
+                "jcr:primaryType"         : "nt:folder",
+                "jcr:createdBy"           : "admin",
+                "jcr:created"             : "Mon Mar 20 2017 11:20:37 GMT+0100",
+                "cq5dam.web.1280.1280.png": {
+                    "jcr:primaryType": "nt:file",
+                    "jcr:createdBy"  : "workflow-process-service",
+                    "jcr:created"    : "Mon Mar 20 2017 11:20:39 GMT+0100",
+                    "jcr:content"    : {
+                        "jcr:primaryType"   : "oak:Resource",
+                        "jcr:lastModifiedBy": "workflow-process-service",
+                        "jcr:mimeType"      : "image/jpeg",
+                        "jcr:lastModified"  : "Mon Mar 20 2017 11:20:39 GMT+0100",
+                        ":jcr:data"         : 27795
+                    }
+                },
+                "original"                : {
+                    "jcr:primaryType": "nt:file",
+                    "jcr:createdBy"  : "admin",
+                    "jcr:created"    : "Mon Mar 20 2017 11:20:37 GMT+0100",
+                    "jcr:content"    : {
+                        "jcr:primaryType"   : "oak:Resource",
+                        "jcr:lastModifiedBy": "admin",
+                        "jcr:mimeType"      : "image/jpeg",
+                        "jcr:lastModified"  : "Mon Mar 20 2017 11:20:37 GMT+0100",
+                        ":jcr:data"         : 49069
+                    }
+                }
+            },
+            "related"           : {
+                "jcr:primaryType": "nt:unstructured"
+            },
+            "metadata"          : {
+                "jcr:primaryType"            : "nt:unstructured",
+                "jcr:mixinTypes"             : [
+                    "cq:Taggable"
+                ],
+                "dam:Physicalheightininches" : "27.77777862548828",
+                "dam:Physicalwidthininches"  : "27.77777862548828",
+                "dam:Fileformat"             : "JPEG",
+                "dam:Progressive"            : "no",
+                "tiff:ImageLength"           : 2000,
+                "dam:extracted"              : "Mon Mar 20 2017 11:20:38 GMT+0100",
+                "dc:format"                  : "image/jpeg",
+                "dam:Bitsperpixel"           : 8,
+                "dam:MIMEtype"               : "image/jpeg",
+                "dam:Physicalwidthindpi"     : 72,
+                "dam:Physicalheightindpi"    : 72,
+                "dam:Numberofimages"         : 1,
+                "dam:Numberoftextualcomments": 0,
+                "dam:scene7Domain"           : "https://s7d9.scene7.com/",
+                "dam:scene7File"             : "dmtestcompany/Adobe_Systems_logo_and_wordmark_DM_JPG",
+                "dam:scene7Folder"           : "dmtestcompany/Adobe/logos",
+                "dam:scene7Type"             : "Image",
+                "tiff:ImageWidth"            : 2000,
+                "dam:sha1"                   : "bb3aa5c9b452b04808006037911705d3592bfd71",
+                "dam:size"                   : 49069,
+                "dc:title": "Adobe Systems Logo and Wordmark",
+                "dc:description": "Adobe Systems Logo and Wordmark in JPEG format"
+            }
+        }
+    },
   "asset1.png": {
     "jcr:primaryType": "dam:Asset",
     "jcr:mixinTypes" : [

--- a/bundles/core/src/test/resources/image/v2/test-content.json
+++ b/bundles/core/src/test/resources/image/v2/test-content.json
@@ -609,6 +609,52 @@
             }
           }
         },
+        "image43"            : {
+          "jcr:primaryType"   : "nt:unstructured",
+          "jcr:createdBy"     : "admin",
+          "jcr:lastModified"  : "Mon Mar 20 2017 11:20:39 GMT+0100",
+          "sling:resourceType": "core/wcm/components/image/v2/image",
+          "cq:policy"         : "coretest/components/content/image/policy_1602844411172",
+          "fileReference"     : "/content/dam/core/images/Adobe_Systems_logo_and_wordmark_DM.svg",
+          "alt"               : "Adobe Logo",
+          "jcr:title"         : "DM features on, DM image",
+          "linkURL"           : "https://www.adobe.com",
+          "fileName"          : "Adobe_Systems_logo_and_wordmark.svg",
+          "file"              : {
+              "jcr:primaryType": "nt:file",
+              "jcr:createdBy"  : "admin",
+              "jcr:content"    : {
+                  "jcr:primaryType"   : "nt:resource",
+                  "jcr:lastModifiedBy": "admin",
+                  "jcr:mimeType"      : "image/svg+xml",
+                  ":jcr:data"         : 450,
+                  "jcr:uuid"          : "efd67232-7672-49ad-b155-0063daee3d22"
+              }
+          }
+      },
+        "image44"            : {
+              "jcr:primaryType"   : "nt:unstructured",
+              "jcr:createdBy"     : "admin",
+              "jcr:lastModified"  : "Mon Mar 20 2017 11:20:39 GMT+0100",
+              "sling:resourceType": "core/wcm/components/image/v2/image",
+              "cq:policy"         : "coretest/components/content/image/policy_1602844411172",
+              "fileReference"     : "/content/dam/core/images/Adobe_Systems_logo_and_wordmark_DM.jpg",
+              "alt"               : "Adobe Logo",
+              "jcr:title"         : "DM features on, DM image",
+              "linkURL"           : "https://www.adobe.com",
+              "fileName"          : "Adobe_Systems_logo_and_wordmark.jpg",
+              "file"              : {
+                  "jcr:primaryType": "nt:file",
+                  "jcr:createdBy"  : "admin",
+                  "jcr:content"    : {
+                      "jcr:primaryType"   : "nt:resource",
+                      "jcr:lastModifiedBy": "admin",
+                      "jcr:mimeType"      : "image/svg+xml",
+                      ":jcr:data"         : 450,
+                      "jcr:uuid"          : "efd67232-7672-49ad-b155-0063daee3d22"
+                  }
+              }
+          },
         "container"             : {
           "jcr:primaryType"   : "nt:unstructured",
           "sling:resourceType": "wcm/foundation/components/responsivegrid",

--- a/bundles/core/src/test/resources/image/v3/test-content.json
+++ b/bundles/core/src/test/resources/image/v3/test-content.json
@@ -615,6 +615,52 @@
             }
           }
         },
+        "image43"            : {
+          "jcr:primaryType"   : "nt:unstructured",
+          "jcr:createdBy"     : "admin",
+          "jcr:lastModified"  : "Mon Mar 20 2017 11:20:39 GMT+0100",
+          "sling:resourceType": "core/wcm/components/image/v3/image",
+          "cq:policy"         : "coretest/components/content/image/policy_1602844411172",
+          "fileReference"     : "/content/dam/core/images/Adobe_Systems_logo_and_wordmark_DM.svg",
+          "alt"               : "Adobe Logo",
+          "jcr:title"         : "DM features on, DM image",
+          "linkURL"           : "https://www.adobe.com",
+          "fileName"          : "Adobe_Systems_logo_and_wordmark.svg",
+          "file"              : {
+              "jcr:primaryType": "nt:file",
+              "jcr:createdBy"  : "admin",
+              "jcr:content"    : {
+                  "jcr:primaryType"   : "nt:resource",
+                  "jcr:lastModifiedBy": "admin",
+                  "jcr:mimeType"      : "image/svg+xml",
+                  ":jcr:data"         : 450,
+                  "jcr:uuid"          : "efd67232-7672-49ad-b155-0063daee3d22"
+              }
+          }
+      },
+        "image44"            : {
+              "jcr:primaryType"   : "nt:unstructured",
+              "jcr:createdBy"     : "admin",
+              "jcr:lastModified"  : "Mon Mar 20 2017 11:20:39 GMT+0100",
+              "sling:resourceType": "core/wcm/components/image/v3/image",
+              "cq:policy"         : "coretest/components/content/image/policy_1602844411172",
+              "fileReference"     : "/content/dam/core/images/Adobe_Systems_logo_and_wordmark_DM.jpg",
+              "alt"               : "Adobe Logo",
+              "jcr:title"         : "DM features on, DM image",
+              "linkURL"           : "https://www.adobe.com",
+              "fileName"          : "Adobe_Systems_logo_and_wordmark.jpg",
+              "file"              : {
+                  "jcr:primaryType": "nt:file",
+                  "jcr:createdBy"  : "admin",
+                  "jcr:content"    : {
+                      "jcr:primaryType"   : "nt:resource",
+                      "jcr:lastModifiedBy": "admin",
+                      "jcr:mimeType"      : "image/svg+xml",
+                      ":jcr:data"         : 450,
+                      "jcr:uuid"          : "efd67232-7672-49ad-b155-0063daee3d22"
+                  }
+              }
+          },
         "image50"            : {
           "jcr:primaryType"   : "nt:unstructured",
           "jcr:createdBy"     : "admin",


### PR DESCRIPTION
Condition changed on when image component should generate '/is/image' url

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/adobe/aem-core-wcm-components/issues/2276
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | 👎
| Major: Breaking Change?  | 👎
| Tests Added + Pass?      | Yes (All tests pass)
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Only S7 files of type image should be loaded via /is/image url. All other files types should be loaded via /is/content.
This will allow files like SVG to be rendered with corrent Content-Type. Hence DM url generated by image component on DM enabled flag must use '/is/image' only when DM processor explicitly sets type as image or when it cannot be inferred.