### PR TITLE
Fix: [Image + Teaser] Don't require ALT text if no asset selected #2523

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-(function($, Granite) {
+ (function($, Granite) {
     "use strict";
 
     var dialogContentSelector = ".cmp-image__editor";
@@ -46,6 +46,7 @@
     var altTextFromPage;
     var altTextFromDAM;
     var altCheckboxSelector = "coral-checkbox[name='./altValueFromDAM']";
+    var altIsDecorativeSelector = 'coral-checkbox[name="./isDecorative"]';
     var altInputSelector = "input[name='./alt']";
     var altInputAlertIconSelector = "input[name='./alt'] + coral-icon[icon='alert']";
     var assetTabSelector = "coral-tab[data-foundation-tracking-event*='asset']";
@@ -65,7 +66,7 @@
         $dialogContent = $dialog.find(dialogContentSelector);
         var dialogContent  = $dialogContent.length > 0 ? $dialogContent[0] : undefined;
         if (dialogContent) {
-            isDecorative = dialogContent.querySelector('coral-checkbox[name="./isDecorative"]');
+            isDecorative = dialogContent.querySelector(altIsDecorativeSelector);
 
             if ($(pageAltCheckboxSelector).length === 1) {
                 // when the tuple is used in the page dialog to define the featured image
@@ -170,8 +171,15 @@
         validate: function() {
             var seededValue = $(altInputSelector).attr("data-seeded-value");
             var isAltCheckboxChecked = $(altCheckboxSelector).attr("checked");
+            var isDecorative = $(altIsDecorativeSelector).attr('checked');
             var assetWithoutDescriptionErrorMessage = "Error: Please provide an asset which has a description that can be used as alt text.";
-            if (isAltCheckboxChecked && !seededValue) {
+
+            // Validate the following:
+            // - the image is not decorative
+            // - alt is not inherited from the DAM
+            // - the alt value is empty.
+            // If all of these are true, return a validation error
+            if (!isDecorative && !isAltCheckboxChecked && !seededValue) {
                 return Granite.I18n.get(assetWithoutDescriptionErrorMessage);
             }
         }
@@ -531,7 +539,7 @@
                             }
                         }
                     }
-
+176
                     if (mutation.attributeName === "disabled") {
                         if ($(altInputSelector).val()) {
                             if (alertIcon.length) {

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
- (function($, Granite) {
+(function($, Granite) {
     "use strict";
 
     var dialogContentSelector = ".cmp-image__editor";
@@ -539,7 +539,7 @@
                             }
                         }
                     }
-176
+
                     if (mutation.attributeName === "disabled") {
                         if ($(altInputSelector).val()) {
                             if (alertIcon.length) {


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2523 
| Patch: Bug Fix?          | ✅ 
| Minor: New Feature?      | 
| Major: Breaking Change?  | 
| Tests Added + Pass?      | N/A
| Documentation Provided   | ✅ Yes (code comments)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Fix the image dialog validation logic per #2523. 
- Checking "Don't provide an alternative text" should prevent an error message from showing under alt when done editing.
- Checking "Inherit from description of asset" should also prevent an error message.