### PR TITLE
[2611] Fixed Non-deterministic behavior of Class.getDeclaredFields() that might fail test in EmbedUrlProcessorServletTest

### DIFF
--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbedUrlProcessorServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbedUrlProcessorServletTest.java
@@ -32,6 +32,7 @@ import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 public class EmbedUrlProcessorServletTest {
@@ -71,9 +72,11 @@ public class EmbedUrlProcessorServletTest {
     public void testUrlWithRegisteredProvider() throws Exception {
         context.request().setQueryString("url=https://www.pinterest.com/pin/99360735500167749/");
         servlet.doGet(context.request(), context.response());
-        String expectedOutput = "{\"processor\":\"pinterest\",\"options\":{\"pinId\":\"99360735500167749\"}}";
         assertEquals(HttpServletResponse.SC_OK, context.response().getStatus(), "Expected the 200 status code.");
         assertEquals("application/json;charset=utf-8", context.response().getContentType(), "Expected the JSON content type.");
-        assertEquals(expectedOutput, context.response().getOutputAsString(), "Does not match the expected response output.");
+        String expectedOutput1 = "{\"processor\":\"pinterest\",\"options\":{\"pinId\":\"99360735500167749\"}}";
+        String expectedOutput2 = "{\"options\":{\"pinId\":\"99360735500167749\"},\"processor\":\"pinterest\"}";
+        String actualOutput = context.response().getOutputAsString();
+        assertTrue(expectedOutput1.equals(actualOutput) || expectedOutput2.equals(actualOutput), "Does not match the expected response output.");
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbedUrlProcessorServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbedUrlProcessorServletTest.java
@@ -74,10 +74,11 @@ public class EmbedUrlProcessorServletTest {
     public void testUrlWithRegisteredProvider() throws Exception {
         context.request().setQueryString("url=https://www.pinterest.com/pin/99360735500167749/");
         servlet.doGet(context.request(), context.response());
+        String expectedOutput = "{\"processor\":\"pinterest\",\"options\":{\"pinId\":\"99360735500167749\"}}";
         assertEquals(HttpServletResponse.SC_OK, context.response().getStatus(), "Expected the 200 status code.");
         assertEquals("application/json;charset=utf-8", context.response().getContentType(), "Expected the JSON content type.");
         ObjectMapper mapper = new ObjectMapper();
-        JsonNode expected = mapper.readTree("{\"processor\":\"pinterest\",\"options\":{\"pinId\":\"99360735500167749\"}}");
+        JsonNode expected = mapper.readTree(expectedOutput);
         JsonNode actual = mapper.readTree(context.response().getOutputAsString());
         assertEquals(expected, actual, "Does not match the expected response output.");
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbedUrlProcessorServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbedUrlProcessorServletTest.java
@@ -28,11 +28,13 @@ import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.internal.services.embed.PinterestUrlProcessor;
 import com.adobe.cq.wcm.core.components.services.embed.UrlProcessor;
 import com.adobe.cq.wcm.core.components.testing.Utils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(AemContextExtension.class)
 public class EmbedUrlProcessorServletTest {
@@ -74,9 +76,9 @@ public class EmbedUrlProcessorServletTest {
         servlet.doGet(context.request(), context.response());
         assertEquals(HttpServletResponse.SC_OK, context.response().getStatus(), "Expected the 200 status code.");
         assertEquals("application/json;charset=utf-8", context.response().getContentType(), "Expected the JSON content type.");
-        String expectedOutput1 = "{\"processor\":\"pinterest\",\"options\":{\"pinId\":\"99360735500167749\"}}";
-        String expectedOutput2 = "{\"options\":{\"pinId\":\"99360735500167749\"},\"processor\":\"pinterest\"}";
-        String actualOutput = context.response().getOutputAsString();
-        assertTrue(expectedOutput1.equals(actualOutput) || expectedOutput2.equals(actualOutput), "Does not match the expected response output.");
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode expected = mapper.readTree("{\"processor\":\"pinterest\",\"options\":{\"pinId\":\"99360735500167749\"}}");
+        JsonNode actual = mapper.readTree(context.response().getOutputAsString());
+        assertEquals(expected, actual, "Does not match the expected response output.");
     }
 }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes [`#2611`](https://github.com/adobe/aem-core-wcm-components/issues/2611)
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Tests Pass
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
- This fix implements the 1st proposed solution mentioned in the [issue](https://github.com/adobe/aem-core-wcm-components/issues/2611).
- The json strings to be compared are converted to `JsonNode` using `ObjectMapper`.
- Comparing with JsonNodes instead of hardcoded strings make sure the correct key value pair are present, even though the order of keys might change. 