### PR TITLE
Upgrade `org.jsoup:jsoup` -> 1.15.3

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -403,7 +403,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.14.3</version>
+            <version>1.15.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/bundles/core/src/test/resources/tableofcontents/exporter-duplicate-ids-content.html
+++ b/bundles/core/src/test/resources/tableofcontents/exporter-duplicate-ids-content.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="en"> 
- <head> 
-  <meta charset="UTF-8"> 
-  <title>TOC Duplicate IDs Test</title> 
- </head> 
- <body> <!-- TOCs --> 
+<html lang="en">
+ <head>
+  <meta charset="UTF-8">
+  <title>TOC Duplicate IDs Test</title>
+ </head>
+ <body><!-- TOCs -->
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#bla">Bla</a>
@@ -18,12 +18,12 @@
        </ul></li>
      </ul></li>
    </ul>
-  </div> <!-- Page Content --> 
-  <div> 
-   <h1 id="bla">Bla</h1> 
-   <h2 id="bla-1">Bla</h2> 
-   <h3 id="bla-2">Bla</h3> 
-   <h4 id="bla-3">Bla</h4>  
+  </div> <!-- Page Content -->
+  <div>
+   <h1 id="bla">Bla</h1>
+   <h2 id="bla-1">Bla</h2>
+   <h3 id="bla-2">Bla</h3>
+   <h4 id="bla-3">Bla</h4>
   </div>
  </body>
 </html>

--- a/bundles/core/src/test/resources/tableofcontents/exporter-include-ignore-content.html
+++ b/bundles/core/src/test/resources/tableofcontents/exporter-include-ignore-content.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="en"> 
- <head> 
-  <meta charset="UTF-8"> 
-  <title>TOC Include Ignore Behavior Test</title> 
- </head> 
- <body> <!-- TOCs --> 
+<html lang="en">
+ <head>
+  <meta charset="UTF-8">
+  <title>TOC Include Ignore Behavior Test</title>
+ </head>
+ <body><!-- TOCs -->
   <div class="cmp-toc__content" id="sample-toc-id">
    <ol>
     <li><a href="#page-title">Page title</a>
@@ -21,7 +21,7 @@
        </ol></li>
      </ol></li>
    </ol>
-  </div> 
+  </div>
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#page-title">Page title</a>
@@ -33,7 +33,7 @@
        </ul></li>
      </ul></li>
    </ul>
-  </div> 
+  </div>
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#page-title">Page title</a>
@@ -42,7 +42,7 @@
       <li><a href="#sidebar-title">Sidebar title</a></li>
      </ul></li>
    </ul>
-  </div> 
+  </div>
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#page-title">Page title</a>
@@ -53,7 +53,7 @@
       <li><a href="#sidebar-teaser">Sidebar teaser</a></li>
      </ul></li>
    </ul>
-  </div> 
+  </div>
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#page-title">Page title</a>
@@ -61,7 +61,7 @@
       <li><a href="#main-title">Main title</a></li>
      </ul></li>
    </ul>
-  </div> 
+  </div>
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#page-title">Page title</a>
@@ -70,7 +70,7 @@
       <li><a href="#main-teaser">Main teaser</a></li>
      </ul></li>
    </ul>
-  </div> 
+  </div>
   <div class="cmp-toc__content">
    <ol>
     <li><a href="#page-title">Page title</a>
@@ -80,25 +80,25 @@
       <li><a href="#sidebar-title">Sidebar title</a></li>
      </ol></li>
    </ol>
