### PR TITLE
SITES-14355 - CISCO | Teaser core component - Smart crop issues

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
+          paths-ignore:
+              - '**/jcr_root/apps/system/config/**'
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v2

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
@@ -134,7 +134,7 @@
             toggleAlternativeFieldsAndLink(imageFromPageImage, isDecorative);
             togglePageImageInherited(imageFromPageImage, isDecorative);
             updateImageThumbnail().then(function() {
-                $cqFileUploadEdit = $dialog.find(".cq-FileUpload-edit:visible");
+                $cqFileUploadEdit = $dialog.find(".cq-FileUpload-edit[trackingelement='edit']");
                 if ($cqFileUploadEdit) {
                     fileReference = $cqFileUploadEdit.data("cqFileuploadFilereference");
                     if (fileReference === "") {


### PR DESCRIPTION
 * use a selector for fileupload which works for Teaser component too where the fileupload is not visible initially when the edit dialog is opened

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `SITES-14355` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | 
| Documentation Provided   | 
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
