### PR TITLE
SITES-9357 - [Accessibility][Core Separator] Missing method to make it decorative

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/SeparatorImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/SeparatorImpl.java
@@ -15,15 +15,21 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
+import com.day.cq.wcm.api.designer.Style;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.models.Separator;
+
+import javax.annotation.PostConstruct;
 
 @Model(adaptables = SlingHttpServletRequest.class,
     adapters = {Separator.class, ComponentExporter.class},
@@ -35,6 +41,34 @@ public class SeparatorImpl implements Separator {
 
     @Self
     private SlingHttpServletRequest request;
+
+    /**
+     * Component properties.
+     */
+    @ScriptVariable
+    protected ValueMap properties;
+
+    /**
+     * The current style.
+     */
+    @ScriptVariable
+    protected Style currentStyle;
+
+    /**
+     * Flag indicating if the separator is decorative.
+     */
+    private boolean decorative;
+
+    @PostConstruct
+    protected void initModel() {
+        decorative = properties.get(PN_IS_DECORATIVE, currentStyle.get(PN_IS_DECORATIVE, false));
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isDecorative() {
+        return decorative;
+    }
 
     @NotNull
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Separator.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Separator.java
@@ -24,5 +24,20 @@ import org.osgi.annotation.versioning.ConsumerType;
  */
 @ConsumerType
 public interface Separator extends Component {
+    /**
+     * Name of the resource property that will indicate if the separator is decorative.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.27.0
+     */
+    String PN_IS_DECORATIVE = "isDecorative";
 
+    /**
+     * Indicates whether the separator is decorative.
+     *
+     * @return {@code true} if the separator is decorative; {@code false} otherwise
+     * @since com.adobe.cq.wcm.core.components.models 12.27.0
+     */
+    default boolean isDecorative() {
+        return false;
+    }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/SeparatorImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/SeparatorImplTest.java
@@ -26,6 +26,8 @@ import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 class SeparatorImplTest {
@@ -36,6 +38,7 @@ class SeparatorImplTest {
     private static final String TEST_ROOT_PAGE = "/content/separator";
     private static final String TEST_ROOT_PAGE_GRID = "/jcr:content/root/responsivegrid";
     private static final String SEPARATOR_1 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/separator-1";
+    private static final String SEPARATOR_2 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/separator-2";
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
 
@@ -45,14 +48,26 @@ class SeparatorImplTest {
     }
 
     @Test
+    void testStandard() {
+        Separator separator = getSeparatorUnderTest(SEPARATOR_1);
+        assertFalse(separator.isDecorative());
+    }
+
+    @Test
+    void testDecorative() {
+        Separator separator = getSeparatorUnderTest(SEPARATOR_2);
+        assertTrue(separator.isDecorative());
+    }
+
+    @Test
     void testExportedType() {
-        Separator separator = getSeparatorUnderTest();
+        Separator separator = getSeparatorUnderTest(SEPARATOR_1);
         assertEquals(SeparatorImpl.RESOURCE_TYPE_V1, ((SeparatorImpl) separator).getExportedType());
         Utils.testJSONExport(separator, Utils.getTestExporterJSONPath(TEST_BASE, "separator1"));
     }
 
-    private Separator getSeparatorUnderTest() {
-        context.currentResource(SeparatorImplTest.SEPARATOR_1);
+    private Separator getSeparatorUnderTest(String path) {
+        context.currentResource(path);
         context.request().setContextPath(CONTEXT_PATH);
         return context.request().adaptTo(Separator.class);
     }

--- a/bundles/core/src/test/resources/separator/test-content.json
+++ b/bundles/core/src/test/resources/separator/test-content.json
@@ -15,6 +15,11 @@
                     "separator-1"          : {
                         "jcr:primaryType"   : "nt:unstructured",
                         "sling:resourceType": "core/wcm/components/separator/v1/separator"
+                    },
+                    "separator-2"          : {
+                        "jcr:primaryType"   : "nt:unstructured",
+                        "sling:resourceType": "core/wcm/components/separator/v1/separator",
+                        "isDecorative"   : "true"
                     }
                 }
             }

--- a/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/README.md
@@ -21,10 +21,19 @@ Separator component written in HTL.
 
 * Allows addition of a horizontal rule element for separating content sections.
 
+### Use Object
+The Separator component uses the `com.adobe.cq.wcm.core.components.models.Separator` Sling Model as its Use-object.
+
+### Component Policy Configuration Properties
+The following configuration properties are used:
+
+1. `./isDecorative` - if set to `true`, then the separator will be ignored by assistive technology
+
 ## Edit Dialog Properties
 The following properties are written to JCR for this Page component and are expected to be available as `Resource` properties:
 
 1. `./id` - defines the component HTML ID attribute.
+2. `./isDecorative` - if set to `true`, then the separator will be ignored by assistive technology
 
 ## BEM Description
 ```

--- a/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/_cq_design_dialog/.content.xml
@@ -30,6 +30,22 @@
                 sling:resourceType="granite/ui/components/coral/foundation/tabs"
                 maximized="{Boolean}true">
                 <items jcr:primaryType="nt:unstructured">
+                    <main
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Separator"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <decorative
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                fieldDescription="Check if the separator is merely decorative and should be ignored by assistive technology."
+                                name="./isDecorative"
+                                text="Decorative"
+                                uncheckedValue="false"
+                                value="{Boolean}true"/>
+                        </items>
+                    </main>
                     <styletab
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="granite/ui/components/coral/foundation/include"

--- a/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/_cq_dialog/.content.xml
@@ -48,6 +48,15 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
+                                            <decorative
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                checked="${not empty cqDesign.isDecorative ? cqDesign.isDecorative : false}"
+                                                fieldDescription="Check if the separator is merely decorative and should be ignored by assistive technology like screen readers."
+                                                name="./isDecorative"
+                                                text="Separator is decorative."
+                                                uncheckedValue="false"
+                                                value="{Boolean}true"/>
                                             <id
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"

--- a/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/separator.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/separator.html
@@ -17,5 +17,7 @@
      data-sly-use.separator="com.adobe.cq.wcm.core.components.models.Separator"
      id="${component.id}"
      class="cmp-separator">
-    <hr class="cmp-separator__horizontal-rule" data-sly-attribute.role="${separator.decorative ? 'none': ''}"/>
+    <hr class="cmp-separator__horizontal-rule"
+        data-sly-attribute.role="${separator.decorative ? 'none': ''}"
+        data-sly-attribute.aria-hidden="${separator.decorative ? 'true': ''}"/>
 </div>

--- a/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/core-content/separator/.content.xml
+++ b/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/core-content/separator/.content.xml
@@ -99,6 +99,49 @@
                             reference="../../component"/>
                     </info>
                 </demo>
+                <title_2
+                    cq:styleIds="[1544759676459]"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Decorative"
+                    sling:resourceType="core-components-examples/components/title"
+                    type="h3"/>
+                <text_2
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/text"
+                    text="&lt;p>Decorative Separator ignored by assistive technologies.&lt;/p>"
+                    textIsRich="true"/>
+                <demo_2
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/demo"
+                    fullWidth="{Boolean}true">
+                    <component
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/demo/component">
+                        <separator
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/separator"
+                            isDecorative="true"/>
+                    </component>
+                    <info
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/tabs">
+                        <properties
+                            cq:panelTitle="Properties"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/properties"
+                            reference="../../component"/>
+                        <markup
+                            cq:panelTitle="Markup"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/markup"
+                            reference="../../component"/>
+                        <json
+                            cq:panelTitle="JSON"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/json"
+                            reference="../../component"/>
+                    </info>
+                </demo_2>
             </responsivegrid>
         </root>
         <image jcr:primaryType="nt:unstructured">

--- a/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/Commons.java
+++ b/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/Commons.java
@@ -144,6 +144,8 @@ public class Commons {
     public static final String CLIENTLIBS_TABS_V1 = "core.wcm.components.tabs.v1";
     // content fragment component
     public static final String RT_CONTENTFRAGMENT_V1 = "core-component/components/contentfragment-v1";
+    // separator component
+    public static final String RT_SEPARATOR_V1 = "core-component/components/separator-v1";
     // content fragment list component
     public static final String RT_CONTENTFRAGMENTLIST_V1 = "core-component/components/contentfragmentlist-v1";
     public static final String RT_CONTENTFRAGMENTLIST_V2 = "core-component/components/contentfragmentlist-v2";

--- a/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/components/separator/SeparatorEditDialog.java
+++ b/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/components/separator/SeparatorEditDialog.java
@@ -1,0 +1,28 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+package com.adobe.cq.wcm.core.components.it.seljup.util.components.separator;
+
+import com.adobe.cq.testing.selenium.pagewidgets.coral.CoralCheckbox;
+
+public class SeparatorEditDialog {
+    public static final String DECORATIVE = "[name='./isDecorative']";
+
+    public void checkDecorative() {
+        CoralCheckbox checkbox = new CoralCheckbox(DECORATIVE);
+        checkbox.click();
+    }
+}

--- a/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/components/separator/v1/Separator.java
+++ b/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/components/separator/v1/Separator.java
@@ -1,0 +1,39 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+package com.adobe.cq.wcm.core.components.it.seljup.util.components.separator.v1;
+
+import com.adobe.cq.testing.selenium.pagewidgets.common.BaseComponent;
+import com.adobe.cq.wcm.core.components.it.seljup.util.components.separator.SeparatorEditDialog;
+
+public class Separator extends BaseComponent {
+
+    private static final String SEPARATOR = ".cmp-separator";
+    private static final String HORIZONTAL_RULE = ".cmp-separator__horizontal-rule";
+
+    public Separator() {
+        super(SEPARATOR);
+    }
+
+    public SeparatorEditDialog getEditDialog() {
+        return new SeparatorEditDialog();
+    }
+
+    public boolean isDecorative() {
+        String role = currentElement.$(HORIZONTAL_RULE).getAttribute("role");
+        return "none".equals(role);
+    }
+}

--- a/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/components/separator/v1/Separator.java
+++ b/testing/it/e2e-selenium-utils/src/main/java/com/adobe/cq/wcm/core/components/it/seljup/util/components/separator/v1/Separator.java
@@ -34,6 +34,7 @@ public class Separator extends BaseComponent {
 
     public boolean isDecorative() {
         String role = currentElement.$(HORIZONTAL_RULE).getAttribute("role");
-        return "none".equals(role);
+        String ariaHidden = currentElement.$(HORIZONTAL_RULE).getAttribute("aria-hidden");
+        return "none".equals(role) && "true".equals(ariaHidden);
     }
 }

--- a/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/separator/v1/SeparatorIT.java
+++ b/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/separator/v1/SeparatorIT.java
@@ -1,0 +1,95 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+package com.adobe.cq.wcm.core.components.it.seljup.tests.separator.v1;
+
+import com.adobe.cq.testing.selenium.pageobject.EditorPage;
+import com.adobe.cq.testing.selenium.pageobject.PageEditorPage;
+import com.adobe.cq.wcm.core.components.it.seljup.AuthorBaseUITest;
+import com.adobe.cq.wcm.core.components.it.seljup.util.Commons;
+import com.adobe.cq.wcm.core.components.it.seljup.util.components.separator.v1.Separator;
+import com.adobe.cq.wcm.core.components.it.seljup.util.constant.RequestConstants;
+import org.apache.http.HttpStatus;
+import org.apache.sling.testing.clients.ClientException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeoutException;
+
+import static com.adobe.cq.wcm.core.components.it.seljup.util.Commons.RT_SEPARATOR_V1;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SeparatorIT extends AuthorBaseUITest {
+
+    private String testPage;
+    private String cmpPath;
+    private EditorPage editorPage;
+    private Separator separator;
+
+    @BeforeEach
+    public void setupBeforeEach() throws ClientException {
+        // create the test page, store page path in 'testPagePath'
+        testPage = authorClient.createPage("testPage", "Test Page Title", rootPage, defaultPageTemplate).getSlingPath();
+
+        // add the separator component
+        cmpPath = Commons.addComponentWithRetry(authorClient, RT_SEPARATOR_V1,testPage + Commons.relParentCompPath, "separator");
+
+        // open the page in the editor
+        editorPage = new PageEditorPage(testPage);
+        editorPage.open();
+
+        separator = new Separator();
+    }
+
+    @AfterEach
+    public void cleanupAfterEach() throws ClientException, InterruptedException {
+        authorClient.deletePageWithRetry(testPage, true,false, RequestConstants.TIMEOUT_TIME_MS, RequestConstants.RETRY_TIME_INTERVAL,  HttpStatus.SC_OK);
+    }
+
+    /**
+     * Test the decorative separator.
+     */
+    @Test
+    @DisplayName("Test decorative")
+    public void testDecorative() throws InterruptedException, TimeoutException {
+        Commons.switchContext("ContentFrame");
+
+        // initial state is normal (not decorative)
+        assertFalse(separator.isDecorative());
+
+        // set it to decorative
+        flipDecorativeInEditDialog();
+
+        assertTrue(separator.isDecorative());
+
+        // set back to normal
+        flipDecorativeInEditDialog();
+
+        assertFalse(separator.isDecorative());
+    }
+
+    private void flipDecorativeInEditDialog() throws TimeoutException, InterruptedException {
+        Commons.switchToDefaultContext();
+        Commons.openEditDialog(editorPage, cmpPath);
+        separator.getEditDialog().checkDecorative();
+        Commons.saveConfigureDialog();
+        Commons.webDriverWait(RequestConstants.WEBDRIVER_WAIT_TIME_MS);
+        Commons.switchContext("ContentFrame");
+    }
+}

--- a/testing/it/it.ui.apps/src/content/jcr_root/apps/core-component/components/separator-v1/.content.xml
+++ b/testing/it/it.ui.apps/src/content/jcr_root/apps/core-component/components/separator-v1/.content.xml
@@ -1,5 +1,6 @@
-<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2018 Adobe
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -12,10 +13,9 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<div data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
-     data-sly-use.separator="com.adobe.cq.wcm.core.components.models.Separator"
-     id="${component.id}"
-     class="cmp-separator">
-    <hr class="cmp-separator__horizontal-rule" data-sly-attribute.role="${separator.decorative ? 'none': ''}"/>
-</div>
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+        jcr:primaryType="cq:Component"
+        jcr:title="Separator V1"
+        sling:resourceSuperType="core/wcm/components/separator/v1/separator"
+        componentGroup=".test"/>


### PR DESCRIPTION

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2334 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      | Yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | 
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
 * implemented support for decorative separator adding isDecorative property in edit dialog and config dialog
 * updated component readme
 * added unit tests and UI tests
 * updated examples library