-  </div> <!-- Page Content --> 
-  <h1 class="cmp-title" id="page-title">Page title</h1> 
-  <div class="main"> 
-   <div class="cmp-title"> 
-    <h2 id="main-title">Main title</h2> 
-   </div> 
-   <div class="cmp-teaser"> 
-    <h2 class="cmp-teaser__title" id="main-teaser">Main teaser</h2> 
-    <h3 class="cmp-teaser__subtitle" id="main-teaser-subtitle">Main teaser subtitle</h3> 
-   </div> 
-  </div> 
-  <div class="sidebar"> 
-   <div class="cmp-title"> 
-    <h2 id="sidebar-title">Sidebar title</h2> 
-   </div> 
-   <div class="cmp-teaser"> 
-    <h2 class="cmp-teaser__title" id="sidebar-teaser">Sidebar teaser</h2> 
-    <h3 class="cmp-teaser__subtitle" id="sidebar-teaser-subtitle">Sidebar teaser subtitle</h3> 
-   </div> 
-  </div>  
+  </div> <!-- Page Content -->
+  <h1 class="cmp-title" id="page-title">Page title</h1>
+  <div class="main">
+   <div class="cmp-title">
+    <h2 id="main-title">Main title</h2>
+   </div>
+   <div class="cmp-teaser">
+    <h2 class="cmp-teaser__title" id="main-teaser">Main teaser</h2>
+    <h3 class="cmp-teaser__subtitle" id="main-teaser-subtitle">Main teaser subtitle</h3>
+   </div>
+  </div>
+  <div class="sidebar">
+   <div class="cmp-title">
+    <h2 id="sidebar-title">Sidebar title</h2>
+   </div>
+   <div class="cmp-teaser">
+    <h2 class="cmp-teaser__title" id="sidebar-teaser">Sidebar teaser</h2>
+    <h3 class="cmp-teaser__subtitle" id="sidebar-teaser-subtitle">Sidebar teaser subtitle</h3>
+   </div>
+  </div>
  </body>
 </html>

--- a/bundles/core/src/test/resources/tableofcontents/exporter-invalid-toc-content.html
+++ b/bundles/core/src/test/resources/tableofcontents/exporter-invalid-toc-content.html
@@ -1,15 +1,15 @@
 <!doctype html>
-<html lang="en"> 
- <head> 
-  <meta charset="UTF-8"> 
-  <title>TOC Invalid Start Stop Levels Test</title> 
- </head> 
- <body> 
-  <div> 
-   <div class="cmp-toc__content"></div> 
-   <div> 
-    <div class="cq-placeholder cmp-toc__template-placeholder" data-emptytext="Table of Contents (v1)"></div> 
-   </div> 
-  </div>  
+<html lang="en">
+ <head>
+  <meta charset="UTF-8">
+  <title>TOC Invalid Start Stop Levels Test</title>
+ </head>
+ <body>
+  <div>
+   <div class="cmp-toc__content"></div>
+   <div>
+    <div class="cq-placeholder cmp-toc__template-placeholder" data-emptytext="Table of Contents (v1)"></div>
+   </div>
+  </div>
  </body>
 </html>

--- a/bundles/core/src/test/resources/tableofcontents/exporter-nesting-content.html
+++ b/bundles/core/src/test/resources/tableofcontents/exporter-nesting-content.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="en"> 
- <head> 
-  <meta charset="UTF-8"> 
-  <title>TOC Nesting Behaviour Test</title> 
- </head> 
- <body> <!-- TOCs --> 
+<html lang="en">
+ <head>
+  <meta charset="UTF-8">
+  <title>TOC Nesting Behaviour Test</title>
+ </head>
+ <body><!-- TOCs -->
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#bla">Bla</a>
@@ -18,7 +18,7 @@
        </ul></li>
      </ul></li>
    </ul>
-  </div> 
+  </div>
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#bla-1">Bla</a>
@@ -30,7 +30,7 @@
       <li><a href="#blu-1">Blu</a></li>
      </ul></li>
    </ul>
-  </div> 
+  </div>
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#bla-2">Bla</a>
@@ -44,7 +44,7 @@
        </ul></li>
      </ul></li>
    </ul>
-  </div> 
+  </div>
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#bla-3">Bla</a>
@@ -56,7 +56,7 @@
       <li><a href="#blu-3">Blu</a></li>
      </ul></li>
    </ul>
-  </div> 
+  </div>
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#bla-4">Bla</a></li>
@@ -66,7 +66,7 @@
       <li><a href="#blu-4">Blu</a></li>
      </ul></li>
    </ul>
-  </div> 
+  </div>
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#bla-5">Bla</a>
@@ -78,7 +78,7 @@
        </ul></li>
      </ul></li>
    </ul>
-  </div> 
+  </div>
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#bla-6">Bla</a>
@@ -91,49 +91,49 @@
       <li><a href="#ble">Ble</a></li>
      </ul></li>
    </ul>
