### PR TITLE
[SITES-16477] Update SDK_URL from documentservices to acrobatservices

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/pdfviewer/v1/pdfviewer/clientlibs/site/js/pdfviewer.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/pdfviewer/v1/pdfviewer/clientlibs/site/js/pdfviewer.js
@@ -18,7 +18,7 @@
 
     var NS = "cmp";
     var IS = "pdfviewer";
-    var SDK_URL = "https://documentservices.adobe.com/view-sdk/viewer.js";
+    var SDK_URL = "https://acrobatservices.adobe.com/view-sdk/viewer.js";
     var SDK_READY_EVENT = "adobe_dc_view_sdk.ready";
 
     var selectors = {


### PR DESCRIPTION
The documentservices.adobe.com url was marked as a tracker by the microsoft edge browser.
The acrobatservices.adobe.com url is one of their approved ones.

See: https://learn.microsoft.com/en-us/microsoft-edge/web-platform/tracking-prevention


<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
