### PR TITLE
resolves #2391 - Add the option to use i18n labels for content fragment element titles

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImpl.java
@@ -24,10 +24,13 @@ import java.util.Optional;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
+import com.adobe.cq.wcm.core.components.models.contentfragment.ContentFragmentList;
+import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
@@ -105,6 +108,10 @@ public class ContentFragmentImpl extends AbstractComponentImpl implements Conten
     @ValueMapValue(name = ContentFragment.PN_DISPLAY_MODE, injectionStrategy = InjectionStrategy.OPTIONAL)
     @Nullable
     private String displayMode;
+
+    @ValueMapValue(name = ContentFragment.PN_USE_I18N_FOR_ELEMENT_TITLE, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Default(booleanValues = false)
+    private Boolean useI18nForElementTitle;
 
     private DAMContentFragment damContentFragment = new EmptyContentFragment();
 
@@ -241,6 +248,11 @@ public class ContentFragmentImpl extends AbstractComponentImpl implements Conten
                 return elementsData.toArray(new ContentFragmentData.ElementData[0]);
             })
             .build();
+    }
+
+    @Override
+    public boolean useI18nForElementTitle() {
+        return BooleanUtils.isTrue(useI18nForElementTitle);
     }
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentListImpl.java
@@ -21,6 +21,7 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.jcr.Session;
 
+import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -109,6 +110,10 @@ public class ContentFragmentListImpl extends AbstractComponentImpl implements Co
     @ValueMapValue(name = ContentFragmentList.PN_SORT_ORDER, injectionStrategy = InjectionStrategy.OPTIONAL)
     @Default(values = Predicate.SORT_ASCENDING)
     private String sortOrder;