-  </div> <!-- Page Content --> 
-  <div class="example-1"> 
-   <h1 id="bla">Bla</h1> 
-   <h2 id="bli">Bli</h2> 
-   <h3 id="blo">Blo</h3> 
-   <h4 id="blu">Blu</h4> 
-  </div> 
-  <div class="example-2"> 
-   <h1 id="bla-1">Bla</h1> 
-   <h2 id="bli-1">Bli</h2> 
-   <h1 id="blo-1">Blo</h1> 
-   <h2 id="blu-1">Blu</h2> 
-  </div> 
-  <div class="example-3"> 
-   <h1 id="bla-2">Bla</h1> 
-   <h3 id="bli-2">Bli</h3> 
-   <h5 id="blo-2">Blo</h5> 
-   <h6 id="blu-2">Blu</h6> 
-  </div> 
-  <div class="example-4"> 
-   <h3 id="bla-3">Bla</h3> 
-   <h4 id="bli-3">Bli</h4> 
-   <h3 id="blo-3">Blo</h3> 
-   <h4 id="blu-3">Blu</h4> 
-  </div> 
-  <div class="example-5"> 
-   <h4 id="bla-4">Bla</h4> 
-   <h3 id="bli-4">Bli</h3> 
-   <h2 id="blo-4">Blo</h2> 
-   <h4 id="blu-4">Blu</h4> 
-  </div> 
-  <div class="example-6"> 
-   <h1 id="bla-5">Bla</h1> 
-   <h3 id="bli-5">Bli</h3> 
-   <h2 id="blo-5">Blo</h2> 
-   <h3 id="blu-5">Blu</h3> 
-  </div> 
-  <div class="example-7"> 
-   <h3 id="bla-6">Bla</h3> 
-   <h6 id="bli-6">Bli</h6> 
-   <h5 id="blo-6">Blo</h5> 
-   <h2 id="blu-6">Blu</h2> 
-   <h3 id="ble">Ble</h3> 
-  </div>  
+  </div> <!-- Page Content -->
+  <div class="example-1">
+   <h1 id="bla">Bla</h1>
+   <h2 id="bli">Bli</h2>
+   <h3 id="blo">Blo</h3>
+   <h4 id="blu">Blu</h4>
+  </div>
+  <div class="example-2">
+   <h1 id="bla-1">Bla</h1>
+   <h2 id="bli-1">Bli</h2>
+   <h1 id="blo-1">Blo</h1>
+   <h2 id="blu-1">Blu</h2>
+  </div>
+  <div class="example-3">
+   <h1 id="bla-2">Bla</h1>
+   <h3 id="bli-2">Bli</h3>
+   <h5 id="blo-2">Blo</h5>
+   <h6 id="blu-2">Blu</h6>
+  </div>
+  <div class="example-4">
+   <h3 id="bla-3">Bla</h3>
+   <h4 id="bli-3">Bli</h4>
+   <h3 id="blo-3">Blo</h3>
+   <h4 id="blu-3">Blu</h4>
+  </div>
+  <div class="example-5">
+   <h4 id="bla-4">Bla</h4>
+   <h3 id="bli-4">Bli</h3>
+   <h2 id="blo-4">Blo</h2>
+   <h4 id="blu-4">Blu</h4>
+  </div>
+  <div class="example-6">
+   <h1 id="bla-5">Bla</h1>
+   <h3 id="bli-5">Bli</h3>
+   <h2 id="blo-5">Blo</h2>
+   <h3 id="blu-5">Blu</h3>
+  </div>
+  <div class="example-7">
+   <h3 id="bla-6">Bla</h3>
+   <h6 id="bli-6">Bli</h6>
+   <h5 id="blo-6">Blo</h5>
+   <h2 id="blu-6">Blu</h2>
+   <h3 id="ble">Ble</h3>
+  </div>
  </body>
 </html>

--- a/bundles/core/src/test/resources/tableofcontents/exporter-no-heading-content.html
+++ b/bundles/core/src/test/resources/tableofcontents/exporter-no-heading-content.html
@@ -1,11 +1,11 @@
 <!doctype html>
-<html lang="en"> 
- <head> 
-  <meta charset="UTF-8"> 
-  <title>TOC No Heading Test</title> 
- </head> 
- <body> <!-- TOCs --> 
-  <div class="cmp-toc__content"></div> 
-  <p>Sample Text</p>  
+<html lang="en">
+ <head>
+  <meta charset="UTF-8">
+  <title>TOC No Heading Test</title>
+ </head>
+ <body><!-- TOCs -->
+  <div class="cmp-toc__content"></div>
+  <p>Sample Text</p>
  </body>
 </html>

