### PR TITLE
[2620] fix datalayer skipClientlibInclude logic

### DIFF
--- a/content/clientlib.config.js
+++ b/content/clientlib.config.js
@@ -28,8 +28,18 @@ module.exports = {
             assets: {
                 js: [
                     "src/scripts/datalayer/v1/polyfill.js",
-                    "node_modules/@adobe/adobe-client-data-layer/dist/adobe-client-data-layer.min.js",
                     "src/scripts/datalayer/v1/datalayer.js"
+                ]
+            }
+        },
+        {
+            name: "core.wcm.components.commons.datalayer.acdl",
+            serializationFormat: "xml",
+            allowProxy: true,
+            jsProcessor: ["default:none", "min:gcc;compilationLevel=whitespace"],
+            assets: {
+                js: [
+                    "node_modules/@adobe/adobe-client-data-layer/dist/adobe-client-data-layer.min.js"
                 ]
             }
         }

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -167,6 +167,7 @@
                         <exclude>**/node_modules/**</exclude>
                         <!-- Ignore generated datalayer clientlib -->
                         <exclude>**/core.wcm.components.commons.datalayer.v1/**</exclude>
+                        <exclude>**/core.wcm.components.commons.datalayer.acdl/**</exclude>
                         <!-- Ignore karma -->
                         <exclude>**/coverage/**</exclude>
                     </excludes>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/footer.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/footer.html
@@ -21,6 +21,7 @@
     <sly data-sly-resource="${'cloudservices' @ resourceType='cq/cloudserviceconfigs/components/servicecomponents'}"></sly>
     <sly data-sly-test="${page.hasCloudconfigSupport}" data-sly-resource="${'cloudconfig-footer' @ resourceType='cq/cloudconfig/components/scripttags/footer'}"></sly>
     <sly data-sly-test="${page.data}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.v1'}"></sly>
+    <sly data-sly-test="${page.data}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.acdl'}"></sly>
     <sly data-sly-list="${page.htmlPageItems}"><script data-sly-test="${item.location.name == 'footer'}"
             data-sly-element="${item.element.name @ context='unsafe'}" data-sly-attribute="${item.attributes}"></script>
     </sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/headlibs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/headlibs.html
@@ -26,5 +26,6 @@
     <sly data-sly-test="${clientLibCategoriesJsHead}" data-sly-call="${clientlib.js @ categories=clientLibCategoriesJsHead, async=page.isClientlibsAsync}"></sly>
     <sly data-sly-test="${clientLibCategories}" data-sly-call="${clientlib.css @ categories=clientLibCategories}"></sly>
     <link data-sly-test="${staticDesignPath}" href="${staticDesignPath}" rel="stylesheet" type="text/css" />
-    <sly data-sly-test="${page.data && page.dataLayerClientlibIncluded}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.v1', async=true}"></sly>
+    <sly data-sly-test="${page.data}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.v1', async=true}"/>
+    <sly data-sly-test="${page.data && page.dataLayerClientlibIncluded}" data-sly-call="${clientlib.js @ categories='core.wcm.components.commons.datalayer.acdl', async=true}"/>
 </template>


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  Fixes #2620
| Patch: Bug Fix?          |
| Minor: New Feature?      | N
| Major: Breaking Change?  | N
| Tests Added + Pass?      | Yes
| Documentation Provided   | N
| Any Dependency Changes?  | N
| License                  | Apache License, Version 2.0

The fix separates the ACDL library from the file datalayer.js and thereby allows the exclusion of the ACDL while retaining the datalayer.js logic (assuming datalayer is enabled).  

These were previously handled as a single clientlib, core.wcm.components.commons.datalayer.v1 and this could be removed by setting the property skipClientlibInclude in the DataLayerConfig CAC to true.  

With this fix the skipClientlibInclude property now only removes the ACDL, leaving a plain array datalayer with the content provided by datalayer.js.

Please see screenshots in issue #2620 to see the issue

