### PR TITLE
[Container] Fix simple layout mode

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractListItemImpl.java
@@ -24,8 +24,10 @@ import com.adobe.cq.wcm.core.components.util.ComponentUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.day.cq.wcm.api.components.Component;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.Optional;
 
@@ -90,4 +92,9 @@ public abstract class AbstractListItemImpl extends AbstractComponentImpl impleme
             .build();
     }
 
+    @Override
+    @JsonIgnore
+    public @Nullable Resource getResource() {
+        return resource;
+    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ListItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ListItem.java
@@ -100,6 +100,17 @@ public interface ListItem extends Component {
     }
 
     /**
+     * Returns the resource of this {@code ListItem}.
+     *
+     * @return the list item {@link Resource} or {@code null}
+     * @since com.adobe.cq.wcm.core.components.models 12.27.0
+     */
+    @Nullable
+    default Resource getResource() {
+        return null;
+    }
+
+    /**
      * Returns the name of this {@code ListItem}.
      *
      * @return the list item name or {@code null}

--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/simple.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/simple.html
@@ -25,7 +25,7 @@
              data-sly-use.allowedTemplate="allowedcomponents.html"
              data-sly-call="${allowedTemplate.allowedcomponents @ title=allowed.title, components=allowed.components}"></sly>
         <sly data-sly-test="${!isAllowedApplicable}"
-             data-sly-repeat="${container.items}" data-sly-resource="${item.path @ decoration=true}"></sly>
+             data-sly-repeat="${container.items}" data-sly-resource="${item.resource @ decoration=true}"></sly>
         <sly data-sly-test="${!isAllowedApplicable && !wcmmode.disabled}"
              data-sly-resource="${resource.path @ resourceType='core/wcm/components/container/v1/container/new', appendPath='/*', decorationTagName='div', cssClassName='new section'}" />
     </div>

--- a/testing/it/http/pom.xml
+++ b/testing/it/http/pom.xml
@@ -268,19 +268,24 @@
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>aem-cloud-testing-clients</artifactId>
-            <version>0.6.1</version>
+            <version>1.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.clients</artifactId>
-            <version>2.0.8</version>
+            <version>3.0.18</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.13</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.1-jre</version>
         </dependency>
     </dependencies>
 </project>

--- a/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/ContainerIT.java
+++ b/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/ContainerIT.java
@@ -16,9 +16,19 @@
 package com.adobe.cq.wcm.core.components.it.http;
 
 
-import com.adobe.cq.testing.client.CQClient;
-import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
-import com.adobe.cq.testing.junit.rules.CQRule;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.testing.clients.ClientException;
 import org.jsoup.Jsoup;
@@ -30,14 +40,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import com.adobe.cq.testing.client.CQClient;
+import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
+import com.adobe.cq.testing.junit.rules.CQRule;
 
 public class ContainerIT {
 
@@ -72,6 +77,14 @@ public class ContainerIT {
     public void testSimplePage() throws ClientException, IOException {
         Tree expected = Tree.read(getClass().getClassLoader().getResourceAsStream("simple-page.txt"));
         String content = adminAuthor.doGet("/content/core-components/simple-page.html", 200).getContent();
+        Elements html = Jsoup.parse(content).select("html");
+        assertStructure(expected, html);
+    }
+
+    @Test
+    public void testStructureLayoutContainerPage() throws ClientException, IOException {
+        Tree expected = Tree.read(getClass().getClassLoader().getResourceAsStream("structure-layout-page.txt"));
+        String content = adminAuthor.doGet("/content/core-components/simple-page/structure-layout-page.html",200).getContent();
         Elements html = Jsoup.parse(content).select("html");
         assertStructure(expected, html);
     }

--- a/testing/it/http/src/test/resources/structure-layout-page.txt
+++ b/testing/it/http/src/test/resources/structure-layout-page.txt
@@ -1,0 +1,11 @@
+html
+    head
+    body.page
+    	div.root
+    		div.cmp-container
+    			div.container
+    				div.cmp-container
+    					div.container
+    						div.cmp-container
+    							div.button
+    								button.cmp-button

--- a/testing/it/it.ui.apps/src/content/jcr_root/apps/core-component/components/container-v1/.content.xml
+++ b/testing/it/it.ui.apps/src/content/jcr_root/apps/core-component/components/container-v1/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2021 Adobe
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,12 +14,9 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
-    jcr:mixinTypes="[rep:AccessControllable]"
-    jcr:primaryType="cq:Page">
-    <core-components/>
-    <responsive-template/>
-    <simple-template/>
-    <simple-template-v3/>
-    <structure-layout-template/>
-</jcr:root>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+        cq:isContainer="{Boolean}true"
+        jcr:primaryType="cq:Component"
+        jcr:title="Container V1"
+        sling:resourceSuperType="core/wcm/components/container/v1/container"
+        componentGroup=".test"/>

--- a/testing/it/it.ui.content/src/content/jcr_root/conf/core-components/settings/wcm/policies/.content.xml
+++ b/testing/it/it.ui.content/src/content/jcr_root/conf/core-components/settings/wcm/policies/.content.xml
@@ -1,19 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2021 Adobe
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
     jcr:mixinTypes="[rep:AccessControllable]"
     jcr:primaryType="cq:Page">
@@ -159,12 +144,12 @@
                     <v1 jcr:primaryType="nt:unstructured">
                         <container jcr:primaryType="nt:unstructured">
                             <policy_1606467713472
-                                jcr:lastModified="{Date}2020-11-27T17:56:03.826+02:00"
+                                jcr:lastModified="{Date}2022-12-19T21:26:57.981+01:00"
                                 jcr:lastModifiedBy="admin"
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Root container"
                                 sling:resourceType="wcm/core/components/policy/policy"
-                                components="group:Core Content"
+                                components="group:.test"
                                 layoutDisabled="false">
                                 <jcr:content jcr:primaryType="nt:unstructured"/>
                             </policy_1606467713472>

--- a/testing/it/it.ui.content/src/content/jcr_root/conf/core-components/settings/wcm/templates/structure-layout-template/.content.xml
+++ b/testing/it/it.ui.content/src/content/jcr_root/conf/core-components/settings/wcm/templates/structure-layout-template/.content.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Template">
+    <jcr:content
+        cq:lastModified="{Date}2022-12-19T21:29:24.393+01:00"
+        cq:lastModifiedBy="admin"
+        cq:templateType="/conf/core-components/settings/wcm/template-types/test-page-v3"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="Structure Layout Template"
+        status="enabled"/>
+</jcr:root>

--- a/testing/it/it.ui.content/src/content/jcr_root/conf/core-components/settings/wcm/templates/structure-layout-template/initial/.content.xml
+++ b/testing/it/it.ui.content/src/content/jcr_root/conf/core-components/settings/wcm/templates/structure-layout-template/initial/.content.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:template="/conf/core-components/settings/wcm/templates/structure-layout-template"
+        jcr:primaryType="cq:PageContent"
+        sling:resourceType="core/wcm/components/page/v3/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="core/wcm/components/container/v1/container">
+            <container_v1
+                jcr:created="{Date}2022-12-19T21:29:09.526+01:00"
+                jcr:createdBy="admin"
+                jcr:lastModified="{Date}2022-12-19T21:29:09.526+01:00"
+                jcr:lastModifiedBy="admin"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="core-component/components/container-v1">
+                <container_v1
+                    jcr:created="{Date}2022-12-19T21:29:17.860+01:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2022-12-19T21:29:17.860+01:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-component/components/container-v1">
+                    <button_v2
+                        jcr:created="{Date}2022-12-19T21:29:24.389+01:00"
+                        jcr:createdBy="admin"
+                        jcr:lastModified="{Date}2022-12-19T21:29:29.608+01:00"
+                        jcr:lastModifiedBy="admin"
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-component/components/button-v2"/>
+                </container_v1>
+            </container_v1>
+        </root>
+    </jcr:content>
+</jcr:root>

--- a/testing/it/it.ui.content/src/content/jcr_root/conf/core-components/settings/wcm/templates/structure-layout-template/policies/.content.xml
+++ b/testing/it/it.ui.content/src/content/jcr_root/conf/core-components/settings/wcm/templates/structure-layout-template/policies/.content.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:lastModified="{Date}2022-12-19T21:26:57.984+01:00"
+        cq:lastModifiedBy="admin"
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="wcm/core/components/policies/mappings">
+        <root
+            cq:policy="core/wcm/components/container/v1/container/policy_1606467713472"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wcm/core/components/policies/mapping"/>
+    </jcr:content>
+</jcr:root>

--- a/testing/it/it.ui.content/src/content/jcr_root/conf/core-components/settings/wcm/templates/structure-layout-template/structure/.content.xml
+++ b/testing/it/it.ui.content/src/content/jcr_root/conf/core-components/settings/wcm/templates/structure-layout-template/structure/.content.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:deviceGroups="[/etc/mobile/groups/responsive]"
+        cq:lastModified="{Date}2022-12-19T21:29:29.621+01:00"
+        cq:lastModifiedBy="admin"
+        cq:template="/conf/core-components/settings/wcm/templates/structure-layout-template"
+        jcr:primaryType="cq:PageContent"
+        sling:resourceType="core/wcm/components/page/v3/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="core/wcm/components/container/v1/container">
+            <container_v1
+                jcr:created="{Date}2022-12-19T21:29:09.526+01:00"
+                jcr:createdBy="admin"
+                jcr:lastModified="{Date}2022-12-19T21:29:09.526+01:00"
+                jcr:lastModifiedBy="admin"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="core-component/components/container-v1">
+                <container_v1
+                    jcr:created="{Date}2022-12-19T21:29:17.860+01:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2022-12-19T21:29:17.860+01:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-component/components/container-v1">
+                    <button_v2
+                        jcr:created="{Date}2022-12-19T21:29:24.389+01:00"
+                        jcr:createdBy="admin"
+                        jcr:lastModified="{Date}2022-12-19T21:29:24.389+01:00"
+                        jcr:lastModifiedBy="admin"
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-component/components/button-v2"
+                        editable="{Boolean}true"/>
+                </container_v1>
+            </container_v1>
+        </root>
+        <cq:responsive jcr:primaryType="nt:unstructured">
+            <breakpoints jcr:primaryType="nt:unstructured">
+                <phone
+                    jcr:primaryType="nt:unstructured"
+                    title="Smaller Screen"
+                    width="{Long}650"/>
+                <tablet
+                    jcr:primaryType="nt:unstructured"
+                    title="Tablet"
+                    width="{Long}1200"/>
+            </breakpoints>
+        </cq:responsive>
+    </jcr:content>
+</jcr:root>

--- a/testing/it/it.ui.content/src/content/jcr_root/content/core-components/simple-page/.content.xml
+++ b/testing/it/it.ui.content/src/content/jcr_root/content/core-components/simple-page/.content.xml
@@ -138,5 +138,6 @@
     </jcr:content>
     <simple-subpage/>
     <simple-page-v3/>
+    <structure-layout-page/>
     <test-page-xf-component/>
 </jcr:root>

--- a/testing/it/it.ui.content/src/content/jcr_root/content/core-components/simple-page/structure-layout-page/.content.xml
+++ b/testing/it/it.ui.content/src/content/jcr_root/content/core-components/simple-page/structure-layout-page/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2021 Adobe
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,12 +14,16 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
-    jcr:mixinTypes="[rep:AccessControllable]"
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
-    <core-components/>
-    <responsive-template/>
-    <simple-template/>
-    <simple-template-v3/>
-    <structure-layout-template/>
+    <jcr:content
+        cq:template="/conf/core-components/settings/wcm/templates/structure-layout-template"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="Structure Layout Page"
+        sling:resourceType="core/wcm/components/page/v3/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="core-component/components/container-v1">
+        </root>
+    </jcr:content>
 </jcr:root>


### PR DESCRIPTION
- Call resource of child items instead of path to render child item with correct resource type
- extend ListItem API with getResource method
- provide http test to validate changes

fixes #2394

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2394 
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | 👎
| Major: Breaking Change?  | 👎
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
