### PR TITLE
Add support for Google data layer

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/DataLayerConfig.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/DataLayerConfig.java
@@ -24,6 +24,8 @@ import org.apache.sling.caconfig.annotation.Property;
 @Configuration(label="Data Layer", description="Configure support for Adobe Client Data Layer")
 public @interface DataLayerConfig {
 
+    String DATALAYER_OBJECT_NAME_ADOBE = "adobeDataLayer";
+
     /**
      *
      * @return {@code true} if the data layer is enabled, {@code false} otherwise. It defaults to {@code false}.
@@ -38,5 +40,30 @@ public @interface DataLayerConfig {
      */
     @Property(label="Data Layer client library not included")
     boolean skipClientlibInclude() default false;
+
+    /**
+     *
+     * @return the name of the datalayer
+     * Defaults to adobeDataLayer.
+     */
+    @Property(label = "Data Layer object name")
+    String name() default DATALAYER_OBJECT_NAME_ADOBE;
+
+    /**
+     *
+     * @return the type of push function (push() or gtag()) of the datalayer
+     * Defaults to push.
+     */
+    @Property(label = "Use gtag function to push data")
+    boolean pushFunctionUseGtag() default false;
+
+    /**
+     *
+     * @return ACDL library not included
+     * Defaults to false.
+     */
+    @Property(label = "ACDL library not included")
+    boolean skipAcdlInclude() default false;
+
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImpl.java
@@ -17,6 +17,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v3;
 
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.caconfig.ConfigurationBuilder;
 import org.apache.sling.models.annotations.Exporter;
@@ -64,5 +65,34 @@ public class PageImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     protected NavigationItem newRedirectItem(@NotNull String redirectTarget, @NotNull SlingHttpServletRequest request, @NotNull LinkManager linkManager) {
         return new RedirectItemImpl(redirectTarget, request, linkManager);
     }
+
+    @Override
+    @JsonIgnore
+    public String getDataLayerName() {
+        String name = getDataLayerConfig().map(DataLayerConfig::name)
+            .orElse("");
+        return StringUtils.isEmpty(name) ? DataLayerConfig.DATALAYER_OBJECT_NAME_ADOBE : name;
+    }
+
+
+    private Optional<DataLayerConfig> getDataLayerConfig() {
+        return Optional.ofNullable(resource.adaptTo(ConfigurationBuilder.class))
+            .map(builder -> builder.as(DataLayerConfig.class));
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isDataLayerUseGtag() {
+        return getDataLayerConfig().map(config -> config.pushFunctionUseGtag())
+            .orElse(false);
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isDataLayerSkipAcdlInclude() {
+        return getDataLayerConfig().map(config -> config.skipAcdlInclude())
+            .orElse(false);
+    }
+
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Component.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Component.java
@@ -64,7 +64,7 @@ public interface Component extends ComponentExporter {
     default ComponentData getData() {
         return null;
     }
-    
+
     /**
      * Returns the style system information associated with the component
      *

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Page.java
@@ -38,6 +38,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 @ConsumerType
 public interface Page extends ContainerExporter, Component {
 
+    String DATALAYER_OBJECT_NAME_ADOBE = "adobeDataLayer";
+
     /**
      * Key used for the regular favicon file.
      *
@@ -467,4 +469,27 @@ public interface Page extends ContainerExporter, Component {
      */
     default boolean isDataLayerClientlibIncluded() {return true;}
 
+    /**
+     * Returns the name of the data layer.
+     *
+     * {@code true} if the data layer client library should be included.
+     * @since om.adobe.cq.wcm.core.components.models 12.24.0
+     */
+    default String getDataLayerName() { return DATALAYER_OBJECT_NAME_ADOBE; }
+
+    /**
+     * Checks if gtag() should be used to push to the data layer.
+     *
+     * {@code true} if gtag() should be used.
+     * @since om.adobe.cq.wcm.core.components.models 12.24.0
+     */
+    default boolean isDataLayerUseGtag() { return false; };
+
+    /**
+     * Checks if the ACDL library should be included.
+     *
+     * {@code true} if ACDL library should be used.
+     * @since om.adobe.cq.wcm.core.components.models 12.24.0
+     */
+    default boolean isDataLayerSkipAcdlInclude() { return false; };
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/DataLayerSupplier.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/DataLayerSupplier.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.wcm.core.components.models.datalayer.AssetData;
 import com.adobe.cq.wcm.core.components.models.datalayer.ContentFragmentData;
-import com.adobe.cq.wcm.core.components.models.datalayer.EmbeddableData;
 
 /**
  * Data layer field value supplier.

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/Utils.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/Utils.java
@@ -156,7 +156,30 @@ public class Utils {
      * @param enabled {@code true} to enable the data layer, {@code false} to disable it
      */
     public static void enableDataLayer(AemContext context, boolean enabled) {
-        configureDataLayer(context, enabled, false);
+        configureDataLayer(context, enabled, false, "adobeDataLayer", false);
+    }
+
+    /**
+     * Sets the data layer context aware configuration of the AEM test context to enable the data layer, including a configured name.
+     *
+     * @param context The AEM test context
+     * @param enabled {@code true} to enable the data layer, {@code false} to disable it
+     * @param name a configured name for the data layer
+     */
+    public static void enableDataLayer(AemContext context, boolean enabled, String name) {
+        configureDataLayer(context, enabled, false, name, false);
+    }
+
+    /**
+     * Sets the data layer context aware configuration of the AEM test context to enable the data layer, including a configured name and choice of push function.
+     *
+     * @param context The AEM test context
+     * @param enabled {@code true} to enable the data layer, {@code false} to disable it
+     * @param name a configured name for the data layer
+     * @param useGtag {@code true} to push to the datalayer using gtag(), {@code false} to use push()
+     */
+    public static void enableDataLayer(AemContext context, boolean enabled, String name, boolean useGtag) {
+        configureDataLayer(context, enabled, false, name, useGtag);
     }
 
     /**
@@ -166,14 +189,27 @@ public class Utils {
      * @param skip {@code true} to not include the data layer clientlib, {@code false} to include it
      */
     public static void skipDataLayerInclude(AemContext context, boolean skip) {
-        configureDataLayer(context, true, skip);
+        configureDataLayer(context, true, skip, "adobeDataLayer", false);
     }
 
-    private static void configureDataLayer(AemContext context, boolean enabled, boolean skip) {
+    /**
+     * Sets the data layer context aware configuration of the AEM test context to not include the data layer clientlib, including the option to skip the clientlib includes.
+     *
+     * @param context The AEM test context
+     * @param enabled {@code true} to enable the data layer, {@code false} to disable it
+     * @param skip {@code true} to not include the data layer clientlib, {@code false} to include it
+     */
+    public static void configureDataLayer(AemContext context, boolean enabled, boolean skip) {
+        configureDataLayer(context,enabled,skip,"adobeDataLayer", false);
+    }
+
+    public static void configureDataLayer(AemContext context, boolean enabled, boolean skip, String name, boolean useGtag) {
         ConfigurationBuilder builder = Mockito.mock(ConfigurationBuilder.class);
         DataLayerConfig dataLayerConfig = Mockito.mock(DataLayerConfig.class);
         lenient().when(dataLayerConfig.enabled()).thenReturn(enabled);
         lenient().when(dataLayerConfig.skipClientlibInclude()).thenReturn(skip);
+        lenient().when(dataLayerConfig.name()).thenReturn(name);
+        lenient().when(dataLayerConfig.pushFunctionUseGtag()).thenReturn(useGtag);
         lenient().when(builder.as(DataLayerConfig.class)).thenReturn(dataLayerConfig);
         context.registerAdapter(Resource.class, ConfigurationBuilder.class, builder);
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v3/PageImplTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.adobe.cq.wcm.core.components.models.Page;
 
+import static com.adobe.cq.wcm.core.components.Utils.configureDataLayer;
 import static com.adobe.cq.wcm.core.components.Utils.skipDataLayerInclude;
 import static com.adobe.cq.wcm.core.components.internal.link.LinkTestUtils.assertValidLink;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -111,4 +112,31 @@ public class PageImplTest extends com.adobe.cq.wcm.core.components.internal.mode
         assertTrue(page.isDataLayerClientlibIncluded(), "The data layer clientlib should be included.");
     }
 
+    @Test
+    protected void testIsDataLayerName_caconfig_empty() {
+        Page page = getPageUnderTest(PAGE);
+        configureDataLayer(context,false, true, "", false);
+        assertTrue(page.getDataLayerName().equals("adobeDataLayer"), "The data layer name should be the default adobeDataLayer.");
+    }
+
+    @Test
+    protected void testIsDataLayerName_caconfig_configured() {
+        Page page = getPageUnderTest(PAGE);
+        configureDataLayer(context,false, true, "dataLayer", false);
+        assertTrue(page.getDataLayerName().equals("dataLayer"), "The data layer name should be the configured 'dataLayer'.");
+    }
+
+    @Test
+    protected void testIsDataLayerGtag_caconfig_configured_true() {
+        Page page = getPageUnderTest(PAGE);
+        configureDataLayer(context,false, true, "", true);
+        assertTrue(page.isDataLayerUseGtag(), "The data layer push function should be gtag (true).");
+    }
+
+    @Test
+    protected void testIsDataLayerGtag_caconfig_configured_false() {
+        Page page = getPageUnderTest(PAGE);
+        configureDataLayer(context,false, true, "", false);
+        assertFalse(page.isDataLayerUseGtag(), "The data layer push function should not be gtag (false).");
+    }
 }

--- a/content/clientlib.config.js
+++ b/content/clientlib.config.js
@@ -32,6 +32,18 @@ module.exports = {
                     "src/scripts/datalayer/v1/datalayer.js"
                 ]
             }
+        },
+        {
+            name: "core.wcm.components.commons.datalayer.generic.v1",
+            serializationFormat: "xml",
+            allowProxy: true,
+            jsProcessor: ["default:none", "min:gcc;compilationLevel=whitespace"],
+            assets: {
+                js: [
+                    "src/scripts/datalayer/v1/polyfill.js",
+                    "src/scripts/datalayer/v1/datalayer.js"
+                ]
+            }
         }
     ]
 };

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -167,6 +167,7 @@
                         <exclude>**/node_modules/**</exclude>
                         <!-- Ignore generated datalayer clientlib -->
                         <exclude>**/core.wcm.components.commons.datalayer.v1/**</exclude>
+                        <exclude>**/core.wcm.components.commons.datalayer.generic.v1/**</exclude>
                         <!-- Ignore karma -->
                         <exclude>**/coverage/**</exclude>
                     </excludes>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ******************************************************************************/
