### PR TITLE
[List] Prevent blank page titles

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageListItemImpl.java
@@ -16,7 +16,10 @@
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.Calendar;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -85,7 +88,7 @@ public class PageListItemImpl extends AbstractListItemImpl implements ListItem {
 
     /**
      * Gets the title of a page list item from a given page.
-     * The list item title is derived from the page by selecting the first non-null value from the
+     * The list item title is derived from the page by selecting the first non-blank value from the
      * following:
      * <ul>
      *     <li>{@link Page#getNavigationTitle()}</li>
@@ -98,17 +101,11 @@ public class PageListItemImpl extends AbstractListItemImpl implements ListItem {
      * @return The list item title.
      */
     public static String getTitle(@NotNull final Page page) {
-        String title = page.getNavigationTitle();
-        if (title == null) {
-            title = page.getPageTitle();
-        }
-        if (title == null) {
-            title = page.getTitle();
-        }
-        if (title == null) {
-            title = page.getName();
-        }
-        return title;
+        return Stream.<Supplier<String>>of(page::getNavigationTitle, page::getPageTitle, page::getTitle)
+            .map(Supplier::get)
+            .filter(StringUtils::isNotBlank)
+            .findFirst()
+            .orElseGet(page::getName);
     }
 
     @Override

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ListImplTest.java
@@ -67,6 +67,8 @@ public class ListImplTest {
     protected static final String LIST_16 = TEST_PAGE_CONTENT_ROOT + "/staticOrderByTitleListTypeWithAccent";
     protected static final String LIST_20 = TEST_PAGE_CONTENT_ROOT + "/listRenderedAsTeaserItems";
 
+    protected static final String LIST_21 = TEST_PAGE_CONTENT_ROOT + "/staticOrderByTitleListTypeWithBlankTitle";
+
     protected final AemContext context = CoreComponentTestContext.newAemContext();
 
     protected String testBase;
@@ -208,6 +210,17 @@ public class ListImplTest {
     protected void testOrderByTitleWithNoTitleForOneItem() {
         List list = getListUnderTest(LIST_15);
         checkListConsistencyByPaths(list, new String[]{"/content/list/pages/page_4", "/content/list/pages/page_1", "/content/list/pages/page_2" });
+    }
+
+    @Test
+    protected void testOrderByTitleWithBlankTitle() {
+        List list = getListUnderTest(LIST_21);
+        checkListConsistencyByPaths(list, new String[]{
+            "/content/list/pages/page_4",
+            "/content/list/pages/page_6",
+            "/content/list/pages/page_1",
+            "/content/list/pages/page_2"
+        });
     }
 
     @Test

--- a/bundles/core/src/test/resources/list/test-content.json
+++ b/bundles/core/src/test/resources/list/test-content.json
@@ -82,6 +82,18 @@
                         "/content/list/pages/page_2"
                     ]
                 },
+                "staticOrderByTitleListTypeWithBlankTitle": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "static",
+                    "orderBy": "title",
+                    "pages": [
+                        "/content/list/pages/page_1",
+                        "/content/list/pages/page_6",
+                        "/content/list/pages/page_2",
+                        "/content/list/pages/page_4"
+                    ]
+                },
                 "staticOrderByTitleListTypeWithAccent": {
                     "jcr:primaryType": "nt:unstructured",
                     "sling:resourceType": "core/wcm/components/list",
@@ -272,6 +284,14 @@
                 "jcr:content": {
                     "jcr:primaryType": "cq:PageContent",
                     "jcr:title": "Páge 1",
+                    "cq:lastModified": "2016-09-21T16:12:45.000-07:00"
+                }
+            },
+            "page_6": {
+                "jcr:primaryType": "cq:Page",
+                "jcr:content": {
+                    "jcr:primaryType": "cq:PageContent",
+                    "jcr:title": " ",
                     "cq:lastModified": "2016-09-21T16:12:45.000-07:00"
                 }
             }

--- a/bundles/core/src/test/resources/list/v3/test-content.json
+++ b/bundles/core/src/test/resources/list/v3/test-content.json
@@ -82,6 +82,18 @@
                         "/content/list/pages/page_2"
                     ]
                 },
+                "staticOrderByTitleListTypeWithBlankTitle": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/list",
+                    "listFrom": "static",
+                    "orderBy": "title",
+                    "pages": [
+                        "/content/list/pages/page_1",
+                        "/content/list/pages/page_6",
+                        "/content/list/pages/page_2",
+                        "/content/list/pages/page_4"
+                    ]
+                },
                 "staticOrderByTitleListTypeWithAccent": {
                     "jcr:primaryType": "nt:unstructured",
                     "sling:resourceType": "core/wcm/components/list/v3/list",
@@ -294,6 +306,14 @@
                 "jcr:content": {
                     "jcr:primaryType": "cq:PageContent",
                     "jcr:title": "Páge 1",
+                    "cq:lastModified": "2016-09-21T16:12:45.000-07:00"
+                }
+            },
+            "page_6": {
+                "jcr:primaryType": "cq:Page",
+                "jcr:content": {
+                    "jcr:primaryType": "cq:PageContent",
+                    "jcr:title": " ",
                     "cq:lastModified": "2016-09-21T16:12:45.000-07:00"
                 }
             }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #2316
| Patch: Bug Fix?          | Y
| Minor: New Feature?      | N
| Major: Breaking Change?  | N
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (updated JavaDoc)
| Any Dependency Changes?  | N
| License                  | Apache License, Version 2.0

Updates the `PageListItemImpl` so that blank page titles are treated the same as null page titles. This prevents an empty title from being shown in lists if the title contains only whitespace.

Adds a test to verify the sorting of list items that have a whitespace-only title (sorts based on name instead of blank title).

----
Fixes #2316
