### PR TITLE
Updated pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,7 @@
 Before making a PR please make sure to read our contributing guidelines
 https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md
 
-IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
- master after it's successfully integrated and tested.
+IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!
 
 For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
 followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.


### PR DESCRIPTION
The template was outdated and suggested using the development branch as a base for pull requests. But development is not used anymore and the main branch should be used instead.