### PR TITLE
Cannot edit components in nested Accordion

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/PanelContainer.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/PanelContainer.js
@@ -104,7 +104,7 @@
             if (that._config.el && that._config.panelContainerType) {
                 var items = $(this._config.el).find(that._config.panelContainerType.itemSelector);
                 items.each(function(index) {
-                    if ($(this).is(that._config.panelContainerType.itemActiveSelector)) {
+                    if ($(this).is("#" + that._config.el.id + " " + that._config.panelContainerType.itemActiveSelector)) {
                         activeIndex = index;
                         return false;
                     }


### PR DESCRIPTION
* Added parent accordion id to active selector, otherwise the first panel in nested accordion will always be returned active (since it's already in an active panel in the parent accordion)

Fixes #2285

