### PR TITLE
SITES-13253: fix RecursionTooDeepException in custom container HTL

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ContainerItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ContainerItemImpl.java
@@ -47,4 +47,18 @@ public final class ContainerItemImpl implements ContainerItem {
         return this.resource;
     }
 
+    @Override
+    @NotNull
+    public String getName() {
+        return this.resource.getName();
+    }
+
+    @Override
+    @NotNull
+    public String getPath() {
+        return this.resource.getPath();
+    }
+
+
+
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ContainerItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ContainerItem.java
@@ -53,4 +53,16 @@ public interface ContainerItem {
     default String getName() {
         return "";
     }
+
+    /**
+     * Returns the path of this container item.
+     *
+     * @return the container item path or {@code null}
+     * @since com.adobe.cq.wcm.core.components.models 12.28.0
+     */
+    @Nullable
+    default String getPath() {
+        return null;
+    }
+
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.27.0")
+@Version("12.28.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractContainerImplTest.java
@@ -69,7 +69,8 @@ public class AbstractContainerImplTest {
             {"Teaser 1 description", "item_1", "/content/container/jcr:content/root/responsivegrid/container-1/item_1", "Teaser 1"},
             {"Teaser 2 description", "item_2", "/content/container/jcr:content/root/responsivegrid/container-1/item_2", "Teaser 2"},
         };
-        verifyContainerItems(expectedItems, container.getItems());
+        verifyContainerListItems(expectedItems, container.getItems());
+        verifyContainerContainerItems(expectedItems, container.getChildren());
     }
 
     private Container getContainerUnderTest(String resourcePath) {
@@ -81,7 +82,7 @@ public class AbstractContainerImplTest {
         return context.request().adaptTo(LayoutContainer.class);
     }
 
-    private void verifyContainerItems(Object[][] expectedItems, List<ListItem> items) {
+    private void verifyContainerListItems(Object[][] expectedItems, List<ListItem> items) {
         assertEquals(expectedItems.length, items.size(), "The container has a different number of items than expected.");
         int index = 0;
         for (ListItem item : items) {
@@ -89,6 +90,16 @@ public class AbstractContainerImplTest {
             assertEquals(expectedItems[index][1], item.getName(), "The container item's name is not what was expected: " + item.getName());
             assertEquals(expectedItems[index][2], item.getPath(), "The container item's path is not what was expected: " + item.getPath());
             assertEquals(expectedItems[index][3], item.getTitle(), "The container item's title is not what was expected: " + item.getTitle());
+            index++;
+        }
+    }
+
+    private void verifyContainerContainerItems(Object[][] expectedItems, List<? extends ContainerItem> items) {
+        assertEquals(expectedItems.length, items.size(), "The container has a different number of items than expected.");
+        int index = 0;
+        for (ContainerItem item : items) {
+            assertEquals(expectedItems[index][1], item.getName(), "The container item's name is not what was expected: " + item.getName());
+            assertEquals(expectedItems[index][2], item.getPath(), "The container item's path is not what was expected: " + item.getPath());
             index++;
         }
     }


### PR DESCRIPTION
- add support for getPath to the ContainerItem


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-13253
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | 👎
| Major: Breaking Change?  | 👎
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
