### PR TITLE
fix: return cq:lastModified Date in data layer for pages

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
@@ -55,6 +55,7 @@ import com.adobe.cq.wcm.core.components.commons.link.LinkManager;
 import com.adobe.cq.wcm.core.components.models.Page;
 import com.adobe.cq.wcm.core.components.models.datalayer.PageData;
 import com.adobe.cq.wcm.core.components.models.datalayer.builder.DataLayerBuilder;
+import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.tagging.Tag;
 import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.api.Template;
@@ -336,6 +337,13 @@ public class PageImpl extends AbstractComponentImpl implements Page {
     protected final PageData getComponentData() {
         return DataLayerBuilder.extending(super.getComponentData()).asPage()
             .withTitle(this::getTitle)
+            .withLastModifiedDate(() ->
+                    Optional.ofNullable(this.getLastModifiedDate())
+                            .map(Calendar::getTime)
+                            .orElseGet(() ->
+                                    Optional.ofNullable(pageProperties.get(JcrConstants.JCR_CREATED, Calendar.class))
+                                            .map(Calendar::getTime)
+                                            .orElse(null)))
             .withTags(() -> Arrays.copyOf(this.keywords, this.keywords.length))
             .withDescription(() -> this.pageProperties.get(NameConstants.PN_DESCRIPTION, String.class))
             .withTemplatePath(() -> Optional.ofNullable(this.currentPage.getTemplate())

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImplTest.java
@@ -128,7 +128,7 @@ public class PageImplTest {
      * have a template set - without causing NPE.
      */
     @Test
-    protected void testPageData_noTemplate() throws PersistenceException {
+    protected void testPageData_noTemplate() throws PersistenceException, ParseException {
         context.load().binaryFile(TEST_BASE + "/static.css", DESIGN_PATH + "/static.css");
 
         // remove the template value
@@ -143,8 +143,10 @@ public class PageImplTest {
 
         PageData pageData = (PageData) getPageUnderTest(PAGE).getData();
         assertNotNull(pageData);
-        assertEquals("2016-01-20T10:33:36Z", new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
-                .format(pageData.getLastModifiedDate()));
+        Calendar calendar = Calendar.getInstance();
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
+        calendar.setTime(sdf.parse("2016-01-20T10:33:36.000+0100"));
+        assertEquals(calendar.getTime(), pageData.getLastModifiedDate());
         assertNull(pageData.getTemplatePath());
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImplTest.java
@@ -34,6 +34,7 @@ import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.Page;
 import com.day.cq.commons.jcr.JcrConstants;
+import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.api.components.ComponentContext;
 import com.day.cq.wcm.api.designer.Design;
 import com.day.cq.wcm.api.designer.Designer;
@@ -148,6 +149,23 @@ public class PageImplTest {
         calendar.setTime(sdf.parse("2016-01-20T10:33:36.000+0100"));
         assertEquals(calendar.getTime(), pageData.getLastModifiedDate());
         assertNull(pageData.getTemplatePath());
+    }
+
+    @Test
+    protected void testPageData_noModificationDate() throws PersistenceException, ParseException {
+        // remove the lastModification value
+        ModifiableValueMap props = Objects.requireNonNull(
+                Optional.ofNullable((context.pageManager().getPage(PAGE)))
+                        .map(com.day.cq.wcm.api.Page::getContentResource)
+                        .map(r -> r.adaptTo(ModifiableValueMap.class))
+                        .orElse(null)
+        );
+        props.remove(NameConstants.PN_PAGE_LAST_MOD);
+        context.resourceResolver().commit();
+
+        PageData pageData = (PageData) getPageUnderTest(PAGE).getData();
+        assertNotNull(pageData);
+        assertNull(pageData.getLastModifiedDate());
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImplTest.java
@@ -143,6 +143,8 @@ public class PageImplTest {
 
         PageData pageData = (PageData) getPageUnderTest(PAGE).getData();
         assertNotNull(pageData);
+        assertEquals("2016-01-20T10:33:36Z", new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
+                .format(pageData.getLastModifiedDate()));
         assertNull(pageData.getTemplatePath());
     }
 

--- a/bundles/core/src/test/resources/page/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/exporter-templated-page.json
@@ -14,6 +14,7 @@
             "xdm:language": "en-GB",
             "@type": "core/wcm/components/page/v1/page",
             "dc:title": "Templated Page",
+            "repo:modifyDate": "2016-01-20T09:33:36Z",
             "xdm:template": "/conf/coretest/settings/wcm/templates/product-page",
             "repo:path": "/core/content/page/templated-page.html",
             "xdm:tags": [

--- a/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
@@ -66,6 +66,7 @@
   "dataLayer": {
     "page-bb590de134": {
       "@type": "core/wcm/components/page/v2/page",
+      "repo:modifyDate": "2016-01-20T09:33:36Z",
       "dc:title": "Templated Page",
       "dc:description": "Description",
       "xdm:template": "/conf/coretest/settings/wcm/templates/product-page",

--- a/bundles/core/src/test/resources/page/v3/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/v3/exporter-templated-page.json
@@ -66,6 +66,7 @@
   "dataLayer": {
     "page-bb590de134": {
       "@type": "core/wcm/components/page/v3/page",
+      "repo:modifyDate": "2016-01-20T09:33:36Z",
       "dc:title": "Templated Page",
       "dc:description": "Description",
       "xdm:template": "/conf/coretest/settings/wcm/templates/product-page",


### PR DESCRIPTION
- add page specific behaviour to get correct last modified date from the page properties
- extend unit test fixes #2384

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2384 
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | 👎
| Major: Breaking Change?  | 👎
| Tests Added + Pass?      | Yes
| Documentation Provided   | No, not needed.
| Any Dependency Changes?  | 👎
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
