### PR TITLE
[SITES-15716] Broken inheritance of thumbnail - page property of a live copy is being overwritten by a rollout of blueprint

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/_cq_dialog/.content.xml
@@ -187,7 +187,7 @@
                                                     uploadUrl="will_be_replaced">
                                                     <granite:data
                                                         jcr:primaryType="nt:unstructured"
-                                                        cq-msm-lockable="./image"/>
+                                                        cq-msm-lockable="/image"/>
                                                 </upload>
                                                 <assetpicker
                                                     granite:class="js-browse-activator"
@@ -196,7 +196,7 @@
                                                     text="Select Image">
                                                     <granite:data
                                                         jcr:primaryType="nt:unstructured"
-                                                        cq-msm-lockable="./image"/>
+                                                        cq-msm-lockable="/image"/>
                                                 </assetpicker>
                                                 <preview
                                                     jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