+/* global gtag */
 (function() {
     "use strict";
 
@@ -23,6 +24,8 @@
     }
     var dataLayerEnabled;
     var dataLayer;
+    var dataLayerName;
+    var dataLayerUseGtag;
 
     var NS = "cmp";
     var IS = "carousel";
@@ -251,12 +254,18 @@
                     var index = getPreviousIndex();
                     navigate(index);
                     if (dataLayerEnabled) {
-                        dataLayer.push({
-                            event: "cmp:show",
-                            eventInfo: {
+                        if (dataLayerUseGtag) {
+                            gtag("event", "cmp:show", {
                                 path: "component." + getDataLayerId(that._elements.item[index])
-                            }
-                        });
+                            });
+                        } else {
+                            dataLayer.push({
+                                event: "cmp:show",
+                                eventInfo: {
+                                    path: "component." + getDataLayerId(that._elements.item[index])
+                                }
+                            });
+                        }
                     }
                 });
             }
@@ -266,12 +275,18 @@
                     var index = getNextIndex();
                     navigate(index);
                     if (dataLayerEnabled) {
-                        dataLayer.push({
-                            event: "cmp:show",
-                            eventInfo: {
+                        if (dataLayerUseGtag) {
+                            gtag("event", "cmp:show", {
                                 path: "component." + getDataLayerId(that._elements.item[index])
-                            }
-                        });
+                            });
+                        } else {
+                            dataLayer.push({
+                                event: "cmp:show",
+                                eventInfo: {
+                                    path: "component." + getDataLayerId(that._elements.item[index])
+                                }
+                            });
+                        }
                     }
                 });
             }
