### PR TITLE
SITES-12966: restore backwards compatibility of container/simple.html

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ResourceListItemImpl.java
@@ -76,6 +76,13 @@ public class ResourceListItemImpl extends AbstractListItemImpl implements ListIt
         link = linkManager.get(resource).build();
     }
 
+    @NotNull
+    @JsonIgnore
+    @Deprecated
+    public Resource getResource() {
+        return resource;
+    }
+
     @Override
     @NotNull
     @JsonIgnore

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImplTest.java
@@ -32,7 +32,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 public class LayoutContainerImplTest {
@@ -63,6 +65,7 @@ public class LayoutContainerImplTest {
             put(LayoutContainer.PN_LAYOUT, "simple");
         }});
         LayoutContainer container = getContainerUnderTest(CONTAINER_1);
+        Resource containerResource = context.resourceResolver().getResource(CONTAINER_1);
 
         assertEquals(
             "background-image:url(/content/dam/core-components-examples/library/sample-assets/mountain-range.jpg);background-size:cover;background-repeat:no-repeat;background-color:#000000;",
@@ -75,7 +78,7 @@ public class LayoutContainerImplTest {
                 {"item_1", "Teaser 1"},
                 {"item_2", "Teaser 2"}
         };
-        verifyContainerItems(expectedItems, container.getItems());
+        verifyContainerItems(containerResource, expectedItems, container.getItems());
         assertEquals("core/wcm/components/container/v1/container", container.getExportedType(), "Exported type mismatch");
         Utils.testJSONExport(container, Utils.getTestExporterJSONPath(TEST_BASE, "container1"));
     }
@@ -120,11 +123,16 @@ public class LayoutContainerImplTest {
         assertEquals("background-image:url(/content/dam/core-components-examples/library/sample-assets/mountain%20range.jpg);background-size:cover;background-repeat:no-repeat;background-color:#000000;", container.getBackgroundStyle(), "Style mismatch");
     }
 
-    private void verifyContainerItems(Object[][] expectedItems, List<ListItem> items) {
+    private void verifyContainerItems(Resource containerResource, Object[][] expectedItems, List<ListItem> items) {
         assertEquals(expectedItems.length, items.size(), "Item number mismatch");
+        String containerPath = containerResource.getPath();
         int index = 0;
         for (ListItem item : items) {
-            assertEquals(expectedItems[index][1], item.getTitle(), "Item title mismatch");
+            assertTrue(item instanceof ResourceListItemImpl);
+            ResourceListItemImpl resourceListItem = (ResourceListItemImpl) item;
+            assertNotNull(resourceListItem.getResource());
+            assertEquals(containerPath + "/" + expectedItems[index][0], resourceListItem.getResource().getPath());
+            assertEquals(expectedItems[index][1], resourceListItem.getTitle(), "Item title mismatch");
             index++;
         }
     }

--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/simple.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/simple.html
@@ -26,7 +26,7 @@
              data-sly-call="${allowedTemplate.allowedcomponents @ title=allowed.title, components=allowed.components}"></sly>
         <sly data-sly-test="${!isAllowedApplicable}"
              data-sly-set.items="${container.children || container.items}"
-             data-sly-repeat="${items}" data-sly-resource="${item.resource @ decoration=true}"></sly>
+             data-sly-repeat="${items}" data-sly-resource="${item.resource || item.path @ decoration=true}"></sly>
         <sly data-sly-test="${!isAllowedApplicable && !wcmmode.disabled}"
              data-sly-resource="${resource.path @ resourceType='core/wcm/components/container/v1/container/new', appendPath='/*', decorationTagName='div', cssClassName='new section'}" />
     </div>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 👍 
| Minor: New Feature?      | no
| Major: Breaking Change?  | no
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

With #2416 and #2409 we implemented a new way to include container children. This change was breaking for custom LayoutContainer implementations that do not (a) implement the new `getChildren()` method and (b) return items that do not have a `resource` field. 

With this change we added the necessary fallbacks:

a) add a `getResource()` (internal but public API) for the deprecated ListItem implementation of the LayoutContainerImpl to preserve the fix for #2409 for custom LayoutContainer implementations that do not implement `getChildren()`
b) add a fallback to item.path for the simple container layout for custom LayoutContainer implementations that return a custom item implementation
