### PR TITLE
[PanelContainer] Make container servlet resourceType aware

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/ContainerServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/ContainerServlet.java
@@ -18,6 +18,9 @@ package com.adobe.cq.wcm.core.components.internal.servlets;
 import com.adobe.cq.wcm.core.components.commons.editor.dialog.childreneditor.Editor;
 import com.adobe.cq.wcm.core.components.internal.models.v1.PanelContainerImpl;
 import com.day.cq.wcm.api.WCMMode;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.sling.api.SlingConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestDispatcherOptions;
@@ -106,7 +109,12 @@ public class ContainerServlet extends SlingAllMethodsServlet {
     protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws ServletException, IOException {
         Resource container = request.getResource();
         RequestDispatcherOptions options = new RequestDispatcherOptions();
-        options.setForceResourceType(Editor.RESOURCE_TYPE);
+        String resourceType = request.getParameter(SlingConstants.PROPERTY_RESOURCE_TYPE);
+        if (StringUtils.isNotEmpty(resourceType)) {
+            options.setForceResourceType(resourceType);
+        } else {
+            options.setForceResourceType(Editor.RESOURCE_TYPE);
+        }
         request.setAttribute(WCMMode.REQUEST_ATTRIBUTE_NAME, WCMMode.DISABLED);
         options.setReplaceSuffix(container.getPath());
         RequestDispatcher dispatcher = request.getRequestDispatcher(container, options);

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/ContainerServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/ContainerServletTest.java
@@ -26,10 +26,13 @@ import java.util.stream.StreamSupport;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 
+import com.adobe.cq.wcm.core.components.commons.editor.dialog.childreneditor.Editor;
 import com.day.cq.wcm.api.WCMException;
 import com.day.cq.wcm.msm.api.LiveRelationship;
 import com.day.cq.wcm.msm.api.LiveRelationshipManager;
 import com.day.cq.wcm.msm.api.LiveStatus;
+
+import org.apache.sling.api.SlingConstants;
 import org.apache.sling.api.request.RequestDispatcherOptions;
 import org.apache.sling.api.resource.Resource;
 
@@ -42,6 +45,7 @@ import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.servlet.MockRequestDispatcherFactory;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -111,8 +115,9 @@ public class ContainerServletTest {
 
     @Test
     public void testGetMultiField() throws ServletException, IOException {
-        context.request().setMethod(HttpConstants.METHOD_GET);
-        context.request().setRequestDispatcherFactory(new MockRequestDispatcherFactory() {
+        MockSlingHttpServletRequest request = context.request();
+        request.setMethod(HttpConstants.METHOD_GET);
+        request.setRequestDispatcherFactory(new MockRequestDispatcherFactory() {
             @Override
             public RequestDispatcher getRequestDispatcher(String s, RequestDispatcherOptions requestDispatcherOptions) {
                 return requestDispatcher;
@@ -124,7 +129,9 @@ public class ContainerServletTest {
             }
         });
 
-        servlet.doGet(context.request(), context.response());
-        verify(requestDispatcher, times(1)).include(context.request(), context.response());
+        servlet.doGet(request, context.response());
+        request.setParameterMap(ImmutableMap.of(SlingConstants.PROPERTY_RESOURCE_TYPE, Editor.RESOURCE_TYPE));
+        servlet.doGet(request, context.response());
+        verify(requestDispatcher, times(2)).include(request, context.response());
     }
 }


### PR DESCRIPTION
- get forced resourceType from request parameter

-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      | 👍
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

The container servlet is also used by the segmenteditor of the core email components project. As the segmenteditor relies on a different multifield item structure the container servlet needs to get the resource Type from the request parameter to render the correct output. Related issue of the core email components is https://github.com/adobe/aem-core-email-components/issues/213
