### PR TITLE
URLs with escaped characters are being removed by XSS because of decoding during link building

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
@@ -15,6 +15,8 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.link;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.httpclient.URI;
@@ -39,6 +41,7 @@ import com.adobe.cq.wcm.core.components.services.link.PathProcessor;
 import com.day.cq.commons.Externalizer;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
+import com.google.common.net.UrlEscapers;
 
 @Designate(ocd = DefaultPathProcessor.Config.class)
 @Component(property = Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE,
@@ -131,7 +134,11 @@ public class DefaultPathProcessor implements PathProcessor {
         }
 
         if (fragmentQuery != null) {
-            path = path + fragmentQuery;
+            Map<String, String> placeholders = new LinkedHashMap<>();
+            String maskedFragmentQuery = LinkUtil.mask(fragmentQuery, placeholders);
+            String escapedFragmentQuery = UrlEscapers.urlFragmentEscaper().escape(maskedFragmentQuery);
+            String unmaskedFragmentQuery = LinkUtil.unmask(escapedFragmentQuery, placeholders);
+            path = path + unmaskedFragmentQuery;
         }
         return path;
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
@@ -15,8 +15,6 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.link;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.httpclient.URI;
@@ -41,7 +39,6 @@ import com.adobe.cq.wcm.core.components.services.link.PathProcessor;
 import com.day.cq.commons.Externalizer;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
-import com.google.common.net.UrlEscapers;
 
 @Designate(ocd = DefaultPathProcessor.Config.class)
 @Component(property = Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE,
@@ -109,18 +106,29 @@ public class DefaultPathProcessor implements PathProcessor {
         if (vanityConfig == VanityConfig.ALWAYS) {
             path = getPathOrVanityUrl(path, request.getResourceResolver());
         }
-        int fragmentQueryMark = path.indexOf('#');
-        if (fragmentQueryMark < 0) {
-            fragmentQueryMark = path.indexOf('?');
+        int queryStringMark = path.indexOf('?');
+        int fragmentMark = path.indexOf('#');
+        final String queryString;
+        final String fragment;
+        if (queryStringMark >= 0 || fragmentMark >= 0) {
+            if (queryStringMark >= 0) {
+                if (fragmentMark >= 0) {
+                    queryString = path.substring(queryStringMark + 1, fragmentMark);
+                    fragment = path.substring(fragmentMark + 1);
+                } else {
+                    queryString = path.substring(queryStringMark + 1);
+                    fragment = null;
+                }
+            } else {
+                queryString = null;
+                fragment = path.substring(fragmentMark + 1);
+            }
+            path = path.substring(0, queryStringMark >= 0 ? queryStringMark : fragmentMark);
+        } else {
+            queryString = null;
+            fragment = null;
         }
 
-        final String fragmentQuery;
-        if (fragmentQueryMark >= 0) {
-            fragmentQuery = path.substring(fragmentQueryMark);
-            path = path.substring(0, fragmentQueryMark);
-        } else {
-            fragmentQuery = null;
-        }
         String cp = request.getContextPath();
         if (!StringUtils.isEmpty(cp) && path.startsWith("/") && !path.startsWith(cp + "/")) {
             path = cp + path;
@@ -133,12 +141,12 @@ public class DefaultPathProcessor implements PathProcessor {
             LOG.error(e.getMessage());
         }
 
-        if (fragmentQuery != null) {
-            Map<String, String> placeholders = new LinkedHashMap<>();
-            String maskedFragmentQuery = LinkUtil.mask(fragmentQuery, placeholders);
-            String escapedFragmentQuery = UrlEscapers.urlFragmentEscaper().escape(maskedFragmentQuery);
-            String unmaskedFragmentQuery = LinkUtil.unmask(escapedFragmentQuery, placeholders);
-            path = path + unmaskedFragmentQuery;
+        if (queryString != null) {
+            path += "?" + LinkUtil.escape(queryString);
+        }
+
+        if (fragment != null) {
+            path += "#" + LinkUtil.escape(fragment);
         }
         return path;
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
@@ -17,7 +17,6 @@ package com.adobe.cq.wcm.core.components.internal.link;
 
 import java.util.Optional;
 
-import org.apache.commons.httpclient.URI;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -134,20 +133,7 @@ public class DefaultPathProcessor implements PathProcessor {
             path = cp + path;
         }
 
-        try {
-            final URI uri = new URI(path, false);
-            path = uri.toString();
-        } catch (Exception e) {
-            LOG.error(e.getMessage());
-        }
-
-        if (queryString != null) {
-            path += "?" + LinkUtil.escape(queryString);
-        }
-
-        if (fragment != null) {
-            path += "#" + LinkUtil.escape(fragment);
-        }
+        path = LinkUtil.escape(path, queryString, fragment);
         return path;
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkBuilderImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkBuilderImpl.java
@@ -15,10 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.link;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -155,12 +152,7 @@ public class LinkBuilderImpl implements LinkBuilder {
     private @NotNull Link buildLink(String path, SlingHttpServletRequest request, Map<String, String> htmlAttributes) {
         if (StringUtils.isNotEmpty(path)) {
             try {
-                // The link contain character sequences that are not well formatted and cannot be decoded, for example
-                // Adobe Campaign expressions like: /content/path/to/page.html?recipient=<%= recipient.id %>
-                Map<String, String> placeholders = new LinkedHashMap<>();
-                String maskedPath = LinkUtil.mask(path, placeholders);
-                maskedPath = URLDecoder.decode(maskedPath, StandardCharsets.UTF_8.name());
-                path = LinkUtil.unmask(maskedPath, placeholders);
+                path = LinkUtil.decode(path);
             } catch (Exception ex) {
                 String message = "Failed to decode url '{}': {}";
                 if (LOGGER.isDebugEnabled()) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkBuilderImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkBuilderImpl.java
@@ -15,19 +15,13 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.link;
 
-import java.io.UnsupportedEncodingException;
-import java.math.BigInteger;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -47,20 +41,19 @@ import com.day.cq.dam.api.Asset;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 
-import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_URL;
 import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_ACCESSIBILITY_LABEL;
 import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_TARGET;
 import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_TITLE_ATTRIBUTE;
+import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_URL;
 import static com.adobe.cq.wcm.core.components.internal.Utils.resolveRedirects;
-import static com.adobe.cq.wcm.core.components.internal.link.LinkManagerImpl.VALID_LINK_TARGETS;
 import static com.adobe.cq.wcm.core.components.internal.link.LinkImpl.ATTR_ARIA_LABEL;
 import static com.adobe.cq.wcm.core.components.internal.link.LinkImpl.ATTR_TARGET;
 import static com.adobe.cq.wcm.core.components.internal.link.LinkImpl.ATTR_TITLE;
+import static com.adobe.cq.wcm.core.components.internal.link.LinkManagerImpl.VALID_LINK_TARGETS;
 
 public class LinkBuilderImpl implements LinkBuilder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LinkBuilderImpl.class);
-    private final static List<Pattern> PATTERNS = Collections.singletonList(Pattern.compile("(<%[=@].*?%>)"));
     public static final String HTML_EXTENSION = ".html";
 
     SlingHttpServletRequest request;
@@ -165,9 +158,9 @@ public class LinkBuilderImpl implements LinkBuilder {
                 // The link contain character sequences that are not well formatted and cannot be decoded, for example
                 // Adobe Campaign expressions like: /content/path/to/page.html?recipient=<%= recipient.id %>
                 Map<String, String> placeholders = new LinkedHashMap<>();
-                String maskedPath = mask(path, placeholders);
+                String maskedPath = LinkUtil.mask(path, placeholders);
                 maskedPath = URLDecoder.decode(maskedPath, StandardCharsets.UTF_8.name());
-                path = unmask(maskedPath, placeholders);
+                path = LinkUtil.unmask(maskedPath, placeholders);
             } catch (Exception ex) {
                 String message = "Failed to decode url '{}': {}";
                 if (LOGGER.isDebugEnabled()) {
@@ -308,74 +301,6 @@ public class LinkBuilderImpl implements LinkBuilder {
         }
         Page resolved = Optional.ofNullable(pair.getLeft()).orElse(page);
         return new ImmutablePair<>(resolved, getPageLinkURL(resolved));
-    }
-
-    /**
-     * Masks a given {@link String} by replacing all occurrences of {@link LinkBuilderImpl#PATTERNS} with a placeholder.
-     * The generated placeholders are put into the given {@link Map} and can be used to unmask a {@link String} later on.
-     * <p>
-     * For example the given original {@link String} {@code /path/to/page.html?r=<%= recipient.id %>} will be transformed to
-     * {@code /path/to/page.html?r=_abcd_} and the placeholder with the expression will be put into the given {@link Map}.
-     *
-     * @param original     the original {@link String}
-     * @param placeholders a {@link Map} the generated placeholders will be put in
-     * @return the masked {@link String}
-     * @see LinkBuilderImpl#unmask(String, Map)
-     */
-    private static String mask(String original, Map<String, String> placeholders) {
-        String masked = original;
-        for (Pattern pattern : PATTERNS) {
-            Matcher matcher = pattern.matcher(masked);
-            while (matcher.find()) {
-                String expression = matcher.group(1);
-                String placeholder = newPlaceholder(masked);
-                masked = masked.replaceFirst(Pattern.quote(expression), placeholder);
-                placeholders.put(placeholder, expression);
-            }
-        }
-        return masked;
-    }
-
-    /**
-     * Unmasks the given {@link String} by replacing the given placeholders with their original value.
-     * <p>
-     * For example the given masked {@link String} {@code /path/to/page.html?r=_abcd_} will be transformed to
-     * {@code /path/to/page.html?r=<%= recipient.id %>} by replacing each of the given {@link Map}s keys with the corresponding value.
-     *
-     * @param masked       the masked {@link String}
-     * @param placeholders the {@link Map} of placeholders to replace
-     * @return the unmasked {@link String}
-     */
-    private static String unmask(String masked, Map<String, String> placeholders) {
-        String unmasked = masked;
-        for (Map.Entry<String, String> placeholder : placeholders.entrySet()) {
-            unmasked = unmasked.replaceFirst(placeholder.getKey(), placeholder.getValue());
-        }
-        return unmasked;
-    }
-
-    /**
-     * Generate a new random placeholder that is not conflicting with any character sequence in the given {@link String}.
-     * <p>
-     * For example the given {@link String} {@code "foo"} a new random {@link String} will be returned that is not contained in the
-     * given {@link String}. In this example the following {@link String}s will never be returned "f", "fo", "foo", "o", "oo".
-     *
-     * @param str the given {@link String}
-     * @return the placeholder name
-     */
-    private static String newPlaceholder(String str) {
-        SecureRandom random = new SecureRandom();
-        StringBuilder placeholderBuilder = new StringBuilder(5);
-
-        do {
-            placeholderBuilder.setLength(0);
-            placeholderBuilder
-                .append("_")
-                .append(new BigInteger(16, random).toString(16))
-                .append("_");
-        } while (str.contains(placeholderBuilder));
-
-        return placeholderBuilder.toString();
     }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtil.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtil.java
@@ -1,0 +1,97 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2023 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.link;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class LinkUtil {
+
+    private final static List<Pattern> PATTERNS = Collections.singletonList(Pattern.compile("(<%[=@].*?%>)"));
+
+    /**
+     * Masks a given {@link String} by replacing all occurrences of {@link LinkUtil#PATTERNS} with a placeholder.
+     * The generated placeholders are put into the given {@link Map} and can be used to unmask a {@link String} later on.
+     * <p>
+     * For example the given original {@link String} {@code /path/to/page.html?r=<%= recipient.id %>} will be transformed to
+     * {@code /path/to/page.html?r=_abcd_} and the placeholder with the expression will be put into the given {@link Map}.
+     *
+     * @param original     the original {@link String}
+     * @param placeholders a {@link Map} the generated placeholders will be put in
+     * @return the masked {@link String}
+     * @see LinkUtil#unmask(String, Map)
+     */
+    public static String mask(String original, Map<String, String> placeholders) {
+        String masked = original;
+        for (Pattern pattern : PATTERNS) {
+            Matcher matcher = pattern.matcher(masked);
+            while (matcher.find()) {
+                String expression = matcher.group(1);
+                String placeholder = newPlaceholder(masked);
+                masked = masked.replaceFirst(Pattern.quote(expression), placeholder);
+                placeholders.put(placeholder, expression);
+            }
+        }
+        return masked;
+    }
+
+    /**
+     * Unmasks the given {@link String} by replacing the given placeholders with their original value.
+     * <p>
+     * For example the given masked {@link String} {@code /path/to/page.html?r=_abcd_} will be transformed to
+     * {@code /path/to/page.html?r=<%= recipient.id %>} by replacing each of the given {@link Map}s keys with the corresponding value.
+     *
+     * @param masked       the masked {@link String}
+     * @param placeholders the {@link Map} of placeholders to replace
+     * @return the unmasked {@link String}
+     */
+    public static String unmask(String masked, Map<String, String> placeholders) {
+        String unmasked = masked;
+        for (Map.Entry<String, String> placeholder : placeholders.entrySet()) {
+            unmasked = unmasked.replaceFirst(placeholder.getKey(), placeholder.getValue());
+        }
+        return unmasked;
+    }
+
+    /**
+     * Generate a new random placeholder that is not conflicting with any character sequence in the given {@link String}.
+     * <p>
+     * For example the given {@link String} {@code "foo"} a new random {@link String} will be returned that is not contained in the
+     * given {@link String}. In this example the following {@link String}s will never be returned "f", "fo", "foo", "o", "oo".
+     *
+     * @param str the given {@link String}
+     * @return the placeholder name
+     */
+    private static String newPlaceholder(String str) {
+        SecureRandom random = new SecureRandom();
+        StringBuilder placeholderBuilder = new StringBuilder(5);
+
+        do {
+            placeholderBuilder.setLength(0);
+            placeholderBuilder
+                    .append("_")
+                    .append(new BigInteger(16, random).toString(16))
+                    .append("_");
+        } while (str.contains(placeholderBuilder));
+
+        return placeholderBuilder.toString();
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessorTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessorTest.java
@@ -79,6 +79,15 @@ class DefaultPathProcessorTest {
     }
 
     @Test
+    void testSanitizeExternalLink() {
+        DefaultPathProcessor underTest = context.registerService(new DefaultPathProcessor());
+        MockSlingHttpServletRequest request = context.request();
+        assertEquals("https://test.com?categ=cat1%7Ccat2", underTest.sanitize("https://test.com?categ=cat1|cat2", request));
+        assertEquals("https://test.com?categ=cat1%7Ccat2#top", underTest.sanitize("https://test.com?categ=cat1|cat2#top", request));
+        assertEquals("https://test.com?categ=cat1%7Ccat2#top%20level", underTest.sanitize("https://test.com?categ=cat1|cat2#top level", request));
+    }
+
+    @Test
     void testVanityUrl() {
         Page page = context.create().page("/content/links/site1/en", "/conf/example",
                 ImmutableMap.of("sling:vanityPath", "vanity.html"));

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessorTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessorTest.java
@@ -76,15 +76,22 @@ class DefaultPathProcessorTest {
         assertEquals(path, underTest.sanitize(path, request));
         path = "/some space#internal";
         assertEquals("/some%20space#internal", underTest.sanitize(path, request));
+        assertEquals("/content/path/to/page.html?recipient=<%= recipient.id %>",
+                underTest.sanitize("/content/path/to/page.html?recipient=<%= recipient.id %>", request));
     }
 
     @Test
     void testSanitizeExternalLink() {
         DefaultPathProcessor underTest = context.registerService(new DefaultPathProcessor());
         MockSlingHttpServletRequest request = context.request();
-        assertEquals("https://test.com?categ=cat1%7Ccat2", underTest.sanitize("https://test.com?categ=cat1|cat2", request));
-        assertEquals("https://test.com?categ=cat1%7Ccat2#top", underTest.sanitize("https://test.com?categ=cat1|cat2#top", request));
-        assertEquals("https://test.com?categ=cat1%7Ccat2#top%20level", underTest.sanitize("https://test.com?categ=cat1|cat2#top level", request));
+        assertEquals("https://test.com?categ=cat1%7Ccat2",
+                underTest.sanitize("https://test.com?categ=cat1|cat2", request));
+        assertEquals("https://test.com?categ=cat1%7Ccat2#top",
+                underTest.sanitize("https://test.com?categ=cat1|cat2#top", request));
+        assertEquals("https://test.com?categ=cat1%7Ccat2#top%20level",
+                underTest.sanitize("https://test.com?categ=cat1|cat2#top level", request));
+        assertEquals("https://test.com?recipient=<%= recipient.id %>",
+                underTest.sanitize("https://test.com?recipient=<%= recipient.id %>", request));
     }
 
     @Test


### PR DESCRIPTION
* Added escaping during link sanitization
* Preserves Adobe Campaign expressions

