### PR TITLE
aem-mock-plugin: Register LatestVersionImplementationPicker by default for unit tests

### DIFF
--- a/testing/aem-mock-plugin/src/main/java/com/adobe/cq/wcm/core/components/testing/mock/ContextPlugins.java
+++ b/testing/aem-mock-plugin/src/main/java/com/adobe/cq/wcm/core/components/testing/mock/ContextPlugins.java
@@ -20,6 +20,7 @@ import org.apache.sling.testing.mock.osgi.context.ContextPlugin;
 import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.wcm.core.components.internal.link.DefaultPathProcessor;
+import com.adobe.cq.wcm.core.components.internal.services.LatestVersionImplementationPicker;
 
 import io.wcm.testing.mock.aem.context.AemContextImpl;
 
@@ -49,7 +50,10 @@ public final class ContextPlugins {
     static void setUp(AemContextImpl context) {
 
         // register default path processor for core components link handling
-        context.registerInjectActivateService(new DefaultPathProcessor());
+        context.registerInjectActivateService(DefaultPathProcessor.class);
+
+        // sling models implementation picker for core component-specific version preferences
+        context.registerInjectActivateService(LatestVersionImplementationPicker.class);
 
     }
 


### PR DESCRIPTION
aem-mock-plugin should register by default the Sling Models implementation picker `com.adobe.cq.wcm.core.components.internal.services.LatestVersionImplementationPicker`, which implements a specific behavior for preferring latest versions and customer implementations of models.

this can be relevant for unit tests if this logic which is in place by default at runtime is expected in the unit test as well.