### PR TITLE
Add DM support to Teaser component

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>core.wcm.components.parent</artifactId>
         <groupId>com.adobe.cq</groupId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -31,7 +31,7 @@
     <!-- P R O J E C T  D E S C R I P T I O N                                   -->
     <!-- ====================================================================== -->
     <artifactId>core.wcm.components.all</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <packaging>content-package</packaging>
 
     <name>Adobe Experience Manager Core WCM Components Full Package</name>

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>core.wcm.components.core</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <packaging>bundle</packaging>
 
     <name>Adobe Experience Manager Core WCM Components Core Bundle</name>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/ImageDelegatePolicyServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/ImageDelegatePolicyServlet.java
@@ -1,0 +1,79 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.servlets;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.request.RequestPathInfo;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.SyntheticResource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import com.adobe.cq.wcm.core.components.internal.models.v1.AbstractImageDelegatingModel;
+import com.adobe.granite.ui.components.ExpressionResolver;
+import com.day.cq.wcm.api.WCMFilteringResourceWrapper;
+import com.day.cq.wcm.api.components.ComponentManager;
+
+@Component(service = { Servlet.class })
+@SlingServletResourceTypes(
+        resourceTypes = ImageDelegatePolicyServlet.RESOURCE_TYPE
+)
+public class ImageDelegatePolicyServlet extends SlingSafeMethodsServlet {
+
+    public static final String RESOURCE_TYPE = "core/wcm/components/include/imagedelegate";
+    private static final String PN_PATH = "path";
+
+    @Reference
+    ExpressionResolver expressionResolver;
+
+    @Override
+    protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response)
+            throws ServletException, IOException {
+        ResourceResolver resourceResolver = request.getResourceResolver();
+        ComponentManager componentManager = resourceResolver.adaptTo(ComponentManager.class);
+        RequestPathInfo requestPathInfo = request.getRequestPathInfo();
+        com.day.cq.wcm.api.components.Component component =
+                Optional.ofNullable(requestPathInfo.getSuffix())
+                        .flatMap(s -> Optional.ofNullable(resourceResolver.getResource(s)))
+                        .flatMap(r -> Optional.ofNullable(componentManager)
+                                .map(c -> c.getComponentOfResource(r)))
+                        .orElse(null);
+        if (Objects.nonNull(component)) {
+            ValueMap properties = component.getProperties();
+            String imageDelegate = properties.get(AbstractImageDelegatingModel.IMAGE_DELEGATE, String.class);
+            RequestDispatcher requestDispatcher = Optional.ofNullable(request.getResource().getValueMap().get(PN_PATH
+                            , String.class))
+                    .map(p -> new WCMFilteringResourceWrapper(resourceResolver.getResource(p), new SyntheticResource(resourceResolver,
+                            requestPathInfo.getSuffix(),
+                            imageDelegate), expressionResolver, request)).map(request::getRequestDispatcher).orElse(null);
+            if (Objects.nonNull(requestDispatcher)) {
+                requestDispatcher.include(request, response);
+            }
+        }
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/ImageDelegatePolicyServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/ImageDelegatePolicyServletTest.java
@@ -1,0 +1,71 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.servlets;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+
+import org.apache.sling.testing.mock.sling.servlet.MockRequestDispatcherFactory;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
+import com.adobe.granite.ui.components.ExpressionCustomizer;
+import com.adobe.granite.ui.components.ExpressionResolver;
+import com.day.cq.wcm.api.designer.Style;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith({AemContextExtension.class, MockitoExtension.class})
+class ImageDelegatePolicyServletTest {
+
+    private static final String TEST_BASE = "/image-delegate-policy-servlet";
+    private static final String APPS_ROOT = "/apps/core/wcm/components";
+    private static final String CONTENT_ROOT = "/content";
+    private static final String SUFFIX = "/content/test/jcr:content/root/responsivegrid/teaser";
+
+    public final AemContext context = CoreComponentTestContext.newAemContext();
+    private ImageDelegatePolicyServlet underTest;
+
+    @Mock
+    private MockRequestDispatcherFactory mockRequestDispatcherFactory;
+
+    @BeforeEach
+    void setUp() {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, CONTENT_ROOT);
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_APPS_JSON, APPS_ROOT);
+        context.requestPathInfo().setSuffix(SUFFIX);
+        underTest = new ImageDelegatePolicyServlet();
+    }
+
+    @Test
+    void testCqDesignAttribute() throws ServletException, IOException {
+        context.currentResource("/apps/core/wcm/components/teaser/cq:design/content/items/tabs/items/image");
+        MockSlingHttpServletRequest request = context.request();
+        request.setRequestDispatcherFactory(mockRequestDispatcherFactory);
+        underTest.doGet(request, context.response());
+        ExpressionCustomizer expressionCustomizer = (ExpressionCustomizer) request.getAttribute(ExpressionCustomizer.class.getName());
+        assertNotNull(expressionCustomizer);
+        Style cqDesign = (Style) expressionCustomizer.getVariable("cqDesign");
+        assertNotNull(cqDesign);
+    }
+}

