### PR TITLE
[Issue #2526] Lazy evaluate navigation sub-items on demand 

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbImpl.java
@@ -41,8 +41,8 @@ import com.day.cq.wcm.api.components.Component;
 import com.day.cq.wcm.api.designer.Style;
 
 @Model(adaptables = SlingHttpServletRequest.class,
-       adapters = {Breadcrumb.class, ComponentExporter.class},
-       resourceType = {BreadcrumbImpl.RESOURCE_TYPE_V1, BreadcrumbImpl.RESOURCE_TYPE_V2})
+    adapters = {Breadcrumb.class, ComponentExporter.class},
+    resourceType = {BreadcrumbImpl.RESOURCE_TYPE_V1, BreadcrumbImpl.RESOURCE_TYPE_V2})
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class BreadcrumbImpl extends AbstractComponentImpl implements Breadcrumb {
 
@@ -61,9 +61,6 @@ public class BreadcrumbImpl extends AbstractComponentImpl implements Breadcrumb 
 
     @ScriptVariable
     private Page currentPage;
-
-    @Self
-    private SlingHttpServletRequest request;
 
     @Self
     protected LinkManager linkManager;
@@ -88,12 +85,6 @@ public class BreadcrumbImpl extends AbstractComponentImpl implements Breadcrumb 
         return Collections.unmodifiableList(items);
     }
 
-    @NotNull
-    @Override
-    public String getExportedType() {
-        return request.getResource().getResourceType();
-    }
-
     private List<NavigationItem> createItems() {
         List<NavigationItem> items = new ArrayList<>();
         int currentLevel = currentPage.getDepth();
@@ -105,8 +96,7 @@ public class BreadcrumbImpl extends AbstractComponentImpl implements Breadcrumb 
                     break;
                 }
                 if (checkIfNotHidden(page)) {
-                    NavigationItem navigationItem = newBreadcrumbItem(page, isActivePage, linkManager, currentLevel,
-                            Collections.emptyList(), getId(), component);
+                    NavigationItem navigationItem = newBreadcrumbItem(page, isActivePage, linkManager, currentLevel, getId(), component);
                     items.add(navigationItem);
                 }
             }
@@ -115,11 +105,37 @@ public class BreadcrumbImpl extends AbstractComponentImpl implements Breadcrumb 
         return items;
     }
 
