### PR TITLE
SITES-13256: fix StringIndexOutOfBoundsException in DefaultPathProcessor

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java
@@ -112,8 +112,13 @@ public class DefaultPathProcessor implements PathProcessor {
         if (queryStringMark >= 0 || fragmentMark >= 0) {
             if (queryStringMark >= 0) {
                 if (fragmentMark >= 0) {
-                    queryString = path.substring(queryStringMark + 1, fragmentMark);
-                    fragment = path.substring(fragmentMark + 1);
+                    if (queryStringMark < fragmentMark) {
+                        queryString = path.substring(queryStringMark + 1, fragmentMark);
+                        fragment = path.substring(fragmentMark + 1);
+                    } else {
+                        fragment = path.substring(fragmentMark + 1, queryStringMark);
+                        queryString = path.substring(queryStringMark + 1);
+                    }
                 } else {
                     queryString = path.substring(queryStringMark + 1);
                     fragment = null;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtil.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtil.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,6 +70,10 @@ public class LinkUtil {
      * @return The escaped fragment
      */
     public static String escape(final String path, final String queryString, final String fragment) {
+        boolean pathContainsFragment = false;
+        if (StringUtils.contains(path, fragment)) {
+            pathContainsFragment = true;
+        }
         final Map<String, String> placeholders = new LinkedHashMap<>();
         final String maskedQueryString = mask(queryString, placeholders);
         String escaped;
@@ -87,9 +92,16 @@ public class LinkUtil {
             }
             if (fragment != null) {
                 StringBuilder sb = new StringBuilder(escaped);
-                escaped = sb.append("#")
-                        .append(URLEncoder.encode(fragment, StandardCharsets.UTF_8.name()).replace("+", "%20"))
-                        .toString();
+                if (pathContainsFragment) {
+                    if (parsed != null) {
+                        escaped = sb.insert(parsed.toString().length(), "#" + fragment).toString();
+                    } else {
+                        escaped = sb.insert(path.indexOf(fragment), "#" + fragment).toString();
+                    }
+                } else {
+                    escaped = sb.append("#").append(URLEncoder.encode(fragment, StandardCharsets.UTF_8.name())
+                            .replace("+", "%20")).toString();
+                }
             }
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessorTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessorTest.java
@@ -92,6 +92,8 @@ class DefaultPathProcessorTest {
                 underTest.sanitize("https://test.com?categ=cat1|cat2#top level", request));
         assertEquals("https://test.com?recipient=<%= recipient.id %>",
                 underTest.sanitize("https://test.com?recipient=<%= recipient.id %>", request));
+        assertEquals("https://test.com/#/downloads/file.html?name=/content/file.zip",
+                underTest.sanitize("https://test.com/#/downloads/file.html?name=/content/file.zip", request));
     }
 
     @Test


### PR DESCRIPTION
Since the change in #2456 links which contains a fragment before the query parameter like https://test.com/#/downloads/file.html?name=/content/file.zip for example will produce a StringIndexOutOfBoundsException.

This PR add a special handing for such URLs.


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-13256
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | 👎
| Major: Breaking Change?  | 👎
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
