### PR TITLE
[2608] Fixed Non-deterministic behavior of HashMap that might fail tests using ContentFragment.getExportedElements()

### DIFF
--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentMockAdapter.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentMockAdapter.java
@@ -106,7 +106,7 @@ public class ContentFragmentMockAdapter implements Function<Resource, ContentFra
             model = resource.getResourceResolver().getResource(data.getValueMap().get(PN_MODEL, String.class));
             // for the 'adaptTo' mock below we use the jcr:content child to mimick the real behavior
             modelAdaptee = model.getChild(JCR_CONTENT);
-            // create an element mock for each property on the master node
+            // create an element mock for each property on the master node sorted by property name
             Resource master = resource.getChild(PATH_MASTER);
             for (String name : master.getValueMap().keySet().stream().sorted().collect(Collectors.toList())) {
                 // skip the primary type and content type properties

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentMockAdapter.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentMockAdapter.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -107,7 +108,7 @@ public class ContentFragmentMockAdapter implements Function<Resource, ContentFra
             modelAdaptee = model.getChild(JCR_CONTENT);
             // create an element mock for each property on the master node
             Resource master = resource.getChild(PATH_MASTER);
-            for (String name : master.getValueMap().keySet()) {
+            for (String name : master.getValueMap().keySet().stream().sorted().collect(Collectors.toList())) {
                 // skip the primary type and content type properties
                 if (JcrConstants.JCR_PRIMARYTYPE.equals(name) || name.endsWith("@ContentType")) {
                     continue;


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes [`#2608`](https://github.com/adobe/aem-core-wcm-components/issues/2608)
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Tests Pass
| Documentation Provided   | No (Added Code Comments)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
- Since the change in ordering of elements loaded by `resource.getChild()` when mocking the `ContentFragment` causes the issue, sorting the elements loaded by the resource will solve the issue. 
- Sorting the elements based on the property name ensures that the elements are always returned in a deterministic order.
- I have used `streams().sorted()` to sort the key set, and I have collected the values in `List` to make sure the order remains constant across different runs. 