### PR TITLE
[TOC] Improve exit condition for TableOfContentsFilter

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/TableOfContentsFilter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/TableOfContentsFilter.java
@@ -122,15 +122,15 @@ public class TableOfContentsFilter implements Filter {
         chain.doFilter(request, responseWrapper);
         String originalContent = responseWrapper.toString();
 
-        if (responseWrapper.getContentType() == null || !responseWrapper.getContentType().contains("text/html")) {
-            LOGGER.debug("Response content type not \"text/html\", bypassing filter");
+        Boolean containsTableOfContents = (Boolean) request.getAttribute(TableOfContentsImpl.TOC_REQUEST_ATTR_FLAG);
+        if (containsTableOfContents == null || !containsTableOfContents) {
+            LOGGER.debug("request attribute {} not present or set to false, bypassing the filter {}", TableOfContentsImpl.TOC_REQUEST_ATTR_FLAG, TableOfContentsFilter.class.getName());
             response.getWriter().write(originalContent);
             return;
         }
 
-        Boolean containsTableOfContents = (Boolean) request.getAttribute(TableOfContentsImpl.TOC_REQUEST_ATTR_FLAG);
-        if (containsTableOfContents == null || !containsTableOfContents) {
-            LOGGER.debug("request attribute {} not present or set to false, bypassing the filter {}", TableOfContentsImpl.TOC_REQUEST_ATTR_FLAG, TableOfContentsFilter.class.getName());
+        if (responseWrapper.getContentType() == null || !responseWrapper.getContentType().contains("text/html")) {
+            LOGGER.debug("Response content type not \"text/html\", bypassing filter");
             response.getWriter().write(originalContent);
             return;
         }


### PR DESCRIPTION
- exit early when the page doesn't contain a TOC component
- exist early when the page is not of content type text/html

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2300 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | No
| Documentation Provided   | No
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0
