### PR TITLE
[ToC] Normalize line endings in tests

### DIFF
--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/TableOfContentsFilterTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/TableOfContentsFilterTest.java
@@ -215,8 +215,8 @@ public class TableOfContentsFilterTest {
             StandardCharsets.UTF_8
         );
         assertEquals(
-            expectedContent,
-            responseWriter.toString(),
+            expectedContent.replaceAll("\\R", System.lineSeparator()),
+            responseWriter.toString().replaceAll("\\R", System.lineSeparator()),
             errorMessage
         );
     }


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #2322
| Patch: Bug Fix?          | N
| Minor: New Feature?      | N
| Major: Breaking Change?  | N
| Tests Added + Pass?      | No tests added - tests failing on Windows now pass
| Documentation Provided   | N/A
| Any Dependency Changes?  | N
| License                  | Apache License, Version 2.0


Normalizes the line endings in the `TableOfContentsFilterTest` to prevent spurious failures on some systems (i.e. windows).

This is accomplished by replacing all line separators in both the filter content and reference file with the system line seperator.

