### PR TITLE
[2530] AdaptiveImage: control skipping/requiring transformation via OSGi config

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumer.java
@@ -71,7 +71,7 @@ public class AdaptiveImageServletMappingConfigurationConsumer {
 
     @Reference
     private ConfigurationAdmin configurationAdmin;
-    
+
     @Reference
     AdaptiveImageServletMetrics metrics;
 
@@ -171,7 +171,9 @@ public class AdaptiveImageServletMappingConfigurationConsumer {
                                         assetStore,
                                         metrics,
                                         oldAISDefaultResizeWidth > 0 ? oldAISDefaultResizeWidth : config.getDefaultResizeWidth(),
-                                        config.getMaxSize()),
+                                        config.getMaxSize(),
+                                        config.getNonTransformableImageTypes(),
+                                        config.getForcedTransformationImageTypes()),
                                 properties
                         )
                 );

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactory.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactory.java
@@ -81,6 +81,19 @@ public class AdaptiveImageServletMappingConfigurationFactory {
         )
         int maxSize() default AdaptiveImageServlet.DEFAULT_MAX_SIZE;
 
+        @AttributeDefinition(
+                name = "Non-transformable image types",
+                description = "Images of the following types (identified by lower-case extension) will never be transformed (e.g. " +
+                        "rotated, cropped, etc.)"
+        )
+        String[] nonTransformableImageTypes() default { "gif", "svg" };
+
+        @AttributeDefinition(
+                name ="Forced transformation image types",
+                description = "Images of the following types (identified by lower-case extensions) will always be transformed, reg. of " +
+                        "editorial application of rotation, transformation, etc. - ensuring e.g. compression is applied."
+        )
+        String[] forcedTransformationImageTypes() default{ } ;
     }
 
     private List<String> resourceTypes;
