### PR TITLE
[Issue #2446] Don't open new `ResourceResolver` to resolve clientlib categories

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
@@ -173,8 +173,7 @@ public class Utils {
         Set<String> superTypes = new HashSet<>();
         String superType = resourceType;
         while (superType != null) {
-            superType = Optional.ofNullable(resourceResolver.getResource(superType))
-                .map(Resource::getResourceSuperType)
+            superType = Optional.ofNullable(resourceResolver.getParentResourceType(superType))
                 .filter(StringUtils::isNotEmpty)
                 .orElse(null);
             if (superType != null) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
@@ -15,49 +15,38 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import javax.annotation.Nullable;
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-import javax.inject.Named;
-
+import com.adobe.cq.wcm.core.components.internal.Utils;
+import com.adobe.cq.wcm.core.components.models.ClientLibraries;
+import com.adobe.cq.wcm.core.components.services.clientLibraries.ClientLibraryLookupService;
+import com.adobe.granite.ui.clientlibs.ClientLibrary;
+import com.adobe.granite.ui.clientlibs.HtmlLibrary;
+import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
+import com.adobe.granite.ui.clientlibs.LibraryType;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.wcm.core.components.internal.Utils;
-import com.adobe.cq.wcm.core.components.models.ClientLibraries;
-import com.adobe.granite.ui.clientlibs.ClientLibrary;
-import com.adobe.granite.ui.clientlibs.HtmlLibrary;
-import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
-import com.adobe.granite.ui.clientlibs.LibraryType;
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Model(
     adaptables = SlingHttpServletRequest.class,
@@ -67,12 +56,6 @@ import com.adobe.granite.ui.clientlibs.LibraryType;
 public class ClientLibrariesImpl implements ClientLibraries {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClientLibrariesImpl.class);
-
-    /**
-     * Name of the subservice used to authenticate as in order to be able to read details about components and
-     * client libraries.
-     */
-    public static final String COMPONENTS_SERVICE = "components-service";
 
     @Self
     private SlingHttpServletRequest request;
@@ -96,12 +79,10 @@ public class ClientLibrariesImpl implements ClientLibraries {
 
     @Inject
     @Named(OPTION_ASYNC)
-    @Nullable
     private boolean async;
 
     @Inject
     @Named(OPTION_DEFER)
-    @Nullable
     private boolean defer;
 
     @Inject
@@ -123,7 +104,7 @@ public class ClientLibrariesImpl implements ClientLibraries {
     private HtmlLibraryManager htmlLibraryManager;
 
     @OSGiService
-    ResourceResolverFactory resolverFactory;
+    ClientLibraryLookupService clientLibrariesService;
 
     private Set<String> resourceTypeSet;
     private Pattern pattern;
@@ -175,13 +156,12 @@ public class ClientLibrariesImpl implements ClientLibraries {
      * Returns the markup for including the client libraries into an HTML page
      *
      * @param type - the type of the client libraries
-     *
      * @return Markup to include the client libraries
      */
-    private String getLibIncludes(LibraryType type) {
+    private String getLibIncludes(@Nullable final LibraryType type) {
         StringWriter sw = new StringWriter();
         try {
-            if (categoriesArray == null || categoriesArray.length == 0)  {
+            if (categoriesArray == null || categoriesArray.length == 0) {
                 LOG.error("No categories detected. Please either specify the categories as a CSV string or a set of resource types for looking them up!");
             } else {
                 PrintWriter out = new PrintWriter(sw);
@@ -206,30 +186,25 @@ public class ClientLibrariesImpl implements ClientLibraries {
      * Returns the HTML markup with the injected JS/CSS attributes
      *
      * @param html - the input html
-     *
      * @return HTML with injected JS/CSS attributes
      */
-    private String getHtmlWithInjectedAttributes(String html) {
-        StringBuilder jsAttributes = new StringBuilder();
-        jsAttributes.append(getHtmlAttr(OPTION_ASYNC, async));
-        jsAttributes.append(getHtmlAttr(OPTION_DEFER, defer));
-        jsAttributes.append(getHtmlAttr(OPTION_CROSSORIGIN, crossorigin));
-        jsAttributes.append(getHtmlAttr(OPTION_ONLOAD, onload));
-        StringBuilder cssAttributes = new StringBuilder();
-        cssAttributes.append(getHtmlAttr(OPTION_MEDIA, media));
-        String updatedHtml = StringUtils.replace(html,"<script ", "<script " + jsAttributes.toString());
-        return StringUtils.replace(updatedHtml,"<link ", "<link " + cssAttributes.toString());
+    private String getHtmlWithInjectedAttributes(@NotNull final String html) {
+        String jsAttributes = getHtmlAttr(OPTION_ASYNC, async)
+            + getHtmlAttr(OPTION_DEFER, defer)
+            + getHtmlAttr(OPTION_CROSSORIGIN, crossorigin)
+            + getHtmlAttr(OPTION_ONLOAD, onload);
+        String updatedHtml = StringUtils.replace(html, "<script ", "<script " + jsAttributes);
+        return StringUtils.replace(updatedHtml, "<link ", "<link " + getHtmlAttr(OPTION_MEDIA, media));
     }
 
     /**
      * Returns the HTML fragment for an attribute, based on its name and a flag to include or not
      *
-     * @param name - the name of the attribute
+     * @param name    - the name of the attribute
      * @param include - {@code true} to include, {@code false} otherwise
-     *
      * @return Fragment for the attribute
      */
-    private String getHtmlAttr(String name, boolean include) {
+    private String getHtmlAttr(@NotNull final String name, boolean include) {
         if (include) {
             return name + " ";
         }
@@ -239,12 +214,11 @@ public class ClientLibrariesImpl implements ClientLibraries {
     /**
      * Returns the HTML fragment for an attribute, based on its name and value
      *
-     * @param name - the name of the attribute
+     * @param name  - the name of the attribute
      * @param value - the value of the attribute
-     *
      * @return Fragment for the attribute
      */
-    private String getHtmlAttr(String name, String value) {
+    private String getHtmlAttr(@NotNull final String name, @Nullable final String value) {
         if (StringUtils.isNotEmpty(value)) {
             return name + "=\"" + value + "\" ";
         }
@@ -255,7 +229,6 @@ public class ClientLibrariesImpl implements ClientLibraries {
      * Returns a concatenated string of the content of all the client libraries, given a library type.
      *
      * @param libraryType - the type of the library
-     *
      * @return The concatenated string of the content of all the client libraries
      */
     private String getInline(LibraryType libraryType) {
@@ -283,76 +256,11 @@ public class ClientLibrariesImpl implements ClientLibraries {
      */
     @NotNull
     protected Set<String> getCategoriesFromComponents() {
-        try (ResourceResolver resourceResolver = resolverFactory.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, COMPONENTS_SERVICE))) {
-            Set<String> categories = new HashSet<>();
-            for (ClientLibrary library : this.getAllClientLibraries(resourceResolver)) {
-                for (String category : library.getCategories()) {
-                    if (pattern == null || pattern.matcher(category).matches()) {
-                        categories.add(category);
-                    }
-                }
-            }
-            return categories;
-        } catch (LoginException e) {
-            LOG.error("Cannot login as a service user", e);
-            return Collections.emptySet();
-        }
-    }
-
-    /**
-     * Gets all of the client libraries.
-     *
-     * @param resourceResolver The resource resolver.
-     * @return Set of all client libraries.
-     */
-    @NotNull
-    private Set<ClientLibrary> getAllClientLibraries(@NotNull final ResourceResolver resourceResolver) {
-        Map<String, ClientLibrary> allLibraries = htmlLibraryManager.getLibraries();
-        Set<ClientLibrary> clientLibraries = new LinkedHashSet<>();
-        for (String resourceType : getAllResourceTypes(resourceResolver)) {
-            Resource resource = resourceResolver.getResource(resourceType);
-            if (resource != null) {
-                clientLibraries.addAll(getClientLibraries(resource, allLibraries));
-            }
-        }
-        return clientLibraries;
-    }
-
-    /**
-     * Gets all resource types.
-     *
-     * @param resourceResolver The resource resolver.
-     * @return Set of all resource types under which to search for client libraries.
-     */
-    @NotNull
-    private Set<String> getAllResourceTypes(@NotNull final ResourceResolver resourceResolver) {
-        Set<String> allResourceTypes = new LinkedHashSet<>(resourceTypeSet);
-        if (inherited) {
-            for (String resourceType : resourceTypeSet) {
-                allResourceTypes.addAll(Utils.getSuperTypes(resourceType, resourceResolver));
-            }
-        }
-        return allResourceTypes;
-    }
-
-    /**
-     * Gets a list of client libraries, starting from the given resource
-     * and diving into its descendants.
-     *
-     * @param resource - the given resource, which will be checked to see if it's a client library
-     * @param allLibraries - Map of all client libraries.
-     * @return List of client libraries for the given resource.
-     */
-    @NotNull
-    private static List<ClientLibrary> getClientLibraries(@org.jetbrains.annotations.Nullable final Resource resource,
-                                                          @NotNull final Map<String, ClientLibrary> allLibraries) {
-        return Optional.ofNullable(resource)
-            .map(Resource::getPath)
-            .map(path -> allLibraries.entrySet().stream()
-                .filter(entry -> entry.getKey().equals(path) || entry.getKey().startsWith(path + "/"))
-                .map(Map.Entry::getValue)
-                .collect(Collectors.toList()))
-            .orElseGet(Collections::emptyList);
+        return this.clientLibrariesService.getAllClientLibraries(this.resourceTypeSet, this.inherited, this.request.getResourceResolver()).stream()
+            .map(ClientLibrary::getCategories)
+            .flatMap(Arrays::stream)
+            .filter(category -> pattern == null || pattern.matcher(category).matches())
+            .collect(Collectors.toSet());
     }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/clientLibraries/ClientLibraryLookupServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/clientLibraries/ClientLibraryLookupServiceImpl.java
@@ -1,0 +1,201 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2023 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.clientLibraries;
+
+import com.adobe.cq.wcm.core.components.internal.Utils;
+import com.adobe.cq.wcm.core.components.services.clientLibraries.ClientLibraryLookupService;
+import com.adobe.granite.ui.clientlibs.ClientLibrary;
+import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventConstants;
+import org.osgi.service.event.EventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of {@link ClientLibraryLookupService}.
+ */
+@Component(service = {ClientLibraryLookupService.class, EventHandler.class},
+    immediate = true,
+    property = {
+        EventConstants.EVENT_TOPIC + "=com/adobe/granite/ui/librarymanager/INVALIDATED"
+    }
+)
+public final class ClientLibraryLookupServiceImpl implements ClientLibraryLookupService, EventHandler {
+
+    /**
+     * Default logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(ClientLibraryLookupServiceImpl.class);
+
+    /**
+     * Name of the sub-service used to authenticate as in order to be able to read details about components and
+     * client libraries.
+     */
+    private static final String COMPONENTS_SERVICE = "components-service";
+
+    /**
+     * Placeholder set used to indicate a cache miss.
+     */
+    private static final LinkedHashSet<ClientLibrary> CACHE_MISS_SET = new LinkedHashSet<>();
+
+    /**
+     * Resource resolver factory service.
+     */
+    private final ResourceResolverFactory resolverFactory;
+
+    /**
+     * Html Library Manager service.
+     */
+    private final HtmlLibraryManager libraryManager;
+
+    /**
+     * Cache used to store previous resource type -> client library mappings.
+     */
+    private final ConcurrentHashMap<String, Set<ClientLibrary>> cache = new ConcurrentHashMap<>();
+
+    /**
+     * Activate the service.
+     *
+     * @param resourceResolverFactory The resource resolver factory service.
+     * @param htmlLibraryManager      The Html Library Manager service.
+     */
+    @Activate
+    public ClientLibraryLookupServiceImpl(@NotNull @Reference final ResourceResolverFactory resourceResolverFactory,
+                                          @NotNull @Reference final HtmlLibraryManager htmlLibraryManager) {
+        this.resolverFactory = resourceResolverFactory;
+        this.libraryManager = htmlLibraryManager;
+    }
+
+    @Override
+    @NotNull
+    public Set<ClientLibrary> getAllClientLibraries(@NotNull final Set<String> resourceTypes, boolean inherited, @NotNull final ResourceResolver resourceResolver) {
+        Set<String> allResourceTypes = getAllResourceTypes(resourceTypes, inherited, resourceResolver);
+        LinkedHashMap<String, Set<ClientLibrary>> results = new LinkedHashMap<>();
+        boolean hasMisses = false;
+
+        // loop through each resource type getting the client libraries from cache or
+        // adding a placeholder if not in cache already.
+        for (String resourceType : allResourceTypes) {
+            Set<ClientLibrary> libraries = this.cache.get(resourceType);
+            if (libraries == null) {
+                LOG.debug("Cache miss {}", resourceType);
+                results.put(resourceType, CACHE_MISS_SET);
+                hasMisses = true;
+            } else {
+                LOG.debug("Cache hit {}", resourceType);
+                results.put(resourceType, libraries);
+            }
+        }
+
+        // handle all cache misses. Cache misses are handled as a block so that there is only
+        // one call to expensive methods (such as session logins, or getting every library).
+        if (hasMisses) {
+            Map<String, ClientLibrary> allLibraries = this.libraryManager.getLibraries();
+            try (ResourceResolver serviceResourceResolver = resolverFactory.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, COMPONENTS_SERVICE))) {
+                LOG.debug("Service resource resolver login");
+                // resolve all the cache misses
+                LinkedHashMap<String, Set<ClientLibrary>> resolvedLibraries = results.entrySet().stream()
+                    .filter(entry -> entry.getValue() == CACHE_MISS_SET)
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toMap(
+                        Function.identity(),
+                        resourceType -> Optional.ofNullable(serviceResourceResolver.getResource(resourceType))
+                            .map(resource -> getClientLibraries(resource, allLibraries))
+                            .orElseGet(LinkedHashSet::new),
+                        (a, b) -> a,
+                        LinkedHashMap::new
+                    ));
+
+                // add all newly resolved libraries to the cache
+                this.cache.putAll(resolvedLibraries);
+
+                // add all newly resolved libraries to the results
+                results.putAll(resolvedLibraries);
+            } catch (LoginException e) {
+                LOG.error("Cannot login as a service user", e);
+            }
+        }
+
+        // merge and return all the results
+        return results.values().stream()
+            .flatMap(Collection::stream)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /**
+     * Gets a list of client libraries, starting from the given resource
+     * and diving into its descendants.
+     *
+     * @param resource     - the given resource, which will be checked to see if it's a client library
+     * @param allLibraries - Map of all client libraries.
+     * @return Set of client libraries for the given resource.
+     */
+    @NotNull
+    private static LinkedHashSet<ClientLibrary> getClientLibraries(@Nullable final Resource resource, @NotNull final Map<String, ClientLibrary> allLibraries) {
+        return Optional.ofNullable(resource)
+            .map(Resource::getPath)
+            .map(path -> allLibraries.entrySet().stream()
+                .filter(entry -> entry.getKey().equals(path) || entry.getKey().startsWith(path + "/"))
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toCollection(LinkedHashSet::new)))
+            .orElseGet(LinkedHashSet::new);
+    }
+
+    /**
+     * Gets all resource types.
+     *
+     * @param resourceTypes    Set of initial resource types.
+     * @param inherited        Flag indicating if super resource types should be included.
+     * @param resourceResolver A resource resolver - does not have to be a special resource resolver.
+     * @return Set of all resource types under which to search for client libraries.
+     */
+    @NotNull
+    private Set<String> getAllResourceTypes(@NotNull final Set<String> resourceTypes, boolean inherited, @NotNull final ResourceResolver resourceResolver) {
+        Set<String> allResourceTypes = new LinkedHashSet<>(resourceTypes);
+        if (inherited) {
+            for (String resourceType : resourceTypes) {
+                allResourceTypes.addAll(Utils.getSuperTypes(resourceType, resourceResolver));
+            }
+        }
+        return allResourceTypes;
+    }
+
+    @Override
+    public void handleEvent(@NotNull final Event event) {
+        this.cache.clear();
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/clientLibraries/ClientLibraryLookupService.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/clientLibraries/ClientLibraryLookupService.java
@@ -1,0 +1,40 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2023 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.services.clientLibraries;
+
+import com.adobe.granite.ui.clientlibs.ClientLibrary;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+/**
+ * Service for looking up client libraries belonging to resource types.
+ *
+ * @since com.adobe.cq.wcm.core.components.services.clientLibraries 1.0.0
+ */
+public interface ClientLibraryLookupService {
+
+    /**
+     * Gets all the client libraries for a given set of resource types.
+     *
+     * @param inherited Flag indicating if super resource types should be included.
+     * @param resourceResolver A resource resolver - does not have to be a special resource resolver.
+     * @return Set of all client libraries.
+     */
+    @NotNull
+    Set<ClientLibrary> getAllClientLibraries(@NotNull Set<String> resourceTypes, boolean inherited, @NotNull ResourceResolver resourceResolver);
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/clientLibraries/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/clientLibraries/package-info.java
@@ -1,0 +1,19 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2023 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+@Version("1.0.0")
+package com.adobe.cq.wcm.core.components.services.clientLibraries;
+
+import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import com.adobe.cq.wcm.core.components.internal.services.clientLibraries.ClientLibraryLookupServiceImpl;
+import com.adobe.cq.wcm.core.components.services.clientLibraries.ClientLibraryLookupService;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
@@ -51,6 +53,7 @@ import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.osgi.service.event.Event;
 
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,6 +64,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(AemContextExtension.class)
@@ -92,6 +96,8 @@ class ClientLibrariesImplTest {
     private static final String CSS_FILE_REL_PATH = "/styles/index.css";
 
     private final AemContext context = CoreComponentTestContext.newAemContext();
+
+    private ResourceResolverFactory serviceResolverFactory;
 
     private Map<String,ClientLibrary> allLibraries; // a map of (path, library) of all the libraries
     private Map<String,ClientLibrary> librariesMap; // a map of (category, library) of all the libraries
@@ -271,6 +277,9 @@ class ClientLibrariesImplTest {
             fail(String.format("Unable to write include: %s", e.getMessage()));
         }
 
+        this.serviceResolverFactory = spy(Objects.requireNonNull(this.context.getService(ResourceResolverFactory.class)));
+        context.registerService(ClientLibraryLookupService.class, new ClientLibraryLookupServiceImpl(serviceResolverFactory, htmlLibraryManager));
+        context.registerInjectActivateService(ClientLibraryLookupServiceImpl.class);
     }
 
     @Test
@@ -298,11 +307,8 @@ class ClientLibrariesImplTest {
         Page page = pageManager.getPage(ROOT_PAGE);
         Map<String, Object> attributes = new HashMap<>();
         attributes.put(ClientLibraries.OPTION_RESOURCE_TYPES, Utils.getPageResourceTypes(page, context.request(), mock(ModelFactory.class)));
+        doThrow(new LoginException()).when(this.serviceResolverFactory).getServiceResourceResolver(anyMap());
         ClientLibrariesImpl clientlibs = Objects.requireNonNull((ClientLibrariesImpl) getClientLibrariesUnderTest(ROOT_PAGE, attributes));
-
-        ResourceResolverFactory factory = mock(ResourceResolverFactory.class);
-        doThrow(new LoginException()).when(factory).getServiceResourceResolver(anyMap());
-        clientlibs.resolverFactory = factory;
         assertEquals(new HashSet<>(), clientlibs.getCategoriesFromComponents());
     }
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2446 
| Patch: Bug Fix?          | N
| Minor: New Feature?      | Y
| Major: Breaking Change?  | N
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

This PR is a Proof of Concept on how to resolve issue #2446.
The solution outlined in issue #2446 is to pin an open service-user session to the user request so that the service user session does not need to be re-opened multiple times (which is costly). The problem with this solution is that the Sling API included in AEM 6.5.x does not currently support this.

The PR proposes an alternative solution. 

This PR builds on the fact that all resource type -> client library category resolution is performed using a service user session.
Since the same service user is used to perform this resolution for every request, the results of this resolution will not differ for different user sessions - therefore the results are suitable to be cached between multiple requests.

To accomplish this, a new service (`ClientLibraryLookupService`) is added.
This service performs the client library category resolution, and then uses a simple `HashMap` as a cache.

Initial requests to a clean cache may still cause  multiple service user session logins during a single user request; however, once the cache is populated, there are *no* service user session logins at all. 

This has an advantage over pinning the service user session to the user request because (with the exception of the first few requests) there are 0 service user sessions created (instead of 1), and additionally the entire logic and repository access associated with the resource type -> client library category resolution is also eliminated and replaced with a simple hashmap lookup - reducing repository access in general. 

To ensure that the cache is kept in sync with the repository, the cache is cleared every time a `com/adobe/granite/ui/librarymanager/INVALIDATED` event is issued - which occurs every time a client library is modified, deleted, or added. 

When this event is issued, the entire cache is invalidated. This is easier than trying to figure out which cache items are no longer valid and selectively clearing just those entries. Changes to the client libraries on a running AEM instance should be infrequent enough that clearing the entire cache will have a negligible performance impact. 
