### PR TITLE
SITES-15109 - RFH - Applying Async in clientlibraries not working on customer instance

### DIFF
--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
@@ -34,6 +34,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.models.factory.ModelFactory;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -356,12 +357,91 @@ class ClientLibrariesImplTest {
     }
 
     @Test
+    void testGetCategoriesWithAdverseInjectedCategories() {
+        // invalid injection
+        Map<String,Object> slingAttributes = new HashMap<>();
+        slingAttributes.put(ClientLibraries.OPTION_CATEGORIES, new Object());
+
+        // valid injection
+        Map<String,Object> requestAttributes = new HashMap<>();
+        requestAttributes.put(ClientLibraries.OPTION_CATEGORIES, TEASER_CATEGORY + "," + ACCORDION_CATEGORY);
+
+        ClientLibraries clientlibs = getClientLibrariesUnderTest(ROOT_PAGE, slingAttributes, requestAttributes);
+
+        //valid injection should be used
+        StringBuilder includes = new StringBuilder();
+        includes.append(jsIncludes.get(TEASER_CATEGORY));
+        includes.append(jsIncludes.get(ACCORDION_CATEGORY));
+        includes.append(cssIncludes.get(TEASER_CATEGORY));
+        includes.append(cssIncludes.get(ACCORDION_CATEGORY));
+        assertEquals(includes.toString(), clientlibs.getJsAndCssIncludes());
+    }
+
+    @Test
+    void testGetCategoriesWithAdverseInjectedCategoriesBackwardsCompatibility() {
+        // original honored injection
+        Map<String,Object> slingAttributes = new HashMap<>();
+        slingAttributes.put(ClientLibraries.OPTION_CATEGORIES, TEASER_CATEGORY + "," + ACCORDION_CATEGORY);
+
+        // new ignored injection
+        Map<String,Object> requestAttributes = new HashMap<>();
+        requestAttributes.put(ClientLibraries.OPTION_CATEGORIES, TEASER_CATEGORY);
+
+        ClientLibraries clientlibs = getClientLibrariesUnderTest(ROOT_PAGE, slingAttributes, requestAttributes);
+
+        StringBuilder includes = new StringBuilder();
+        includes.append(jsIncludes.get(TEASER_CATEGORY));
+        includes.append(jsIncludes.get(ACCORDION_CATEGORY));
+        includes.append(cssIncludes.get(TEASER_CATEGORY));
+        includes.append(cssIncludes.get(ACCORDION_CATEGORY));
+        assertEquals(includes.toString(), clientlibs.getJsAndCssIncludes());
+    }
+
+    @Test
     void testGetCategoriesWithInjectedResourceType() {
         Map<String,Object> attributes = new HashMap<>();
         attributes.put("resourceTypes", new HashSet<String>() {{
             add("core/wcm/components/accordion/v1/accordion");
         }});
         ClientLibraries clientlibs = getClientLibrariesUnderTest(ROOT_PAGE, attributes);
+        StringBuilder includes = new StringBuilder();
+        includes.append(jsIncludes.get(ACCORDION_CATEGORY));
+        includes.append(cssIncludes.get(ACCORDION_CATEGORY));
+        assertEquals(includes.toString(), clientlibs.getJsAndCssIncludes());
+    }
+
+    @Test
+    void testGetCategoriesWithAdverseInjectedResourceType() {
+        // invalid injection
+        Map<String,Object> slingAttributes = new HashMap<>();
+        slingAttributes.put(ClientLibraries.OPTION_RESOURCE_TYPES, new Object());
+        // valid injection
+        Map<String,Object> requestAttributes = new HashMap<>();
+        requestAttributes.put(ClientLibraries.OPTION_RESOURCE_TYPES, new HashSet<String>() {{
+            add("core/wcm/components/accordion/v1/accordion");
+        }});
+        ClientLibraries clientlibs = getClientLibrariesUnderTest(ROOT_PAGE, slingAttributes, requestAttributes);
+        StringBuilder includes = new StringBuilder();
+        includes.append(jsIncludes.get(ACCORDION_CATEGORY));
+        includes.append(cssIncludes.get(ACCORDION_CATEGORY));
+        assertEquals(includes.toString(), clientlibs.getJsAndCssIncludes());
+    }
+
+    @Test
+    void testGetCategoriesWithAdverseInjectedResourceTypeBackwardsCompatibility() {
+        // original honored injection
+        Map<String,Object> slingAttributes = new HashMap<>();
+        slingAttributes.put(ClientLibraries.OPTION_RESOURCE_TYPES, new HashSet<String>() {{
+            add("core/wcm/components/accordion/v1/accordion");
+        }});
+        // new ignored injection
+        Map<String,Object> requestAttributes = new HashMap<>();
+        requestAttributes.put(ClientLibraries.OPTION_RESOURCE_TYPES, new HashSet<String>() {{
+            add("core/wcm/components/accordion/v1/accordion");
+            add("core/wcm/components/carousel/v3/carousel");
+        }});
+
+        ClientLibraries clientlibs = getClientLibrariesUnderTest(ROOT_PAGE, slingAttributes, requestAttributes);
         StringBuilder includes = new StringBuilder();
         includes.append(jsIncludes.get(ACCORDION_CATEGORY));
         includes.append(cssIncludes.get(ACCORDION_CATEGORY));
@@ -524,6 +604,26 @@ class ClientLibrariesImplTest {
             }
             context.request().setResource(resource);
             return context.request().adaptTo(ClientLibraries.class);
+        }
+        return null;
+    }
+
+    private ClientLibraries getClientLibrariesUnderTest(String path, Map<String,Object> slingAttributes, Map<String,Object> requestAttributes) {
+        Resource resource = context.currentResource(path);
+        if (resource != null) {
+            MockSlingHttpServletRequest request = context.request();
+            if (slingAttributes != null) {
+                SlingBindings slingBindings = (SlingBindings) request.getAttribute(SlingBindings.class.getName());
+                for (Map.Entry<String,Object> entry : slingAttributes.entrySet()) {
+                    slingBindings.put(entry.getKey(), entry.getValue());
+                }
+                request.setAttribute(SlingBindings.class.getName(), slingBindings);
+                for (Map.Entry<String,Object> entry : requestAttributes.entrySet()) {
+                    request.setAttribute(entry.getKey(), entry.getValue());
+                }
+            }
+            request.setResource(resource);
+            return request.adaptTo(ClientLibraries.class);
         }
         return null;
     }


### PR DESCRIPTION
 * added request attribute based injection for categories and resourceTypes fields as a safety mechanism to reduce the risk of unintended injections on these two fields
 * updated unit tests

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-15109 , #1808
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
