### PR TITLE
SITES-15835 -httpclient-osgi dependency change

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -434,8 +434,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient-osgi</artifactId>
+            <groupId>com.day.commons.osgi.wrapper</groupId>
+            <artifactId>com.day.commons.osgi.wrapper.commons-httpclient</artifactId>
         </dependency>
 
         <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -766,9 +766,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient-osgi</artifactId>
-                <version>4.5.13</version>
+                <groupId>com.day.commons.osgi.wrapper</groupId>
+                <artifactId>com.day.commons.osgi.wrapper.commons-httpclient</artifactId>
+                <version>3.1.0.018</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
                         <exclude>**/*.editorconfig</exclude>
                         <exclude>**/*.stylelintrc.yaml</exclude>
                         <exclude>**/*.eslintignore</exclude>
+                        <!-- Ignore target folders -->
+                        <exclude>**/target/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes SITES-15835
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | No
| Documentation Provided   | No (code comments and or markdown)
| Any Dependency Changes?  | **org.apache.httpcomponents:httpclient-osgi:4.5.13** changed to **com.day.commons.osgi.wrapper:com.day.commons.osgi.wrapper.commons-httpclient:3.1.0.018**
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Changed **httpclient-osgi** dependency to **com.day.commons.osgi.wrapper.commons-httpclient** and added a target folder exclusion to apache-rat-plugin configuration