### PR TITLE
SITES-19321: Do not show ghost component when no edit mode

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractPanelContainerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractPanelContainerImpl.java
@@ -28,6 +28,7 @@ import com.adobe.cq.wcm.core.components.models.PanelContainer;
 import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import com.adobe.cq.wcm.core.components.util.ComponentUtils;
 
+import com.day.cq.wcm.api.WCMMode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
@@ -49,6 +50,7 @@ public abstract class AbstractPanelContainerImpl extends AbstractContainerImpl i
      * The resource type.
      */
     public static final String RESOURCE_TYPE = "core/wcm/components/panelcontainer/v1/panelcontainer";
+    public static final String GHOST_COMPONENT_RESOURCE_TYPE = "wcm/msm/components/ghost";
 
     /**
      * The active item property.
@@ -85,7 +87,10 @@ public abstract class AbstractPanelContainerImpl extends AbstractContainerImpl i
     @Override
     public final List<PanelContainerItemImpl> getChildren() {
         if (this.panelItems == null) {
+            WCMMode wcmMode = WCMMode.fromRequest(this.request);
+            boolean showGhostComponent = wcmMode == WCMMode.EDIT;
             this.panelItems = ComponentUtils.getChildComponents(this.resource, this.request).stream()
+                .filter(item -> showGhostComponent || !GHOST_COMPONENT_RESOURCE_TYPE.equals(item.getResourceType()))
                 .map(item -> new PanelContainerItemImpl(item, this))
                 .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
         }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes https://jira.corp.adobe.com/browse/SITES-19321
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

Prevent the "ghost" component to be displayed if not EDIT wcm mode