+
+    @ValueMapValue(name = ContentFragmentList.PN_USE_I18N_FOR_ELEMENT_TITLE, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Default(booleanValues = false)
+    private Boolean useI18nForElementTitle;
 
     private final List<DAMContentFragment> items = new ArrayList<>();
 
@@ -208,5 +213,10 @@ public class ContentFragmentListImpl extends AbstractComponentImpl implements Co
     @Override
     public String getExportedType() {
         return slingHttpServletRequest.getResource().getResourceType();
+    }
+
+    @Override
+    public boolean useI18nForElementTitle() {
+        return BooleanUtils.isTrue(useI18nForElementTitle);
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/ContentFragment.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/ContentFragment.java
@@ -64,6 +64,13 @@ public interface ContentFragment extends DAMContentFragment, ContainerExporter, 
     String PN_DISPLAY_MODE = "displayMode";
 
     /**
+     * Name of the optional resource property that gives the option to translate the element titles with i18n
+     *
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.6.0
+     */
+    String PN_USE_I18N_FOR_ELEMENT_TITLE = "useI18nForElementTitle";
+
+    /**
      * Returns resource type that is used for the internal responsive grid.
      *
      * @return resource type
@@ -118,4 +125,15 @@ public interface ContentFragment extends DAMContentFragment, ContainerExporter, 
     default String[] getParagraphs() {
         return null;
     }
+
+    /**
+     * Use i18n to translate the content fragment title
+     *
+     * @return true if i18n can be used to translate the content fragment title
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.6.0
+     */
+    default boolean useI18nForElementTitle() {
+        return false;
+    }
+
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/ContentFragmentList.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/ContentFragmentList.java
@@ -90,6 +90,13 @@ public interface ContentFragmentList  extends Component {
     String PN_SORT_ORDER = "sortOrder";
 
     /**
+     * Name of the optional resource property that gives the option to translate the element titles with i18n
+     *
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.6.0
+     */
+    String PN_USE_I18N_FOR_ELEMENT_TITLE = "useI18nForElementTitle";
+
+    /**
      * Returns a list of {@link DAMContentFragment content fragments}.
      *
      * @return the list of content fragments
@@ -110,5 +117,15 @@ public interface ContentFragmentList  extends Component {
     @Override
     default String getExportedType() {
         return "";
+    }
+
+    /**
+     * Use i18n to translate the content fragment title
+     *
+     * @return true if i18n can be used to translate the content fragment title
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.6.0
+     */
+    default boolean useI18nForElementTitle() {
+        return false;
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/package-info.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("1.5.1")
+@Version("1.6.0")
 package com.adobe.cq.wcm.core.components.models.contentfragment;
 
 import org.osgi.annotation.versioning.Version;

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/_cq_dialog/.content.xml
@@ -134,6 +134,12 @@
                                             jcr:primaryType="nt:unstructured"
                                             field-path="${requestPathInfo.resourcePath}"/>
                                     </variationName>
+                                    <useI18nForElementTitle
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                        text="Use i18n labels to translate the content fragment element titles"
+                                        name="./useI18nForElementTitle"
+                                        value="true"/>
                                     <id
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/contentfragment.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/contentfragment.html
@@ -15,7 +15,7 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <sly data-sly-use.fragment="com.adobe.cq.wcm.core.components.models.contentfragment.ContentFragment"
      data-sly-test="${properties.fragmentPath}" data-sly-use.cfTemplates="templates.html">
-    <sly data-sly-call="${cfTemplates.contentFragment @ fragment=fragment, fragmentPath=properties.fragmentPath, wcmmode=wcmmode}"></sly>
+    <sly data-sly-call="${cfTemplates.contentFragment @ fragment=fragment, fragmentPath=properties.fragmentPath, wcmmode=wcmmode, useI18nForElementTitle = fragment.useI18nForElementTitle}"></sly>
 </sly>
 
 <sly data-sly-use.template="core/wcm/components/commons/v1/templates.html"

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/element.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/element.html
@@ -13,9 +13,10 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<template data-sly-template.element="${@ element='The content fragment element'}">
+<template data-sly-template.element="${@ element='The content fragment element',  useI18nForElementTitle='Use i18n to translate the element titles'}">
     <div class="cmp-contentfragment__element cmp-contentfragment__element--${element.name}" data-cmp-contentfragment-element-type="${element.dataType}">
-        <dt class="cmp-contentfragment__element-title">${element.title}</dt>
+        <dt class="cmp-contentfragment__element-title" data-sly-test="${!useI18nForElementTitle}">${element.title}</dt>
+        <dt class="cmp-contentfragment__element-title" data-sly-test="${useI18nForElementTitle}">${element.title @ i18n}</dt>
         <dd class="cmp-contentfragment__element-value">
             <sly data-sly-test="${element.dataType == 'calendar'}" data-sly-use.tpl="core/wcm/components/contentfragment/v1/contentfragment/calendar.html"
                  data-sly-call="${tpl.element @ date = element.value}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/templates.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/templates.html
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 
-<template data-sly-template.contentFragment="${@ fragment='The content fragment', fragmentPath='', wcmmode='WCM mode'}">
+<template data-sly-template.contentFragment="${@ fragment='The content fragment', fragmentPath='', wcmmode='WCM mode', useI18nForElementTitle='Use i18n to translate the element titles'}">
     <article id="${fragment.id}"
              class="cmp-contentfragment cmp-contentfragment--${fragment.name}"
              data-cmp-contentfragment-model="${fragment.type}"
@@ -30,7 +30,7 @@
             <sly data-sly-call="${paragraphs @ fragment=fragment}"></sly>
         </sly>
         <sly data-sly-test="${!isParagraphMode}">
-            <sly data-sly-call="${elements @ fragment=fragment, wcmmode=wcmmode}"></sly>
+            <sly data-sly-call="${elements @ fragment=fragment, wcmmode=wcmmode, useI18nForElementTitle=useI18nForElementTitle}"></sly>
         </sly>
     </article>
 </template>
@@ -46,10 +46,10 @@
     </div>
 </template>
 
-<template data-sly-template.elements="${@ fragment='The content fragment', wcmmode='WCM mode'}">
+<template data-sly-template.elements="${@ fragment='The content fragment', wcmmode='WCM mode', useI18nForElementTitle='Use i18n to translate the element title'}">
     <dl class="cmp-contentfragment__elements${!wcmmode.disabled ? ' cq-dd-contentfragment' : ''}"
         data-sly-list.element="${fragment.elements}"
         data-sly-use.elementTemplate="core/wcm/components/contentfragment/v1/contentfragment/element.html">
-        <sly data-sly-call="${elementTemplate.element @ element=element}"></sly>
+        <sly data-sly-call="${elementTemplate.element @ element=element, useI18nForElementTitle=useI18nForElementTitle}"></sly>
     </dl>
 </template>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v2/contentfragmentlist/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v2/contentfragmentlist/_cq_dialog/.content.xml
@@ -138,6 +138,12 @@
                                             jcr:primaryType="nt:unstructured"
                                             cmp-field-path="${requestPathInfo.resourcePath}"/>
                                     </elementNames>
+                                    <useI18nForElementTitle
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                        text="Use i18n labels to translate the content fragment element titles"
+                                        name="./useI18nForElementTitle"
+                                        value="true"/>
                                 </items>
                             </column>
                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v2/contentfragmentlist/contentfragmentlist.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v2/contentfragmentlist/contentfragmentlist.html
@@ -18,7 +18,7 @@
     <section data-sly-list.fragment="${list.listItems}"
              id="${list.id}"
              class="cmp-contentfragmentlist">
-        <sly data-sly-call="${fragmentTemplate.contentFragment @ fragment=fragment, wcmmode=wcmmode}"></sly>
+        <sly data-sly-call="${fragmentTemplate.contentFragment @ fragment=fragment, wcmmode=wcmmode, useI18nForElementTitle=list.useI18nForElementTitle}"></sly>
     </section>
 </sly>
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #1, Fixes #2391
| Patch: Bug Fix?          | 
| Minor: New Feature?      | Yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | Not applicable? no UI tests in AEM core components
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

Add the option to use i18n labels for content fragment element titles, which are not translateable in any UI of AEM