--- a/bundles/core/src/test/resources/image-delegate-policy-servlet/test-apps.json
+++ b/bundles/core/src/test/resources/image-delegate-policy-servlet/test-apps.json
@@ -1,0 +1,40 @@
+{
+  "teaser": {
+    "jcr:primaryType"        : "cq:Component",
+    "imageDelegate"          : "core/wcm/components/image",
+    "jcr:createdBy"          : "admin",
+    "jcr:title"              : "Teaser (v2)",
+    "jcr:description"        : "Displays an image together with a link that can act as a teaser for a site section.",
+    "cq:icon"                : "image",
+    "componentGroup"         : ".core-wcm",
+    "cq:design" : {
+      "jcr:primaryType": "nt:unstructured",
+      "content": {
+        "jcr:primaryType": "nt:unstructured",
+        "items": {
+          "jcr:primaryType": "nt:unstructured",
+          "tabs": {
+            "jcr:primaryType": "nt:unstructured",
+            "items": {
+              "jcr:primaryType": "nt:unstructured",
+              "image" :{
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "core/wcm/components/include/imagedelegate",
+                "path" : "core/wcm/components/image/cq:dialog/content/items/tabs/items/asset"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "image" : {
+    "jcr:primaryType"        : "cq:Component",
+    "jcr:createdBy"          : "admin",
+    "jcr:title"              : "Image (v3)",
+    "sling:resourceSuperType": "core/wcm/components/image",
+    "jcr:description"        : "Smart Adaptive Image",
+    "cq:icon"                : "image",
+    "componentGroup"         : ".core-wcm"
+  }
+}

--- a/bundles/core/src/test/resources/image-delegate-policy-servlet/test-content.json
+++ b/bundles/core/src/test/resources/image-delegate-policy-servlet/test-content.json
@@ -1,0 +1,18 @@
+{
+  "test" : {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "root": {
+        "jcr:primaryType": "nt:unstructured",
+        "responsivegrid": {
+          "jcr:primaryType": "nt:unstructured",
+          "teaser": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "core/wcm/components/teaser"
+          }
+        }
+      }
+    }
+  }
+}

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -31,7 +31,7 @@
     <!-- P R O J E C T  D E S C R I P T I O N                                   -->
     <!-- ====================================================================== -->
     <artifactId>core.wcm.components.config</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <packaging>content-package</packaging>
 
     <name>Adobe Experience Manager Core WCM Components Configurations</name>

--- a/content/package-lock.json
+++ b/content/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "com.adobe.cq.core.wcm.components.content",
-    "version": "2.21.3-SNAPSHOT",
+    "version": "0.20.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "com.adobe.cq.core.wcm.components.content",
-            "version": "2.21.3-SNAPSHOT",
+            "version": "0.20.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@adobe/adobe-client-data-layer": "2.0.2"

--- a/content/package.json
+++ b/content/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.adobe.cq.core.wcm.components.content",
-    "version": "2.21.3-SNAPSHOT",
+    "version": "0.20.0",
     "description": "Adobe Experience Manager Core WCM Components Content Package",
     "license": "Apache-2.0",
     "private": false,

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -31,7 +31,7 @@
     <!-- P R O J E C T  D E S C R I P T I O N                                   -->
     <!-- ====================================================================== -->
     <artifactId>core.wcm.components.content</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <packaging>content-package</packaging>
     <name>Adobe Experience Manager Core WCM Components Content Package</name>
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/_cq_dialog/.content.xml
@@ -111,36 +111,6 @@
                                                 text="Don’t provide an alternative text"
                                                 uncheckedValue="false"
                                                 value="{Boolean}true"/>
-                                            <disableLazyLoading
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                                granite:hide="${cqDesign.disableLazyLoading}"
-                                                fieldDescription="When checked, image will be loaded eagerly, regardless of if the image is currently visible by the user."
-                                                name="./disableLazyLoading"
-                                                text="Disable lazy loading"
-                                                deleteHint="{Boolean}true"
-                                                value="{Boolean}true"/>
-                                        </items>
-                                    </column>
-                                </items>
-                            </columns>
-                        </items>
-                    </asset>
-                    <metadata
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="Metadata"
-                        sling:resourceType="granite/ui/components/coral/foundation/container"
-                        margin="{Boolean}true">
-                        <items jcr:primaryType="nt:unstructured">
-                            <columns
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
-                                margin="{Boolean}true">
-                                <items jcr:primaryType="nt:unstructured">
-                                    <column
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/coral/foundation/container">
-                                        <items jcr:primaryType="nt:unstructured">
                                             <dynamicmediaGroup
                                                 granite:hide="${!cqDesign.enableDmFeatures}"
                                                 jcr:primaryType="nt:unstructured"
@@ -185,14 +155,14 @@
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="dam/components/scene7/common/imagepresetdatasource"/>
                                                     </imagepreset>
-													<smartcroprenditions
-														granite:class="cmp-image__editor-dynamicmedia-smartcroprendition"
-														jcr:primaryType="nt:unstructured"
-														sling:resourceType="granite/ui/components/coral/foundation/form/select"
-														fieldDescription="Select Auto for Dynamic Media to decide the best rendition. Else select a specific smart crop rendition."
-														fieldLabel="Rendition"
-														name="./smartCropRendition">
-													</smartcroprenditions>
+                                                    <smartcroprenditions
+                                                        granite:class="cmp-image__editor-dynamicmedia-smartcroprendition"
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                        fieldDescription="Select Auto for Dynamic Media to decide the best rendition. Else select a specific smart crop rendition."
+                                                        fieldLabel="Rendition"
+                                                        name="./smartCropRendition">
+                                                    </smartcroprenditions>
                                                     <imageModifiers
                                                         jcr:primaryType="nt:unstructured"
                                                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
@@ -201,6 +171,37 @@
                                                         name="./imageModifiers"/>
                                                 </items>
                                             </dynamicmediaGroup>
+                                            <disableLazyLoading
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                granite:hide="${cqDesign.disableLazyLoading}"
+                                                fieldDescription="When checked, image will be loaded eagerly, regardless of if the image is currently visible by the user."
+                                                name="./disableLazyLoading"
+                                                text="Disable lazy loading"
+                                                deleteHint="{Boolean}true"
+                                                value="{Boolean}true"/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </asset>
+                    <metadata
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Metadata"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+
                                             <captionGroup
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/well">

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
@@ -356,7 +356,8 @@
                     </text>
                     <image
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        jcr:title="Asset"
+                        sling:resourceType="core/wcm/components/include/imagedelegate"
                         path="core/wcm/components/image/v3/image/cq:dialog/content/items/tabs/items/asset"/>
                     <styletab
                             jcr:primaryType="nt:unstructured"

--- a/examples/all/pom.xml
+++ b/examples/all/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>core.wcm.components.examples.all</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <packaging>content-package</packaging>
 
     <name>Adobe Experience Manager Core WCM Components Examples Aggregator Package</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>core.wcm.components.examples</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <packaging>pom</packaging>
 
     <name>Adobe Experience Manager Core WCM Components Examples Reactor</name>

--- a/examples/ui.apps/pom.xml
+++ b/examples/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
@@ -31,7 +31,7 @@
     <!-- P R O J E C T  D E S C R I P T I O N                                   -->
     <!-- ====================================================================== -->
     <artifactId>core.wcm.components.examples.ui.apps</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <packaging>content-package</packaging>
     <name>Adobe Experience Manager Core WCM Components Examples Application Package</name>
 

--- a/examples/ui.config/pom.xml
+++ b/examples/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
@@ -31,7 +31,7 @@
     <!-- P R O J E C T  D E S C R I P T I O N                                   -->
     <!-- ====================================================================== -->
     <artifactId>core.wcm.components.examples.ui.config</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <packaging>content-package</packaging>
     <name>Adobe Experience Manager Core WCM Components Examples Configuration &amp; Bundles Package</name>
 

--- a/examples/ui.content/pom.xml
+++ b/examples/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
@@ -31,7 +31,7 @@
     <!-- P R O J E C T  D E S C R I P T I O N                                   -->
     <!-- ====================================================================== -->
     <artifactId>core.wcm.components.examples.ui.content</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <packaging>content-package</packaging>
     <name>Adobe Experience Manager Core WCM Components Examples Content Package</name>
 

--- a/extensions/amp/bundle/pom.xml
+++ b/extensions/amp/bundle/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>core.wcm.components.extensions.amp</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <packaging>bundle</packaging>
 
     <name>Adobe Experience Manager Core WCM Components AMP Extension Bundle</name>

--- a/extensions/amp/content/package-lock.json
+++ b/extensions/amp/content/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "core.wcm.components.extensions.amp-content",
-    "version": "2.21.3-SNAPSHOT",
+    "version": "0.20.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "core.wcm.components.extensions.amp-content",
-            "version": "2.21.3-SNAPSHOT",
+            "version": "0.20.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "aemfed": "^0.1.1",

--- a/extensions/amp/content/package.json
+++ b/extensions/amp/content/package.json
@@ -1,6 +1,6 @@
 {
     "name": "core.wcm.components.extensions.amp-content",
-    "version": "2.21.3-SNAPSHOT",
+    "version": "0.20.0",
     "description": "Adobe Experience Manager Core WCM Components AMP Extension Content Package",
     "license": "Apache-2.0",
     "private": false,

--- a/extensions/amp/content/pom.xml
+++ b/extensions/amp/content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
 
@@ -31,7 +31,7 @@
     <!-- P R O J E C T  D E S C R I P T I O N                                   -->
     <!-- ====================================================================== -->
     <artifactId>core.wcm.components.extensions.amp.content</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <packaging>content-package</packaging>
     <name>Adobe Experience Manager Core WCM Components AMP Extension Content Package</name>
 

--- a/extensions/amp/pom.xml
+++ b/extensions/amp/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>core.wcm.components.extensions.amp.reactor</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <packaging>pom</packaging>
 
     <name>Adobe Experience Manager Core WCM Components AMP Extension Reactor</name>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.adobe.cq</groupId>
     <artifactId>core.wcm.components.parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
 
     <name>Adobe Experience Manager Core WCM Components Parent</name>
     <description>A set of standardized components for AEM 6.3+ that can be used to speed up development of websites.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>core.wcm.components.reactor</artifactId>
     <packaging>pom</packaging>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
 
     <name>Adobe Experience Manager Core WCM Components Reactor</name>
 

--- a/testing/aem-mock-plugin/pom.xml
+++ b/testing/aem-mock-plugin/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>core.wcm.components.testing.aem-mock-plugin</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <name>Adobe Experience Manager Core WCM Components AEM Mocks Plugin</name>
 
     <description>Helps setting up mock environment for unit testing custom code based on Core Components.</description>
@@ -66,13 +66,13 @@
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>core.wcm.components.core</artifactId>
-            <version>2.21.3-SNAPSHOT</version>
+            <version>0.20.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>core.wcm.components.junit.core</artifactId>
-            <version>2.21.3-SNAPSHOT</version>
+            <version>0.20.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/testing/it/e2e-selenium-utils/pom.xml
+++ b/testing/it/e2e-selenium-utils/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
 
@@ -33,7 +33,7 @@
     <!-- ====================================================================== -->
     <groupId>com.adobe.cq</groupId>
     <artifactId>core.wcm.components.it.e2e-selenium-utils</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <name>Adobe Experience Manager Core WCM Components E2E Testing Utils</name>
     <packaging>jar</packaging>
 

--- a/testing/it/e2e-selenium/pom.xml
+++ b/testing/it/e2e-selenium/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
 
@@ -33,7 +33,7 @@
     <!-- ====================================================================== -->
     <groupId>com.adobe.cq</groupId>
     <artifactId>core.wcm.components.it.e2e-selenium</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <name>Adobe Experience Manager Core WCM Components Selenium Base Test Framework</name>
 
     <build>

--- a/testing/it/http/pom.xml
+++ b/testing/it/http/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
 
@@ -33,7 +33,7 @@
     <!-- ====================================================================== -->
     <groupId>com.adobe.cq</groupId>
     <artifactId>core.wcm.components.it.http</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <name>Adobe Experience Manager Core WCM Components HTTP Integration Tests</name>
 
     <build>

--- a/testing/it/it.ui.apps/package-lock.json
+++ b/testing/it/it.ui.apps/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "com.adobe.cq.core.wcm.components.it.content",
-    "version": "2.21.3-SNAPSHOT",
+    "version": "0.20.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "com.adobe.cq.core.wcm.components.it.content",
-            "version": "2.21.3-SNAPSHOT",
+            "version": "0.20.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "sync-pom-version-to-package": "^1.6.1"

--- a/testing/it/it.ui.apps/package.json
+++ b/testing/it/it.ui.apps/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.adobe.cq.core.wcm.components.it.ui.apps",
-    "version": "2.21.3-SNAPSHOT",
+    "version": "0.20.0",
     "description": "Adobe Experience Manager Core WCM Components IT Immutable Content",
     "license": "Apache-2.0",
     "private": false,

--- a/testing/it/it.ui.apps/pom.xml
+++ b/testing/it/it.ui.apps/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
 
@@ -34,7 +34,7 @@
     <artifactId>core.wcm.components.it.ui.apps</artifactId>
     <packaging>content-package</packaging>
     <name>Adobe Experience Manager Core WCM Components IT Immutable Content</name>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
 
     <!-- ====================================================================== -->
     <!-- P R O P E R T I E S                                                    -->

--- a/testing/it/it.ui.content/pom.xml
+++ b/testing/it/it.ui.content/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
 
@@ -34,7 +34,7 @@
     <artifactId>core.wcm.components.it.ui.content</artifactId>
     <packaging>content-package</packaging>
     <name>Adobe Experience Manager Core WCM Components IT Mutable Content</name>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
 
     <!-- ====================================================================== -->
     <!-- P R O P E R T I E S                                                    -->

--- a/testing/junit/core/pom.xml
+++ b/testing/junit/core/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.parent</artifactId>
-        <version>2.21.3-SNAPSHOT</version>
+        <version>0.20.0</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>core.wcm.components.junit.core</artifactId>
-    <version>2.21.3-SNAPSHOT</version>
+    <version>0.20.0</version>
     <packaging>bundle</packaging>
 
     <name>Adobe Experience Manager Core WCM Components JUnit Testing</name>


### PR DESCRIPTION
- provide servlet to include asset tab from image component into the the teaser dialog. In this case the cqDesign request attribute needs to be reset to the imageDelegate component
- move the DM settings from the metadata tab to the asset tap in the image dialog, so it is still only required to include the asset tab within the teaser dialog

relates to #1473

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
