### PR TITLE
[SITES-16761] Fixed missing toolbar for image component

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/ngdmsmartcrop/js/smartcropaction.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/ngdmsmartcrop/js/smartcropaction.js
@@ -18,11 +18,15 @@
     "use strict";
     ns.image.v3.actions.smartCrop = function() {
         const editable = this;
-        authorNs.DialogFrame.openDialog(new ns.image.v3.smartCropDialog(editable));
+        if (this.authorNs) {
+            authorNs.DialogFrame.openDialog(new ns.image.v3.smartCropDialog(editable));
+        }
     };
 
     ns.image.v3.actions.smartCrop.condition = function(editable) {
-        return authorNs.pageInfoHelper.canModify() && hasNGDMSmartCropAction(editable) && isNGDMImage(editable);
+        if (this.authorNs) {
+            return authorNs.pageInfoHelper.canModify() && hasNGDMSmartCropAction(editable) && isNGDMImage(editable);
+        }
     };
 
     function hasNGDMSmartCropAction(editable) {


### PR DESCRIPTION
Jira: https://jira.corp.adobe.com/browse/SITES-16761
Added two null pointer checks since `authorNs` is usually undefined.
Since [smartcropaction.js](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/ngdmsmartcrop/js/smartcropaction.js) was added with https://github.com/adobe/aem-core-wcm-components/commit/b49e22c80a42b8db9c4804b8fe0b72e684cc48df I assume that the focus was NGDM and that's the case when `authorNs` should be defined. Hence this is a fix for non-NGDM case.