@@ -566,8 +581,13 @@
                 var removePayload = { component: {} };
                 removePayload.component[carouselId] = { shownItems: undefined };
 
-                dataLayer.push(removePayload);
-                dataLayer.push(updatePayload);
+                if (dataLayerUseGtag) {
+                    gtag("set", removePayload);
+                    gtag("set", updatePayload);
+                } else {
+                    dataLayer.push(removePayload);
+                    dataLayer.push(updatePayload);
+                }
             }
 
             // reset the autoplay transition interval following navigation, if not already hovering the carousel
@@ -590,12 +610,18 @@
             focusWithoutScroll(that._elements["indicator"][index]);
 
             if (dataLayerEnabled) {
-                dataLayer.push({
-                    event: "cmp:show",
-                    eventInfo: {
+                if (dataLayerUseGtag) {
+                    gtag("event", "cmp:show", {
                         path: "component." + getDataLayerId(that._elements.item[index])
-                    }
-                });
+                    });
+                } else {
+                    dataLayer.push({
+                        event: "cmp:show",
+                        eventInfo: {
+                            path: "component." + getDataLayerId(that._elements.item[index])
+                        }
+                    });
+                }
             }
         }
 
@@ -679,7 +705,10 @@
      */
     function onDocumentReady() {
         dataLayerEnabled = document.body.hasAttribute("data-cmp-data-layer-enabled");
-        dataLayer = (dataLayerEnabled) ? window.adobeDataLayer = window.adobeDataLayer || [] : undefined;
+        dataLayerName = document.body.getAttribute("data-cmp-data-layer-name");
+        dataLayerUseGtag = typeof gtag === "function" && document.body.hasAttribute("data-cmp-data-layer-use-gtag");
+        dataLayerName = dataLayerName || "adobeDataLayer";
+        dataLayer = window[dataLayerName];
 
         var elements = document.querySelectorAll(selectors.self);
         for (var i = 0; i < elements.length; i++) {

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/headlibs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/headlibs.html
@@ -26,5 +26,12 @@
     <sly data-sly-test="${clientLibCategoriesJsHead}" data-sly-call="${clientlib.js @ categories=clientLibCategoriesJsHead, async=page.isClientlibsAsync}"></sly>
     <sly data-sly-test="${clientLibCategories}" data-sly-call="${clientlib.css @ categories=clientLibCategories}"></sly>
     <link data-sly-test="${staticDesignPath}" href="${staticDesignPath}" rel="stylesheet" type="text/css" />
-    <sly data-sly-test="${page.data && page.dataLayerClientlibIncluded}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.v1', async=true}"></sly>
+    <sly data-sly-test="${!page.dataLayerSkipAcdlInclude}">
+        <sly data-sly-test="${page.data && page.dataLayerClientlibIncluded}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.v1', async=true}"></sly>
+    </sly>
+    <sly data-sly-test="${page.dataLayerSkipAcdlInclude}">
+        <sly data-sly-test="${page.data && page.dataLayerClientlibIncluded}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.generic.v1', async=true}"></sly>
+    </sly>
+</sly>
+
 </template>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/page.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/page.html
@@ -24,16 +24,27 @@
           id="${page.id}"
           data-cmp-link-accessibility-enabled
           data-cmp-link-accessibility-text="${'opens in a new tab' @ i18n}"
-          data-cmp-data-layer-enabled="${page.data ? true : false}">
+          data-cmp-data-layer-enabled="${page.data ? true : false}"
+          data-cmp-data-layer-name="${page.dataLayerName @ context='scriptToken'}"
+          data-cmp-data-layer-use-gtag="${page.dataLayerUseGtag ? true : false}">
         <script data-sly-test.dataLayerEnabled="${page.data}">
-          window.adobeDataLayer = window.adobeDataLayer || [];
-          adobeDataLayer.push({
+          var dataLayerName = '${page.dataLayerName @ context="scriptToken"}' || 'adobeDataLayer';
+          var dataLayerUseGtagString = '${page.dataLayerUseGtag @ context="scriptToken"}';
+          var dataLayerUseGtag = typeof gtag === "function" &&  dataLayerUseGtagString === "true";
+          window[dataLayerName] = window[dataLayerName]  || [];
+          if (dataLayerUseGtag) {
+              gtag("event", "cmp:show", {
+                  page: JSON.parse("${page.data.json @ context='scriptString'}"),
+                  path: 'page.${page.id @ context="scriptString"}'
+              });
+          } else {
+          window[dataLayerName].push({
               page: JSON.parse("${page.data.json @ context='scriptString'}"),
               event:'cmp:show',
               eventInfo: {
                   path: 'page.${page.id @ context="scriptString"}'
               }
-          });
+          }); }
         </script>
         <sly data-sly-test.isRedirectPage="${page.redirectTarget && (wcmmode.edit || wcmmode.preview)}"
              data-sly-call="${redirect.redirect @ redirectTarget = page.redirectTarget}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/clientlibs/site/js/text.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/clientlibs/site/js/text.js
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ******************************************************************************/
+/* global gtag */
 (function() {
     "use strict";
 
     var dataLayerEnabled;
     var dataLayer;
+    var dataLayerUseGtag;
+    var dataLayerName;
 
     /**
      * Adds Click Event Listener to the main <div> of the Text Components
@@ -41,13 +44,20 @@
         var componentId = getDataLayerId(element);
 
         if (event.target.tagName === "A") {
-            dataLayer.push({
-                event: "cmp:click",
-                eventInfo: {
+            if (dataLayerUseGtag) {
+                gtag("event", "cmp:click", {
                     path: "component." + componentId,
                     link: event.target.getAttribute("href")
-                }
-            });
+                });
+            } else {
+                dataLayer.push({
+                    event: "cmp:click",
+                    eventInfo: {
+                        path: "component." + componentId,
+                        link: event.target.getAttribute("href")
+                    }
+                });
+            }
         }
 
     }
@@ -72,7 +82,10 @@
 
     function onDocumentReady() {
         dataLayerEnabled = document.body.hasAttribute("data-cmp-data-layer-enabled");
-        dataLayer = (dataLayerEnabled) ? window.adobeDataLayer = window.adobeDataLayer || [] : undefined;
+        dataLayerName = document.body.getAttribute("data-cmp-data-layer-name");
+        dataLayerUseGtag = typeof gtag === "function" && document.body.hasAttribute("data-cmp-data-layer-use-gtag");
+        dataLayerName = dataLayerName || "adobeDataLayer";
+        dataLayer = (dataLayerEnabled) ? window[dataLayerName] = window[dataLayerName]  || [] : undefined;
 
         if (dataLayerEnabled) {
             addClickEventListenerToTextComponents();

--- a/content/src/scripts/datalayer/v1/datalayer.js
+++ b/content/src/scripts/datalayer/v1/datalayer.js
@@ -13,16 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ******************************************************************************/
+/* global gtag */
 (function() {
     "use strict";
 
     var dataLayerEnabled;
+    var dataLayerName;
+    var dataLayerUseGtag;
     var dataLayer;
 
     function addComponentToDataLayer(component) {
-        dataLayer.push({
-            component: getComponentObject(component)
-        });
+        if (dataLayerUseGtag) {
+            gtag("set", { component: getComponentObject(component) });
+        } else {
+            dataLayer.push({
+                component: getComponentObject(component)
+            });
+        }
     }
 
     function attachClickEventListener(element) {
@@ -47,12 +54,18 @@
         var element = event.currentTarget;
         var componentId = getClickId(element);
 
-        dataLayer.push({
-            event: "cmp:click",
-            eventInfo: {
+        if (dataLayerUseGtag) {
+            gtag("event", "cmp:click", {
                 path: "component." + componentId
-            }
-        });
+            });
+        } else {
+            dataLayer.push({
+                event: "cmp:click",
+                eventInfo: {
+                    path: "component." + componentId
+                }
+            });
+        }
     }
 
     function getComponentData(element) {
@@ -76,7 +89,10 @@
 
     function onDocumentReady() {
         dataLayerEnabled = document.body.hasAttribute("data-cmp-data-layer-enabled");
-        dataLayer        = (dataLayerEnabled) ? window.adobeDataLayer = window.adobeDataLayer || [] : undefined;
+        dataLayerName = document.body.getAttribute("data-cmp-data-layer-name");
+        dataLayerUseGtag = typeof gtag === "function" && document.body.hasAttribute("data-cmp-data-layer-use-gtag");
+        dataLayerName = dataLayerName || "adobeDataLayer";
+        dataLayer = (dataLayerEnabled) ? window[dataLayerName] = window[dataLayerName]  || [] : undefined;
 
         if (dataLayerEnabled) {
 
@@ -91,9 +107,13 @@
                 attachClickEventListener(element);
             });
 
-            dataLayer.push({
-                event: "cmp:loaded"
-            });
+            if (dataLayerUseGtag) {
+                gtag("event", "cmp:loaded");
+            } else {
+                dataLayer.push({
+                    event: "cmp:loaded"
+                });
+            }
         }
     }
 


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | None
| Patch: Bug Fix?          | None
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes
| Any Dependency Changes?  | Yes, data layer read me
| License                  | Apache License, Version 2.0

The PR adds code to:

Make the name of the data layer configurable
Option to exclude ACDL but keep the other logic
Option to push to a datalayer using the gtag() function instead of push()
Modified unit tests

Please see the updated documentation in DATA_LAYER_INTEGRATION.md
