### PR TITLE
[2606] Fixed Non-deterministic behavior of HashSet that might fail the test ClientLibrariesImplTest

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
@@ -297,7 +297,7 @@ public class ClientLibrariesImpl implements ClientLibraries {
     @NotNull
     protected Set<String> getCategoriesFromComponents() {
         try (ResourceResolver resourceResolver = resolverFactory.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, COMPONENTS_SERVICE))) {
-            Set<String> categories = new HashSet<>();
+            Set<String> categories = new LinkedHashSet<>();
             for (ClientLibrary library : this.getAllClientLibraries(resourceResolver)) {
                 for (String category : library.getCategories()) {
                     if (pattern == null || pattern.matcher(category).matches()) {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
@@ -53,6 +53,7 @@ import com.day.cq.wcm.api.PageManager;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -456,12 +457,18 @@ class ClientLibrariesImplTest {
             add("core/wcm/components/carousel/v3/carousel");
         }});
         ClientLibraries clientlibs = getClientLibrariesUnderTest(ROOT_PAGE, attributes);
-        StringBuilder includes = new StringBuilder();
-        includes.append(jsIncludes.get(ACCORDION_CATEGORY));
-        includes.append(jsIncludes.get(CAROUSEL_CATEGORY));
-        includes.append(cssIncludes.get(ACCORDION_CATEGORY));
-        includes.append(cssIncludes.get(CAROUSEL_CATEGORY));
-        assertEquals(includes.toString(), clientlibs.getJsAndCssIncludes());
+        String actual = clientlibs.getJsAndCssIncludes();
+        StringBuilder includes1 = new StringBuilder();
+        includes1.append(jsIncludes.get(ACCORDION_CATEGORY));
+        includes1.append(jsIncludes.get(CAROUSEL_CATEGORY));
+        includes1.append(cssIncludes.get(ACCORDION_CATEGORY));
+        includes1.append(cssIncludes.get(CAROUSEL_CATEGORY));
+        StringBuilder includes2 = new StringBuilder();
+        includes2.append(jsIncludes.get(CAROUSEL_CATEGORY));
+        includes2.append(jsIncludes.get(ACCORDION_CATEGORY));
+        includes2.append(cssIncludes.get(CAROUSEL_CATEGORY));
+        includes2.append(cssIncludes.get(ACCORDION_CATEGORY));
+        assertTrue((includes1.toString().equals(actual)) || (includes2.toString().equals(actual)));
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImplTest.java
@@ -53,7 +53,6 @@ import com.day.cq.wcm.api.PageManager;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -457,18 +456,12 @@ class ClientLibrariesImplTest {
             add("core/wcm/components/carousel/v3/carousel");
         }});
         ClientLibraries clientlibs = getClientLibrariesUnderTest(ROOT_PAGE, attributes);
-        String actual = clientlibs.getJsAndCssIncludes();
-        StringBuilder includes1 = new StringBuilder();
-        includes1.append(jsIncludes.get(ACCORDION_CATEGORY));
-        includes1.append(jsIncludes.get(CAROUSEL_CATEGORY));
-        includes1.append(cssIncludes.get(ACCORDION_CATEGORY));
-        includes1.append(cssIncludes.get(CAROUSEL_CATEGORY));
-        StringBuilder includes2 = new StringBuilder();
-        includes2.append(jsIncludes.get(CAROUSEL_CATEGORY));
-        includes2.append(jsIncludes.get(ACCORDION_CATEGORY));
-        includes2.append(cssIncludes.get(CAROUSEL_CATEGORY));
-        includes2.append(cssIncludes.get(ACCORDION_CATEGORY));
-        assertTrue((includes1.toString().equals(actual)) || (includes2.toString().equals(actual)));
+        StringBuilder includes = new StringBuilder();
+        includes.append(jsIncludes.get(ACCORDION_CATEGORY));
+        includes.append(jsIncludes.get(CAROUSEL_CATEGORY));
+        includes.append(cssIncludes.get(ACCORDION_CATEGORY));
+        includes.append(cssIncludes.get(CAROUSEL_CATEGORY));
+        assertEquals(includes.toString(), clientlibs.getJsAndCssIncludes());
     }
 
     @Test


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes [`#2606`](https://github.com/adobe/aem-core-wcm-components/issues/2606)
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Tests Pass
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
- Since the non-deterministic order of `HashSet` causes the issue, we need to make it deterministic.
- This is done by changing the implementation of `categories` from `HashSet` to `LinkedHashSet`. 
- This ensures that the order of elements is maintained in their order of insertion similar to
https://github.com/adobe/aem-core-wcm-components/blob/0efca91f4b7b5f56a02fefabbdec273c8b77ffd8/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java#L324
