### PR TITLE
[Page] Correct NPE in `PageImpl#getData()` (#2330)

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.PostConstruct;
@@ -337,7 +338,9 @@ public class PageImpl extends AbstractComponentImpl implements Page {
             .withTitle(this::getTitle)
             .withTags(() -> Arrays.copyOf(this.keywords, this.keywords.length))
             .withDescription(() -> this.pageProperties.get(NameConstants.PN_DESCRIPTION, String.class))
-            .withTemplatePath(() -> this.currentPage.getTemplate().getPath())
+            .withTemplatePath(() -> Optional.ofNullable(this.currentPage.getTemplate())
+                .map(Template::getPath)
+                .orElse(null))
             .withUrl(() -> linkManager.get(currentPage).build().getURL())
             .withLanguage(this::getLanguage)
             .build();


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2330
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes (Added + PasS)
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Corrects a NPE that can arise when the `cq:template` property is not set on a page.

Additionally, tests are added to assert that `PageData#getTemplatePath()` returns null in this situation (without throwing an NPE).

These tests confirmed the presence of the NPE prior to implementing the fix.

