### PR TITLE
[Image V3] Hide "Disable lazy loading" if disabled by policy

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/_cq_dialog/.content.xml
@@ -114,11 +114,11 @@
                                             <disableLazyLoading
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                                checked="${not empty cqDesign.disableLazyLoading ? cqDesign.disableLazyLoading : false}"
-                                                fieldDescription="When checked, it will preload all images, without using lazy loading."
+                                                granite:hide="${cqDesign.disableLazyLoading}"
+                                                fieldDescription="When checked, image will be loaded eagerly, regardless of if the image is currently visible by the user."
                                                 name="./disableLazyLoading"
                                                 text="Disable lazy loading"
-                                                uncheckedValue="false"
+                                                deleteHint="{Boolean}true"
                                                 value="{Boolean}true"/>
                                         </items>
                                     </column>


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2311 
| Patch: Bug Fix?          | Y
| Minor: New Feature?      | N
| Major: Breaking Change?  | N
| Tests Added + Pass?      | N/A
| Documentation Provided   | N/A
| Any Dependency Changes?  | N
| License                  | Apache License, Version 2.0
----

- Changes the V3 dialog such that the "Disable lazy loading" option is hidden if "Disable lazy loading" is set in the policy (and thus lazy loading does not need to be disabled on individual component instances).
- Clarifies the field description to make it clear that the checkbox only applies to the image component instance currently being edited.
- Adds `@deleteHint=true` to the "Disable lazy loading" dialog option because `@disableLazyLoading=false` has no meaning. (same behviour as when omitted). So, there's no reason to keep the property around.

----
refs #2311