### PR TITLE
[ImageV2] Lazy loading image isn't getting visible inside of a Carousel

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -198,14 +198,14 @@
 
             that._elements.image.addEventListener("cmp-image-redraw", that.update);
 
-            var interSectionObserver = new IntersectionObserver(function(entries, interSectionObserver) {
+            that._interSectionObserver = new IntersectionObserver(function(entries, interSectionObserver) {
                 entries.forEach(function(entry) {
                     if (entry.intersectionRatio > 0) {
                         that.update();
                     }
                 });
             });
-            interSectionObserver.observe(that._elements.self);
+            that._interSectionObserver.observe(that._elements.self);
 
             that.update();
         }
@@ -248,6 +248,7 @@
             if (that._lazyLoaderShowing) {
                 that._elements.image.addEventListener("load", removeLazyLoader);
             }
+            that._interSectionObserver.unobserve(that._elements.self);
         }
 
         function getOptimalWidth(widths, useDevicePixelRatio) {

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -200,10 +200,10 @@
 
             var interSectionObserver = new IntersectionObserver(function(entries, interSectionObserver) {
                 entries.forEach(function(entry) {
-                    if (entry.intersectionRatio > 0 ) {
+                    if (entry.intersectionRatio > 0) {
                         that.update();
                     }
-                })
+                });
             });
             interSectionObserver.observe(that._elements.self);
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -197,6 +197,16 @@
             });
 
             that._elements.image.addEventListener("cmp-image-redraw", that.update);
+
+            var interSectionObserver = new IntersectionObserver(function(entries, interSectionObserver) {
+                entries.forEach(function(entry) {
+                    if (entry.intersectionRatio > 0 ) {
+                        that.update();
+                    }
+                })
+            });
+            interSectionObserver.observe(that._elements.self);
+
             that.update();
         }
 


### PR DESCRIPTION
- add IntersectionObserver to trigger update and check if image is getting visible\

fixes #2291

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2291
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | 👎
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