-    protected NavigationItem newBreadcrumbItem(Page page, boolean active, @NotNull LinkManager linkManager, int level, List<NavigationItem> children, String parentId, Component component) {
-        return new BreadcrumbItemImpl(page, active, linkManager, level, children, parentId, component);
+    /**
+     * Create a Breadcrumb Item.
+     *
+     * @param page        The page for which to create a breadcrumb item.
+     * @param active      Flag indicating if the breadcrumb item is active.
+     * @param linkManager Link manager service.
+     * @param level       Depth level of the navigation item.
+     * @param parentId    ID of the parent navigation component.
+     * @param component   The parent navigation {@link Component}.
+     */
+    protected NavigationItem newBreadcrumbItem(@NotNull final Page page,
+                                               final boolean active,
+                                               @NotNull final LinkManager linkManager,
+                                               final int level,
+                                               final String parentId,
+                                               final Component component) {
+        return new BreadcrumbItemImpl(page, active, linkManager, level, parentId, component);
     }
 
-    private boolean checkIfNotHidden(Page page) {
-        return !page.isHideInNav() || showHidden;
+    /**
+     * Check if a page should be shown in the breadcrumb
+     * A page should be shown if either
+     * <ul>
+     *     <li>`showHidden` is set to true for this component; or,</li>
+     *     <li>The page is not configured to be hidden in navigation</li>
+     * </ul>
+     *
+     * @param page The page to check.
+     * @return True if the page should be shown in the breadcrumb, false if not.
+     */
+    private boolean checkIfNotHidden(@NotNull final Page page) {
+        return this.showHidden || !page.isHideInNav();
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/BreadcrumbItemImpl.java
@@ -16,7 +16,7 @@
 
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
-import java.util.List;
+import java.util.Collections;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -28,12 +28,29 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import static org.apache.sling.api.SlingConstants.PROPERTY_PATH;
 
-@JsonIgnoreProperties(value = {"page", "children", "level", "description", "lastModified",PROPERTY_PATH})
+/**
+ * V1 Breadcrumb Item Implementation.
+ */
+@JsonIgnoreProperties(value = {"page", "children", "level", "description", "lastModified", PROPERTY_PATH})
 public class BreadcrumbItemImpl extends NavigationItemImpl implements NavigationItem {
 
-    public BreadcrumbItemImpl(Page page, boolean active, @NotNull LinkManager linkManager, int level,
-                              List<NavigationItem> children, String parentId, Component component) {
-        super(page, active, active, linkManager, level, children, parentId, component);
+    /**
+     * Construct a Breadcrumb Item.
+     *
+     * @param page        The page for which to create a breadcrumb item.
+     * @param active      Flag indicating if the breadcrumb item is active.
+     * @param linkManager Link manager service.
+     * @param level       Depth level of the navigation item.
+     * @param parentId    ID of the parent navigation component.
+     * @param component   The parent navigation {@link Component}.
+     */
+    public BreadcrumbItemImpl(@NotNull final Page page,
+                              final boolean active,
+                              @NotNull final LinkManager linkManager,
+                              final int level,
+                              final String parentId,
+                              final Component component) {
+        super(page, active, active, linkManager, level, Collections::emptyList, parentId, component);
     }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/LanguageNavigationItemImpl.java
@@ -17,6 +17,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Supplier;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -28,21 +29,61 @@ import com.adobe.cq.wcm.core.components.models.datalayer.builder.DataLayerBuilde
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.components.Component;
 
+/**
+ * V1 Language Navigation Item implementation.
+ */
 public class LanguageNavigationItemImpl extends NavigationItemImpl implements LanguageNavigationItem {
 
-    protected String title;
-    protected Locale locale;
-    protected String country;
-    protected String language;
+    /**
+     * Navigation item title.
+     */
+    private final String title;
 
-    public LanguageNavigationItemImpl(Page page, boolean active, boolean current, @NotNull LinkManager linkManager, int level,
-                                      List<NavigationItem> children, String title, String parentId, Component component) {
-        super(page, active, current, linkManager, level, children, parentId, component);
+    /**
+     * Locale for this language navigation item.
+     */
+    private Locale locale;
+
+    /**
+     * Country for this language navigation item.
+     */
+    private String country;
+
+    /**
+     * Language for this language navigation item.
+     */
+    private String language;
+
+    /**
+     * Construct a Language Navigation Item.
+     *
+     * @param page             The page for which to create a navigation item.
+     * @param active           Flag indicating if the navigation item is active.
+     * @param current          Flag indicating if the navigation item is current page.
+     * @param linkManager      Link manager service.
+     * @param level            Depth level of the navigation item.
+     * @param childrenSupplier The child navigation items supplier.
+     * @param title            The item title.
+     * @param parentId         ID of the parent navigation component.
+     * @param component        The parent navigation {@link Component}.
+     */
+    public LanguageNavigationItemImpl(@NotNull final Page page,
+                                      final boolean active,
+                                      final boolean current,
+                                      @NotNull final LinkManager linkManager,
+                                      final int level,
+                                      @NotNull final Supplier<List<NavigationItem>> childrenSupplier,
+                                      final String title,
+                                      final String parentId,
+                                      final Component component) {
+        super(page, active, current, linkManager, level, childrenSupplier, parentId, component);
         this.title = title;
     }
 
     @Override
-    public String getTitle() { return title; }
+    public String getTitle() {
+        return title;
+    }
 
     @Override
     public Locale getLocale() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationItemImpl.java
@@ -17,6 +17,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v1;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -26,21 +27,63 @@ import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.components.Component;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+/**
+ * V1 Navigation Item Implementation.
+ */
 public class NavigationItemImpl extends PageListItemImpl implements NavigationItem {
 
-    protected List<NavigationItem> children = Collections.emptyList();
-    protected int level;
-    protected boolean active;
-    private boolean current;
+    /**
+     * List of children.
+     * Note - this will be null until populated from {@link #childrenSupplier} and so should remain private.
+     */
+    private List<NavigationItem> children;
 
-    public NavigationItemImpl(Page page, boolean active, boolean current, @NotNull LinkManager linkManager, int level,
-                              List<NavigationItem> children,
-                              String parentId, Component component) {
+    /**
+     * Navigation level.
+     */
+    private final int level;
+
+    /**
+     * Flag indicating if this navigation item is active.
+     */
+    private final boolean active;
+
+    /**
+     * Flag indicating if this navigation item is for the current page.
+     */
+    private final boolean current;
+
+    /**
+     * Supplier for child navigation items.
+     */
+    @NotNull
+    private final Supplier<@NotNull List<NavigationItem>> childrenSupplier;
+
+    /**
+     * Construct a Navigation Item.
+     *
+     * @param page             The page for which to create a navigation item.
+     * @param active           Flag indicating if the navigation item is active.
+     * @param current          Flag indicating if the navigation item is current page.
+     * @param linkManager      Link manager service.
+     * @param level            Depth level of the navigation item.
+     * @param childrenSupplier The child navigation items supplier.
+     * @param parentId         ID of the parent navigation component.
+     * @param component        The parent navigation {@link Component}.
+     */
+    public NavigationItemImpl(@NotNull final Page page,
+                              final boolean active,
+                              final boolean current,
+                              @NotNull final LinkManager linkManager,
+                              final int level,
+                              @NotNull final Supplier<List<NavigationItem>> childrenSupplier,
+                              final String parentId,
+                              final Component component) {
         super(linkManager, page, parentId, component);
         this.active = active;
         this.current = current;
         this.level = level;
-        this.children = children;
+        this.childrenSupplier = childrenSupplier;
     }
 
     @Override
@@ -62,6 +105,9 @@ public class NavigationItemImpl extends PageListItemImpl implements NavigationIt
 
     @Override
     public List<NavigationItem> getChildren() {
+        if (this.children == null) {
+            this.children = Collections.unmodifiableList(this.childrenSupplier.get());
+        }
         return children;
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/LanguageNavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/LanguageNavigationImpl.java
@@ -16,6 +16,7 @@
 package com.adobe.cq.wcm.core.components.internal.models.v2;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Exporter;
@@ -31,18 +32,31 @@ import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.components.Component;
 
+/**
+ * V2 Language Navigation model implementation.
+ */
 @Model(adaptables = SlingHttpServletRequest.class,
-       adapters = {LanguageNavigation.class, ComponentExporter.class},
-       resourceType = {LanguageNavigationImpl.RESOURCE_TYPE})
-@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME ,
-          extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+    adapters = {LanguageNavigation.class, ComponentExporter.class},
+    resourceType = {LanguageNavigationImpl.RESOURCE_TYPE})
+@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME,
+    extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class LanguageNavigationImpl extends com.adobe.cq.wcm.core.components.internal.models.v1.LanguageNavigationImpl implements LanguageNavigation {
 
+    /**
+     * V2 Language Navigation resource type.
+     */
     public static final String RESOURCE_TYPE = "core/wcm/components/languagenavigation/v2/languagenavigation";
 
-    protected LanguageNavigationItem newLanguageNavigationItem(Page page, boolean active, boolean current, @NotNull LinkManager linkManager,
-                                                               int level, List<NavigationItem> children, String title, String parentId,
-                                                               Component component) {
+    @Override
+    protected LanguageNavigationItem newLanguageNavigationItem(@NotNull final Page page,
+                                                               final boolean active,
+                                                               final boolean current,
+                                                               @NotNull final LinkManager linkManager,
+                                                               final int level,
+                                                               @NotNull final Supplier<List<NavigationItem>> children,
+                                                               final String title,
+                                                               final String parentId,
+                                                               final Component component) {
         return new LanguageNavigationItemImpl(page, active, current, linkManager, level, children, title, parentId, component);
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/LanguageNavigationItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/LanguageNavigationItemImpl.java
@@ -17,6 +17,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v2;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Supplier;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -26,21 +27,61 @@ import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.components.Component;
 
+/**
+ * V2 Language Navigation Item implementation.
+ */
 public class LanguageNavigationItemImpl extends NavigationItemImpl implements LanguageNavigationItem {
 
-    protected String title;
-    protected Locale locale;
-    protected String country;
-    protected String language;
+    /**
+     * Navigation item title.
+     */
+    private final String title;
 
-    public LanguageNavigationItemImpl(Page page, boolean active, boolean current, @NotNull LinkManager linkManager, int level,
-                                      List<NavigationItem> children, String title, String parentId, Component component) {
-        super(page, active, current, linkManager, level, children, parentId, component);
+    /**
+     * Locale for this language navigation item.
+     */
+    private Locale locale;
+
+    /**
+     * Country for this language navigation item.
+     */
+    private String country;
+
+    /**
+     * Language for this language navigation item.
+     */
+    private String language;
+
+    /**
+     * Construct a Language Navigation Item.
+     *
+     * @param page             The page for which to create a navigation item.
+     * @param active           Flag indicating if the navigation item is active.
+     * @param current          Flag indicating if the navigation item is current page.
+     * @param linkManager      Link manager service.
+     * @param level            Depth level of the navigation item.
+     * @param childrenSupplier The child navigation items supplier.
+     * @param title            The item title.
+     * @param parentId         ID of the parent navigation component.
+     * @param component        The parent navigation {@link Component}.
+     */
+    public LanguageNavigationItemImpl(@NotNull final Page page,
+                                      final boolean active,
+                                      final boolean current,
+                                      @NotNull final LinkManager linkManager,
+                                      final int level,
+                                      @NotNull final Supplier<List<NavigationItem>> childrenSupplier,
+                                      final String title,
+                                      final String parentId,
+                                      final Component component) {
+        super(page, active, current, linkManager, level, childrenSupplier, parentId, component);
         this.title = title;
     }
 
     @Override
-    public String getTitle() { return title; }
+    public String getTitle() {
+        return title;
+    }
 
     @Override
     public Locale getLocale() {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/NavigationImpl.java
@@ -16,6 +16,7 @@
 package com.adobe.cq.wcm.core.components.internal.models.v2;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Exporter;
@@ -30,16 +31,29 @@ import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.components.Component;
 
+/**
+ * V2 Navigation model implementation.
+ */
 @Model(adaptables = SlingHttpServletRequest.class,
         adapters = {Navigation.class, ComponentExporter.class},
         resourceType = {NavigationImpl.RESOURCE_TYPE})
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME , extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class NavigationImpl extends com.adobe.cq.wcm.core.components.internal.models.v1.NavigationImpl {
 
+    /**
+     * V2 Navigation resource type.
+     */
     public static final String RESOURCE_TYPE = "core/wcm/components/navigation/v2/navigation";
 
-    protected NavigationItem newNavigationItem(Page page, boolean active, boolean current, @NotNull LinkManager linkManager, int level,
-                                               List<NavigationItem> children, String parentId, Component component) {
+    @Override
+    protected NavigationItem newNavigationItem(@NotNull final Page page,
+                                               final boolean active,
+                                               final boolean current,
+                                               @NotNull final LinkManager linkManager,
+                                               final int level,
+                                               @NotNull final Supplier<@NotNull List<NavigationItem>> children,
+                                               final String parentId,
+                                               final Component component) {
         return new NavigationItemImpl(page, active, current, linkManager, level, children, parentId, component);
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/NavigationItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/NavigationItemImpl.java
@@ -17,6 +17,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v2;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -28,20 +29,63 @@ import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.components.Component;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+/**
+ * V2 Navigation Item Implementation.
+ */
 public class NavigationItemImpl extends PageListItemImpl implements NavigationItem {
 
-    protected List<NavigationItem> children = Collections.emptyList();
-    protected int level;
-    protected boolean active;
-    private boolean current;
+    /**
+     * List of children.
+     * Note - this will be null until populated from {@link #childrenSupplier} and so should remain private.
+     */
+    private List<NavigationItem> children;
 
-    public NavigationItemImpl(Page page, boolean active, boolean current, @NotNull LinkManager linkManager, int level, List<NavigationItem> children,
-                              String parentId, Component component) {
+    /**
+     * Navigation level.
+     */
+    private final int level;
+
+    /**
+     * Flag indicating if this navigation item is active.
+     */
+    private final boolean active;
+
+    /**
+     * Flag indicating if this navigation item is for the current page.
+     */
+    private final boolean current;
+
+    /**
+     * Supplier for child navigation items.
+     */
+    @NotNull
+    private final Supplier<@NotNull List<NavigationItem>> childrenSupplier;
+
+    /**
+     * Construct a Navigation Item.
+     *
+     * @param page The page for which to create a navigation item.
+     * @param active Flag indicating if the navigation item is active.
+     * @param current Flag indicating if the navigation item is current page.
+     * @param linkManager Link manager service.
+     * @param level Depth level of the navigation item.
+     * @param childrenSupplier The child navigation items supplier.
+     * @param parentId ID of the parent navigation component.
+     * @param component The parent navigation {@link Component}.
+     */
+    public NavigationItemImpl(@NotNull final Page page,
+                              final boolean active,
+                              final boolean current,
+                              @NotNull final LinkManager linkManager,
+                              final int level,
+                              @NotNull final Supplier<@NotNull List<@NotNull NavigationItem>> childrenSupplier,
+                              final String parentId,
+                              final Component component) {
         super(linkManager, page, parentId, component);
         this.active = active;
         this.current = current;
         this.level = level;
-        this.children = children;
+        this.childrenSupplier = childrenSupplier;
     }
 
     @Override
@@ -63,6 +107,9 @@ public class NavigationItemImpl extends PageListItemImpl implements NavigationIt
 
     @Override
     public List<NavigationItem> getChildren() {
+        if (this.children == null) {
+            this.children = Collections.unmodifiableList(this.childrenSupplier.get());
+        }
         return children;
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/BreadcrumbImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/BreadcrumbImpl.java
@@ -15,8 +15,6 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v3;
 
-import java.util.List;
-
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
@@ -30,16 +28,28 @@ import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.components.Component;
 
+/**
+ * V3 Breadcrumb model implementation.
+ */
 @Model(adaptables = SlingHttpServletRequest.class,
         adapters = {Breadcrumb.class, ComponentExporter.class},
         resourceType = BreadcrumbImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class BreadcrumbImpl extends com.adobe.cq.wcm.core.components.internal.models.v1.BreadcrumbImpl implements Breadcrumb {
 
+    /**
+     * V3 Breadcrumb component resource type.
+     */
     protected static final String RESOURCE_TYPE = "core/wcm/components/breadcrumb/v3/breadcrumb";
 
-    protected NavigationItem newBreadcrumbItem(Page page, boolean active, @NotNull LinkManager linkManager, int level, List<NavigationItem> children, String parentId, Component component) {
-        return new BreadcrumbItemImpl(page, active, linkManager, level, children, parentId, component);
+    @Override
+    protected NavigationItem newBreadcrumbItem(@NotNull final Page page,
+                                               final boolean active,
+                                               @NotNull final LinkManager linkManager,
+                                               final int level,
+                                               final String parentId,
+                                               final Component component) {
+        return new BreadcrumbItemImpl(page, active, linkManager, level, parentId, component);
     }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/BreadcrumbItemImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/BreadcrumbItemImpl.java
@@ -16,7 +16,7 @@
 
 package com.adobe.cq.wcm.core.components.internal.models.v3;
 
-import java.util.List;
+import java.util.Collections;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -32,12 +32,29 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import static org.apache.sling.api.SlingConstants.PROPERTY_PATH;
 
-@JsonIgnoreProperties(value = {"page", "children", "level", "description", "lastModified",PROPERTY_PATH})
+/**
+ * V3 Breadcrumb Item Implementation.
+ */
+@JsonIgnoreProperties(value = {"page", "children", "level", "description", "lastModified", PROPERTY_PATH})
 public class BreadcrumbItemImpl extends NavigationItemImpl implements NavigationItem {
 
-    public BreadcrumbItemImpl(Page page, boolean active, @NotNull LinkManager linkManager, int level,
-                              List<NavigationItem> children, String parentId, Component component) {
-        super(page, active, active, linkManager, level, children, parentId, component);
+    /**
+     * Construct a Breadcrumb Item.
+     *
+     * @param page        The page for which to create a breadcrumb item.
+     * @param active      Flag indicating if the breadcrumb item is active.
+     * @param linkManager Link manager service.
+     * @param level       Depth level of the navigation item.
+     * @param parentId    ID of the parent navigation component.
+     * @param component   The parent navigation {@link Component}.
+     */
+    public BreadcrumbItemImpl(@NotNull final Page page,
+                              final boolean active,
+                              @NotNull final LinkManager linkManager,
+                              final int level,
+                              final String parentId,
+                              final Component component) {
+        super(page, active, active, linkManager, level, Collections::emptyList, parentId, component);
     }
 
     @Override

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/NavigationItemImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/NavigationItemImplTest.java
@@ -44,7 +44,7 @@ public class NavigationItemImplTest {
         when(linkBuilder.build()).thenReturn(link);
         when(linkManager.get(page)).thenReturn(linkBuilder);
         Component component = mock(Component.class);
-        NavigationItemImpl navigationItem = new NavigationItemImpl(page, true, true, linkManager, 0, Collections.emptyList(), "id", component);
+        NavigationItemImpl navigationItem = new NavigationItemImpl(page, true, true, linkManager, 0, Collections::emptyList, "id", component);
         assertEquals(page, navigationItem.getPage());
         assertTrue(navigationItem.isActive());
         assertEquals(Collections.emptyList(), navigationItem.getChildren());


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #2526 
| Patch: Bug Fix?          | No
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes 
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Changes `Navigation` and `NavigationItem` Sling models so that the children are passed as a `Supplier` instead of the `List`.

This means that a full traversal and evaluation of the navigation tree does not need to be performed before the `Navigation` model returns the `List<NavigationItem>` to the caller. Evaluating deeper levels of the navigation structure will occur on demand if required.

