### PR TITLE
SITES-13771 Content Fragment List component : Property Name is getting displayed to users rather than Field Label

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ModelElementsDataSourceServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ModelElementsDataSourceServlet.java
@@ -116,6 +116,12 @@ public class ModelElementsDataSourceServlet extends AbstractDataSourceServlet {
                     ValueMap valueMap = elementResource.getValueMap();
                     String valueValue = valueMap.get("name", "");
                     String textValue = valueMap.get("fieldLabel", valueValue);
+                    if (textValue.equals(valueValue)) {
+                        textValue = valueMap.get("cfm-element", valueValue);
+                        if (textValue == null || textValue.isEmpty()) {
+                            textValue = valueValue;
+                        }
+                    }
                     if (isOrderBy && StringUtils.isNotEmpty(valueValue)) {
                         valueValue = "jcr:content/data/master/" + valueValue;
                     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ModelElementsDataSourceServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ModelElementsDataSourceServlet.java
@@ -118,9 +118,6 @@ public class ModelElementsDataSourceServlet extends AbstractDataSourceServlet {
                     String textValue = valueMap.get("fieldLabel", valueValue);
                     if (textValue.equals(valueValue)) {
                         textValue = valueMap.get("cfm-element", valueValue);
-                        if (textValue == null || textValue.isEmpty()) {
-                            textValue = valueValue;
-                        }
                     }
                     if (isOrderBy && StringUtils.isNotEmpty(valueValue)) {
                         valueValue = "jcr:content/data/master/" + valueValue;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ModelElementsDataSourceServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/ModelElementsDataSourceServletTest.java
@@ -86,7 +86,7 @@ public class ModelElementsDataSourceServletTest {
                 hasItem(resourceWithPropertiesTextAndValue("Created", "jcr:created")),
                 hasItem(resourceWithPropertiesTextAndValue("Last Modified", "jcr:content/jcr:lastModified")),
                 hasItem(resourceWithPropertiesTextAndValue("textFieldLabel", "jcr:content/data/master/textField")),
-                hasItem(resourceWithPropertiesTextAndValue("multiTextField", "jcr:content/data/master/multiTextField"))));
+                hasItem(resourceWithPropertiesTextAndValue("Multi Text Field", "jcr:content/data/master/multiTextField"))));
     }
 
     @Test
@@ -111,7 +111,7 @@ public class ModelElementsDataSourceServletTest {
                 hasItem(resourceWithPropertiesTextAndValue("Created", "jcr:created")),
                 hasItem(resourceWithPropertiesTextAndValue("Last Modified", "jcr:content/jcr:lastModified")),
                 hasItem(resourceWithPropertiesTextAndValue("textFieldLabel", "jcr:content/data/master/textField")),
-                hasItem(resourceWithPropertiesTextAndValue("multiTextField", "jcr:content/data/master/multiTextField")),
+                hasItem(resourceWithPropertiesTextAndValue("Multi Text Field", "jcr:content/data/master/multiTextField")),
                 hasItem(resourceWithPropertiesTextAndValue("dateAndTimeFieldLabel", "jcr:content/data/master/dateAndTimeField")),
                 hasItem(resourceWithPropertiesTextAndValue("numberFieldLabel", "jcr:content/data/master/numberField"))));
     }
@@ -135,7 +135,7 @@ public class ModelElementsDataSourceServletTest {
         assertThat(resourceList, allOf(
                 hasItem(resourceWithPropertiesTextAndValue("textFieldLabel", "textField")),
                 // Multi text field doesn't have the 'fieldLabel' property, instead label is stored as 'cfm-element':
-                hasItem(resourceWithPropertiesTextAndValue("multiTextField", "multiTextField")),
+                hasItem(resourceWithPropertiesTextAndValue("Multi Text Field", "multiTextField")),
                 hasItem(resourceWithPropertiesTextAndValue("numberFieldLabel", "numberField")),
                 // Boolean field is a checkbox and therefore doesn't have a 'fieldLabel', instead there is a 'text' property
                 hasItem(resourceWithPropertiesTextAndValue("booleanField", "booleanField")),

--- a/bundles/core/src/test/resources/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/test-content.json
+++ b/bundles/core/src/test/resources/com/adobe/cq/wcm/core/components/internal/servlets/contentfragment/test-content.json
@@ -54,7 +54,7 @@
                             "valueType": "string",
                             "showEmptyInReadOnly": "true",
                             "metaType": "text-multi",
-                            "cfm-element": "multiTextFieldLabel",
+                            "cfm-element": "Multi Text Field",
                             "name": "multiTextField",
                             "sling:resourceType": "dam/cfm/admin/components/authoring/contenteditor/multieditor",
                             "renderReadOnly": "false"


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
https://jira.corp.adobe.com/browse/SITES-13771
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://jira.corp.adobe.com/browse/SITES-13771,  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Bug fix
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

Tries to get the multi text field from "cfm-element" key rather than from the fieldLabel key and falls back on the default value in case is doesn't find anything.