@@ -92,6 +105,10 @@ public class AdaptiveImageServletMappingConfigurationFactory {
     private int defaultResizeWidth;
 
     private int maxSize;
+
+    private List<String> nonTransformableImageTypes;
+
+    private List<String> forcedTransformationImageTypes;
 
     /**
      * Invoked when a configuration is created or modified.
@@ -106,6 +123,8 @@ public class AdaptiveImageServletMappingConfigurationFactory {
         extensions = getValues(config.extensions());
         defaultResizeWidth = config.defaultResizeWidth();
         maxSize = config.maxSize();
+        nonTransformableImageTypes = getValues(config.nonTransformableImageTypes());
+        forcedTransformationImageTypes = getValues(config.forcedTransformationImageTypes());
     }
 
     /**
@@ -156,6 +175,22 @@ public class AdaptiveImageServletMappingConfigurationFactory {
     }
 
     /**
+     * Returns the image types' extensions that will not be transformed by the {@link AdaptiveImageServlet}.
+     * Defaults to gif and svg.
+     * @return
+     */
+    @NotNull
+    public List<String> getNonTransformableImageTypes() { return Collections.unmodifiableList(this.nonTransformableImageTypes); }
+
+    /**
+     * Returns the image types' extensions that will always be transformed by the {@link AdaptiveImageServlet} e.g. enforcing compression
+     * independently from editorial applied changes.
+     * @return
+     */
+    @NotNull
+    public List<String> getForcedTransformationImageTypes() { return Collections.unmodifiableList(this.forcedTransformationImageTypes); }
+
+    /**
      * Internal helper for filtering out null and empty values from the configuration options.
      *
      * @param config - Array of strings which might include null or empty values
@@ -176,6 +211,7 @@ public class AdaptiveImageServletMappingConfigurationFactory {
     @Override
     public String toString() {
         return "{resourceTypes: " + resourceTypes.toString() + ", selectors: " + selectors.toString() + ", extensions: " + extensions
-                .toString() + ", defaultResizeWidth: " + defaultResizeWidth + "}";
+                .toString() + ", defaultResizeWidth: " + defaultResizeWidth + ", nonTransformableImageTypes: " + nonTransformableImageTypes
+                .toString() + ", forcedTransformationImageTypes: " + forcedTransformationImageTypes.toString() + "}";
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactoryTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactoryTest.java
@@ -58,11 +58,20 @@ public class AdaptiveImageServletMappingConfigurationFactoryTest {
             public int maxSize() {
                 return AdaptiveImageServlet.DEFAULT_MAX_SIZE;
             }
+
+            @Override
+            public String[] nonTransformableImageTypes() { return new String[] {"gif", "svg"}; }
+
+            @Override
+            public String[] forcedTransformationImageTypes() { return new String[] { }; }
         });
         testValues(new String[] {"core/image"}, configurationFactory.getResourceTypes());
         testValues(new String[] {"coreimg"}, configurationFactory.getSelectors());
         testValues(new String[] {"jpg", "gif", "png"}, configurationFactory.getExtensions());
-        assertEquals("{resourceTypes: [core/image], selectors: [coreimg], extensions: [jpg, gif, png], defaultResizeWidth: 1280}",
+        testValues(new String[] {"gif", "svg"}, configurationFactory.getNonTransformableImageTypes());
+        testValues(new String[] { }, configurationFactory.getForcedTransformationImageTypes());
+        assertEquals("{resourceTypes: [core/image], selectors: [coreimg], extensions: [jpg, gif, png], defaultResizeWidth: 1280, " +
+                     "nonTransformableImageTypes: [gif, svg], forcedTransformationImageTypes: []}",
                 configurationFactory.toString());
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletTest.java
@@ -123,7 +123,8 @@ class AdaptiveImageServletTest extends AbstractImageTest {
             Rendition rendition = invocation.getArgument(0);
             return ImageIO.read(rendition.getStream());
         });
-        servlet = new AdaptiveImageServlet(mockedMimeTypeService, assetStore, metrics, ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH, AdaptiveImageServlet.DEFAULT_MAX_SIZE);
+        servlet = new AdaptiveImageServlet(mockedMimeTypeService, assetStore, metrics, ADAPTIVE_IMAGE_SERVLET_DEFAULT_RESIZE_WIDTH,
+                AdaptiveImageServlet.DEFAULT_MAX_SIZE, List.of("gif", "svg"), List.of());
     }
 
     @AfterEach

--- a/config/src/content/jcr_root/apps/core/wcm/config/com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServletMappingConfigurationFactory-coreimg.config
+++ b/config/src/content/jcr_root/apps/core/wcm/config/com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServletMappingConfigurationFactory-coreimg.config
@@ -15,3 +15,5 @@
 resource.types=["core/wcm/components/image","cq/Page"]
 selectors=["coreimg"]
 extensions=["jpg","jpeg","png","gif","svg"]
+nonTransformableImageTypes=["gif","svg"]
+forceTransformationImageTypes=[]

--- a/config/src/content/jcr_root/apps/core/wcm/config/com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServletMappingConfigurationFactory-img.config
+++ b/config/src/content/jcr_root/apps/core/wcm/config/com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServletMappingConfigurationFactory-img.config
@@ -15,3 +15,5 @@
 resource.types=["core/wcm/components/image"]
 selectors=["img"]
 extensions=["jpg","jpeg","png","gif","svg"]
+nonTransformableImageTypes=["gif","svg"]
+forcedTransformationImageTypes=[]


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2530
| Patch: Bug Fix?          | No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Ensures users can configure which image types are never transformed (currently: svg and gif) and which image types are always transformed (currently: none) via OSGi. 
By this, transformation can be easily disabled for other image types, but it is also possible to require the transformation for jpg/jpeg, thus ensuring custom compression settings are used - currently, editors in AEM have to crop jpg images by a single pixel just to deliver them in a compressed way - otherwise, web performance and green web goals are not met. 
The default configurations for these settings ensure backward compatibility, as they ensure the system behaves as before. 