### PR TITLE
[Accordion] Allow single expansion to start with all closed

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/README.md
@@ -42,7 +42,7 @@ It is also possible to define the allowed components for the Accordion.
 ### Edit Dialog Properties
 The following properties are written to JCR for this Accordion component and are expected to be available as `Resource` properties:
 
-1. `./singleExpansion` - `true` if one panel should be forced to be expanded at a time, `false` otherwise.
+1. `./singleExpansion` - `true` if only one panel should be allowed to be expanded at a time, `false` otherwise.
 2. `./expandedItems` - defines the names of the items that are expanded by default.
 3. `./headingElement` - defines the heading element to use for the accordion headers (`h2` - `h6`).
 4. `./id` - defines the component HTML ID attribute.
@@ -75,7 +75,7 @@ Apply a `data-cmp-is="accordion"` attribute to the wrapper block to enable initi
 
 The following attributes can be added to the same element to provide options:
 
-1. `data-cmp-single-expansion` - if the attribute is present, forces a single panel to be expanded at a time.
+1. `data-cmp-single-expansion` - if the attribute is present, allows only a single panel to be expanded at a time.
 
 The following attributes can be added to the accordion item (`data-cmp-hook-accordion="item"`):
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
@@ -97,8 +97,8 @@
         if (childrenEditor && singleExpansion && expandedItems && expandedSelect && expandedSelectSingle) {
             Coral.commons.ready(childrenEditor, function() {
                 var cmpChildrenEditor = $(childrenEditor).adaptTo("cmp-childreneditor");
-                updateExpandedSelect(childrenEditor, expandedSelect, expandedItemValues);
-                updateExpandedSelect(childrenEditor, expandedSelectSingle, expandedItemValues);
+                updateExpandedSelect(childrenEditor, expandedSelect, expandedItemValues, false);
+                updateExpandedSelect(childrenEditor, expandedSelectSingle, expandedItemValues, true);
                 if (cmpChildrenEditor.items().length === 0) {
                     toggleExpandedSelects(expandedSelect, expandedSelectSingle, undefined, true);
                 } else {
@@ -106,8 +106,8 @@
                 }
 
                 childrenEditor.on("change", function() {
-                    updateExpandedSelect(childrenEditor, expandedSelect, expandedItemValues);
-                    updateExpandedSelect(childrenEditor, expandedSelectSingle, expandedItemValues);
+                    updateExpandedSelect(childrenEditor, expandedSelect, expandedItemValues, false);
+                    updateExpandedSelect(childrenEditor, expandedSelectSingle, expandedItemValues, true);
                     if (cmpChildrenEditor.items().length === 0) {
                         toggleExpandedSelects(expandedSelect, expandedSelectSingle, undefined, true);
                     } else {
@@ -174,8 +174,9 @@
      * @param {HTMLElement} childrenEditor Children editor multifield
      * @param {HTMLElement} expandedSelect Expanded accordion items select field
      * @param {String[]} expandedItemValues Expanded accordion item values
+     * @param {Boolean} singleExpansion true if single expansion is enabled, false otherwise
      */
-    function updateExpandedSelect(childrenEditor, expandedSelect, expandedItemValues) {
+    function updateExpandedSelect(childrenEditor, expandedSelect, expandedItemValues, singleExpansion) {
         var selectedValues = (expandedSelect.values.length) ? expandedSelect.values : expandedItemValues;
         expandedSelect.items.getAll().forEach(function(item) {
             if (item.value !== "") {
@@ -185,6 +186,15 @@
 
         var cmpChildrenEditor = $(childrenEditor).adaptTo("cmp-childreneditor");
         if (cmpChildrenEditor) {
+            if (singleExpansion) {
+                expandedSelect.items.add({
+                    selected: (selectedValues.length === 0),
+                    content: {
+                        textContent: Granite.I18n.get("None")
+                    }
+                });
+                expandedSelect.items.first().set("value", null, true);
+            }
             cmpChildrenEditor.items().forEach(function(item) {
                 expandedSelect.items.add({
                     selected: (selectedValues.indexOf(item.name) > -1),

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/site/js/accordion.js
@@ -122,10 +122,6 @@
 
                 if (that._properties.singleExpansion) {
                     var expandedItems = getExpandedItems();
-                    // no expanded item annotated, force the first item to display.
-                    if (expandedItems.length === 0) {
-                        toggle(0);
-                    }
                     // multiple expanded items annotated, display the last item open.
                     if (expandedItems.length > 1) {
                         toggle(expandedItems.length - 1);


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1256 
| Patch: Bug Fix?          | Y
| Minor: New Feature?      | Y
| Major: Breaking Change?  | N
| Tests Added + Pass?      | N/A
| Documentation Provided   | Yes (Updated readme)
| Any Dependency Changes?  | N
| License                  | Apache License, Version 2.0

Allows a single-expansion accordion to be configured to start with
all panels closed by default. Previously, this could only be done
in multi-expansion accordions.

This is accomplished by manually adding a "None" option to the initial
open panel dropdown in the edit dialog. Additionally, the code that
automatically opens the first panel if none is set as open (for single
expansion accordions) is removed from the site clientlib such that if
no panel is specified to be open on load, then no panel will be open on
load.

(Note: this could also be accomplished by adding `emptyOption={Boolean}true` to `/apps/core/wcm/components/accordion/v1/accordion/cq:dialog/content/items/tabs/items/properties/items/columns/items/column/items/expandedSelectSingle` - however, i'm not sure it's clear that an empty item with no discernable label implies "None".

The documentation is updated to clarify that no panel is _forced_ to be
open; rather, only one _can_ be opened.

----
issue #1256


