### PR TITLE
Add check if id of tab item is available

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/PanelContainer.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/PanelContainer.js
@@ -104,7 +104,11 @@
             if (that._config.el && that._config.panelContainerType) {
                 var items = $(this._config.el).find(that._config.panelContainerType.itemSelector);
                 items.each(function(index) {
-                    if ($(this).is("#" + that._config.el.id + " " + that._config.panelContainerType.itemActiveSelector)) {
+                    var activeItemSelector = that._config.panelContainerType.itemActiveSelector;
+                    if (that._config.el.id) {
+                        activeItemSelector = "#" + that._config.el.id + " " + activeItemSelector;
+                    }
+                    if ($(this).is(activeItemSelector)) {
                         activeIndex = index;
                         return false;
                     }


### PR DESCRIPTION
Components which got inherit from a panel container but hasn't set the id of a panel container items are currently facing an issue with the change in #2408.

In this PR I added a check if the id is present before using it as part of the selector.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-13592, SITES-13475
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