--- a/bundles/core/src/test/resources/tableofcontents/exporter-template-placeholder-content.html
+++ b/bundles/core/src/test/resources/tableofcontents/exporter-template-placeholder-content.html
@@ -1,11 +1,11 @@
 <!doctype html>
-<html lang="en"> 
- <head> 
-  <meta charset="UTF-8"> 
-  <title>TOC Template Placeholder Test</title> 
- </head> 
- <body> 
-  <div> 
+<html lang="en">
+ <head>
+  <meta charset="UTF-8">
+  <title>TOC Template Placeholder Test</title>
+ </head>
+ <body>
+  <div>
    <div class="cmp-toc__content">
     <ul>
      <li><a href="#bla">Bla</a>
@@ -19,21 +19,21 @@
         </ul></li>
       </ul></li>
     </ul>
-   </div> 
-   <div>  
-   </div> 
-  </div> 
-  <div> 
-   <div class="cmp-toc__content"></div> 
-   <div> 
-    <div class="cq-placeholder cmp-toc__template-placeholder" data-emptytext="Table of Contents (v1)"></div> 
-   </div> 
-  </div> 
-  <div> 
-   <h1 id="bla">Bla</h1> 
-   <h2 id="bli">Bli</h2> 
-   <h3 id="blo">Blo</h3> 
-   <h4 id="blu">Blu</h4> 
-  </div>  
+   </div>
+   <div>
+   </div>
+  </div>
+  <div>
+   <div class="cmp-toc__content"></div>
+   <div>
+    <div class="cq-placeholder cmp-toc__template-placeholder" data-emptytext="Table of Contents (v1)"></div>
+   </div>
+  </div>
+  <div>
+   <h1 id="bla">Bla</h1>
+   <h2 id="bli">Bli</h2>
+   <h3 id="blo">Blo</h3>
+   <h4 id="blu">Blu</h4>
+  </div>
  </body>
 </html>

--- a/bundles/core/src/test/resources/tableofcontents/test-duplicate-ids-content.html
+++ b/bundles/core/src/test/resources/tableofcontents/test-duplicate-ids-content.html
@@ -6,7 +6,7 @@
  </head>
  <body>
   <!-- TOCs -->
-  <div class="cmp-toc__placeholder"> 
+  <div class="cmp-toc__placeholder">
   </div>
   <!-- Page Content -->
   <div>

--- a/bundles/core/src/test/resources/tableofcontents/test-nesting-content.html
+++ b/bundles/core/src/test/resources/tableofcontents/test-nesting-content.html
@@ -7,25 +7,25 @@
  <body>
   <!-- TOCs -->
   <div class="cmp-toc__placeholder"
-   data-cmp-toc-include-classes="example-1"> 
+   data-cmp-toc-include-classes="example-1">
   </div>
   <div class="cmp-toc__placeholder"
-   data-cmp-toc-include-classes="example-2"> 
+   data-cmp-toc-include-classes="example-2">
   </div>
   <div class="cmp-toc__placeholder"
-   data-cmp-toc-include-classes="example-3"> 
+   data-cmp-toc-include-classes="example-3">
   </div>
   <div class="cmp-toc__placeholder"
-   data-cmp-toc-include-classes="example-4"> 
+   data-cmp-toc-include-classes="example-4">
   </div>
   <div class="cmp-toc__placeholder"
-   data-cmp-toc-include-classes="example-5"> 
+   data-cmp-toc-include-classes="example-5">
   </div>
   <div class="cmp-toc__placeholder"
-   data-cmp-toc-include-classes="example-6"> 
+   data-cmp-toc-include-classes="example-6">
   </div>
   <div class="cmp-toc__placeholder"
-   data-cmp-toc-include-classes="example-7"> 
+   data-cmp-toc-include-classes="example-7">
   </div>
 
   <!-- Page Content -->


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2365
| Patch: Bug Fix?          | Y
| Minor: New Feature?      | N
| Major: Breaking Change?  | N
| Tests Added + Pass?      | Yes (updated)
| Documentation Provided   | N/A
| Any Dependency Changes?  | Yes (embedded `jsoup` 1.14.3 -> 1.15.3)
| License                  | Apache License, Version 2.0

Jsoup is upgraded to the latest version to rectify CVE-2022-36033.

Additionally, Jsoup 1.5.2+ trims whitespace during prettying; therefore, the output golden files to reflect this change.
See [Jsoup changelog](https://github.com/jhy/jsoup/blob/master/CHANGES) for version 1.5.2 for details.
