### PR TITLE
SITES-18137: core.wcm.components.core: remove non-test use of Guava

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -372,6 +372,10 @@
             <artifactId>commons-collections</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/Utils.java
@@ -15,6 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -54,7 +55,6 @@ import com.day.cq.wcm.api.Template;
 import com.day.cq.wcm.api.designer.Designer;
 import com.day.cq.wcm.api.designer.Style;
 import com.day.cq.wcm.foundation.AllowedComponentList;
-import com.google.common.collect.ImmutableSet;
 
 import static com.adobe.cq.wcm.core.components.models.Image.PN_ALT_VALUE_FROM_DAM;
 import static com.adobe.cq.wcm.core.components.models.Image.PN_ALT_VALUE_FROM_PAGE_IMAGE;
@@ -65,12 +65,12 @@ public class Utils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
 
-    private static final Set<String> INTERNAL_PARAMETER = ImmutableSet.of(
-            ":formstart",
-            "_charset_",
-            ":redirect",
-            ":cq_csrf_token"
-    );
+    private static final Set<String> INTERNAL_PARAMETER = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+        ":formstart",
+        "_charset_",
+        ":redirect",
+        ":cq_csrf_token"
+    )));
 
     private Utils() {
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/helper/image/AdaptiveImageHelper.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/helper/image/AdaptiveImageHelper.java
@@ -32,7 +32,6 @@ import org.jetbrains.annotations.Nullable;
 
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
-import com.google.common.base.Joiner;
 
 public class AdaptiveImageHelper {
 
@@ -124,12 +123,12 @@ public class AdaptiveImageHelper {
         }
         if (lastModifiedSuffix > 0) {
             suffix = StringUtils.replace(suffix, String.valueOf(lastModifiedSuffix), String.valueOf(lastModifiedEpoch));
-            redirectLocation = Joiner.on('.').join(Text.escapePath(request.getContextPath() + requestPathInfo.getResourcePath()),
-                    requestPathInfo.getSelectorString(), requestPathInfo.getExtension() + Text.escapePath(suffix));
+            redirectLocation = Text.escapePath(request.getContextPath() + requestPathInfo.getResourcePath()) + "." +
+                    requestPathInfo.getSelectorString() + "." + requestPathInfo.getExtension() + Text.escapePath(suffix);
         } else if (request.getResource().isResourceType(IMAGE_RESOURCE_TYPE)) {
-            redirectLocation = Joiner.on('.').join(Text.escapePath(request.getContextPath() + requestPathInfo.getResourcePath()),
-                    requestPathInfo.getSelectorString(), requestPathInfo.getExtension() + "/" + lastModifiedEpoch,
-                    requestPathInfo.getExtension());
+            redirectLocation = Text.escapePath(request.getContextPath() + requestPathInfo.getResourcePath()) + "." +
+                    requestPathInfo.getSelectorString() + "." + requestPathInfo.getExtension() + "/" +
+                    lastModifiedEpoch + "." + requestPathInfo.getExtension();
         } else {
             String resourcePath = request.getPathInfo();
             String extension = FilenameUtils.getExtension(resourcePath);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/LinkHtmlAttributesSerializer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/LinkHtmlAttributesSerializer.java
@@ -17,6 +17,7 @@
 package com.adobe.cq.wcm.core.components.internal.jackson;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -26,14 +27,13 @@ import org.apache.commons.lang3.StringUtils;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.google.common.collect.ImmutableSet;
 
 public class LinkHtmlAttributesSerializer extends StdSerializer<Map<String, String>> {
 
     /**
      * List of the link's ignored html attributes from the Json export.
      */
-    private static final Set<String> IGNORED_HTML_ATTRIBUTES = ImmutableSet.of("href");
+    private static final Set<String> IGNORED_HTML_ATTRIBUTES = Collections.singleton("href");
 
     public LinkHtmlAttributesSerializer() { this(null); }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkImpl.java
@@ -15,6 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.link;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -32,7 +33,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Wraps link information to be used in models.
@@ -148,7 +148,7 @@ public final class LinkImpl<T> implements Link<T> {
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             attributes.putAll(filteredAttributes);
         }
-        return ImmutableMap.copyOf(attributes);
+        return Collections.unmodifiableMap(attributes);
     }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkManagerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkManagerImpl.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import javax.annotation.PostConstruct;
 
+import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -37,7 +38,6 @@ import com.adobe.cq.wcm.core.components.services.link.PathProcessor;
 import com.day.cq.dam.api.Asset;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.designer.Style;
-import com.google.common.collect.ImmutableSet;
 
 import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_URL;
 
@@ -50,7 +50,7 @@ public class LinkManagerImpl implements LinkManager {
      * <code>_self</code> is used in the edit dialog but not listed as allowed here as we do not
      * want to render a target attribute at all when <code>_self</code> is selected.
      */
-    public static final Set<String> VALID_LINK_TARGETS = ImmutableSet.of("_blank", "_parent", "_top");
+    public static final Set<String> VALID_LINK_TARGETS = SetUtils.unmodifiableSet("_blank", "_parent", "_top");
 
     /**
      * Name of the resource property that for redirecting pages will indicate if original page or redirect target page should be returned.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/embeddable/YouTubeImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/embeddable/YouTubeImpl.java
@@ -17,6 +17,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v1.embeddable;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
@@ -45,7 +46,6 @@ import com.day.cq.wcm.api.designer.Style;
 import com.day.cq.wcm.api.policies.ContentPolicy;
 import com.day.cq.wcm.api.policies.ContentPolicyManager;
 import com.day.cq.wcm.commons.policy.ContentPolicyStyle;
-import com.google.common.collect.ImmutableMap;
 
 @Model(
         adaptables = SlingHttpServletRequest.class,
@@ -202,7 +202,7 @@ public class YouTubeImpl extends AbstractComponentImpl implements YouTube {
     @NotNull
     protected EmbeddableData getComponentData() {
         return DataLayerBuilder.extending(super.getComponentData()).asEmbeddable()
-                .withEmbeddableDetails(() -> ImmutableMap.of(PN_VIDEO_ID, videoId))
+                .withEmbeddableDetails(() -> Collections.singletonMap(PN_VIDEO_ID, videoId))
                 .build();
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
@@ -15,14 +15,17 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v2;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.codec.net.URLCodec;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Exporter;
@@ -47,7 +50,6 @@ import com.day.cq.dam.api.DamConstants;
 import com.day.cq.dam.scene7.api.constants.Scene7AssetType;
 import com.day.cq.dam.scene7.api.constants.Scene7Constants;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.google.common.net.UrlEscapers;
 
 /**
  * V2 Image model implementation.
@@ -57,6 +59,27 @@ import com.google.common.net.UrlEscapers;
     resourceType = ImageImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.v1.ImageImpl implements Image {
+
+    //SITES-18137: imitate the exact behavior of com.google.common.net.URL_FRAGMENT_ESCAPER
+    private static final BitSet URL_FRAGMENT_SAFE_CHARS = new BitSet(256);
+
+    static {
+        //alphanumeric characters
+        for(int i = 97; i <= 122; i++) {
+            URL_FRAGMENT_SAFE_CHARS.set(i);
+        }
+        for(int i = 65; i <= 90; i++) {
+            URL_FRAGMENT_SAFE_CHARS.set(i);
+        }
+        for(int i = 48; i <= 57; i++) {
+            URL_FRAGMENT_SAFE_CHARS.set(i);
+        }
+        // safe characters from Guava's URL_FRAGMENT_ESCAPER: -._~!$'()*,;&=@:+/?
+        byte[] nonAlphaNumeric = new byte[] { 45, 46, 95, 126, 33, 36, 39, 40, 41, 42, 44, 59, 38, 61, 64, 58, 43, 47, 63 };
+        for(int i = 0; i < nonAlphaNumeric.length; i++) {
+            URL_FRAGMENT_SAFE_CHARS.set(nonAlphaNumeric[i]);
+        }
+    }
 
     @ValueMapValue(name = "imageModifiers", injectionStrategy = InjectionStrategy.OPTIONAL)
     @Nullable
@@ -187,7 +210,8 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
                     //check DM asset - check for "dam:scene7File" metadata value
                     String dmAssetName = asset.getMetadataValue(Scene7Constants.PN_S7_FILE);
                     if(isDmFeaturesEnabled && (!StringUtils.isEmpty(dmAssetName))){
-                        dmAssetName = UrlEscapers.urlFragmentEscaper().escape(dmAssetName);
+                        //SITES-18137: imitate the exact behavior of com.google.common.net.URL_FRAGMENT_ESCAPER
+                        dmAssetName = new String(URLCodec.encodeUrl(URL_FRAGMENT_SAFE_CHARS, dmAssetName.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
                         //image is DM
                         dmImage = true;
                         useAssetDelivery = false;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
@@ -15,17 +15,14 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v2;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.codec.net.URLCodec;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Exporter;
@@ -43,6 +40,7 @@ import com.adobe.cq.wcm.core.components.commons.link.Link;
 import com.adobe.cq.wcm.core.components.internal.helper.image.AssetDeliveryHelper;
 import com.adobe.cq.wcm.core.components.internal.models.v1.ImageAreaImpl;
 import com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServlet;
+import com.adobe.cq.wcm.core.components.internal.link.LinkUtil;
 import com.adobe.cq.wcm.core.components.models.Image;
 import com.adobe.cq.wcm.core.components.models.ImageArea;
 import com.day.cq.dam.api.Asset;
@@ -59,27 +57,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
     resourceType = ImageImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.v1.ImageImpl implements Image {
-
-    //SITES-18137: imitate the exact behavior of com.google.common.net.URL_FRAGMENT_ESCAPER
-    private static final BitSet URL_FRAGMENT_SAFE_CHARS = new BitSet(256);
-
-    static {
-        //alphanumeric characters
-        for(int i = 97; i <= 122; i++) {
-            URL_FRAGMENT_SAFE_CHARS.set(i);
-        }
-        for(int i = 65; i <= 90; i++) {
-            URL_FRAGMENT_SAFE_CHARS.set(i);
-        }
-        for(int i = 48; i <= 57; i++) {
-            URL_FRAGMENT_SAFE_CHARS.set(i);
-        }
-        // safe characters from Guava's URL_FRAGMENT_ESCAPER: -._~!$'()*,;&=@:+/?
-        byte[] nonAlphaNumeric = new byte[] { 45, 46, 95, 126, 33, 36, 39, 40, 41, 42, 44, 59, 38, 61, 64, 58, 43, 47, 63 };
-        for(int i = 0; i < nonAlphaNumeric.length; i++) {
-            URL_FRAGMENT_SAFE_CHARS.set(nonAlphaNumeric[i]);
-        }
-    }
 
     @ValueMapValue(name = "imageModifiers", injectionStrategy = InjectionStrategy.OPTIONAL)
     @Nullable
@@ -210,8 +187,7 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
                     //check DM asset - check for "dam:scene7File" metadata value
                     String dmAssetName = asset.getMetadataValue(Scene7Constants.PN_S7_FILE);
                     if(isDmFeaturesEnabled && (!StringUtils.isEmpty(dmAssetName))){
-                        //SITES-18137: imitate the exact behavior of com.google.common.net.URL_FRAGMENT_ESCAPER
-                        dmAssetName = new String(URLCodec.encodeUrl(URL_FRAGMENT_SAFE_CHARS, dmAssetName.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+                        dmAssetName = LinkUtil.escapeFragment(dmAssetName);
                         //image is DM
                         dmImage = true;
                         useAssetDelivery = false;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -75,9 +75,6 @@ import com.day.cq.wcm.api.policies.ContentPolicyManager;
 import com.day.cq.wcm.commons.WCMUtils;
 import com.day.cq.wcm.foundation.WCMRenditionPicker;
 import com.day.image.Layer;
-import com.google.common.base.Splitter;
-import com.google.common.collect.Lists;
-import com.google.common.net.HttpHeaders;
 
 import static com.adobe.cq.wcm.core.components.internal.Utils.getWrappedImageResourceWithInheritance;
 import static com.adobe.cq.wcm.core.components.internal.helper.image.AdaptiveImageHelper.IMAGE_RESOURCE_TYPE;
@@ -656,7 +653,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
         response.setContentType(contentType);
         String extension = mimeTypeService.getExtension(contentType);
         String disposition = "svg".equalsIgnoreCase(extension) ? "attachment" : "inline";
-        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, disposition + "; filename=" + URLEncoder.encode(imageName, CharEncoding.UTF_8));
+        response.setHeader("Content-Disposition", disposition + "; filename=" + URLEncoder.encode(imageName, CharEncoding.UTF_8));
         IOUtils.copy(inputStream, response.getOutputStream());
     }
 
@@ -852,7 +849,12 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
         if (StringUtils.isEmpty(selector)) {
             throw new IllegalArgumentException("Expected 1, 2 or 3 selectors instead got empty selector");
         }
-        ArrayList<String> selectorList = Lists.newArrayList(Splitter.on('.').omitEmptyStrings().trimResults().split(selector));
+        ArrayList<String> selectorList = new ArrayList<>();
+        for (String s : selector.split("\\.")) {
+            if (!s.isEmpty()) {
+                selectorList.add(s.trim());
+            }
+        }
         if (selectorList.size() > 3) {
             throw new IllegalArgumentException("Expected 1, 2 or 3 selectors, instead got: " + selectorList.size());
         }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -851,8 +851,9 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
         }
         ArrayList<String> selectorList = new ArrayList<>();
         for (String s : selector.split("\\.")) {
-            if (!s.isEmpty()) {
-                selectorList.add(s.trim());
+            String trimmed = s.trim();
+            if (!trimmed.isEmpty()) {
+                selectorList.add(trimmed);
             }
         }
         if (selectorList.size() > 3) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -727,6 +727,13 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.4</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
                 <version>17.0.0</version>


### PR DESCRIPTION
Resolves #2639 
Added compile dependency to core.wcm.components.core: org.apache.commons:commons-collections4-4.4 
Replaced non-test usages of Guava with JavaSE and Apache Commons.
