### PR TITLE
SITES-16183 - Testing Release Core Components 2.24.0

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtils.java
@@ -26,6 +26,7 @@ import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObjectBuilder;
 
+import com.adobe.cq.dam.cfm.ElementTemplate;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -300,5 +301,24 @@ public class ContentFragmentUtils {
         }
 
         return componentExporterMap;
+    }
+
+    /**
+     * Returns the {@code metaType} propery of an element in the content fragment model.
+     *
+     * @param element the content element
+     *
+     * @return the meta type of the element
+     */
+    public static String getElementMetaType(ContentElement element) {
+        ElementTemplate elementTemplate = element.adaptTo(ElementTemplate.class);
+        if (elementTemplate != null) {
+            Resource resource = elementTemplate.adaptTo(Resource.class);
+            if (resource != null) {
+                ValueMap valueMap = resource.getValueMap();
+                return valueMap.get("metaType", String.class);
+            }
+        }
+        return null;
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/DAMContentFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/DAMContentFragmentImpl.java
@@ -17,6 +17,11 @@ package com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment;
 
 import java.util.*;
 
+import com.adobe.cq.dam.cfm.ContentElement;
+import com.adobe.cq.dam.cfm.ContentFragment;
+import com.adobe.cq.dam.cfm.ContentFragmentException;
+import com.adobe.cq.dam.cfm.ContentVariation;
+import com.adobe.cq.dam.cfm.FragmentData;
 import org.apache.commons.collections.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
@@ -26,11 +31,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.dam.cfm.ContentElement;
-import com.adobe.cq.dam.cfm.ContentFragment;
-import com.adobe.cq.dam.cfm.ContentFragmentException;
-import com.adobe.cq.dam.cfm.ContentVariation;
-import com.adobe.cq.dam.cfm.FragmentData;
 import com.adobe.cq.dam.cfm.converter.ContentTypeConverter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.internal.ContentFragmentUtils;
@@ -259,8 +259,16 @@ public class DAMContentFragmentImpl implements DAMContentFragment {
             return getData().getContentType();
         }
 
+
         @Override
         public boolean isMultiLine() {
+            String metaType = ContentFragmentUtils.getElementMetaType(element);
+            if ("text-multi".equals(metaType)) {
+                return true;
+            } else if ("text-single".equals(metaType)) {
+                return false;
+            }
+
             String contentType = getContentType();
             // a text element is defined as a single-valued element with a certain content type (e.g. "text/plain",
             // "text/html", "text/x-markdown", potentially others)

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtilsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentUtilsTest.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import javax.json.Json;
 import javax.json.JsonReader;
 
+import com.adobe.cq.dam.cfm.ElementTemplate;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -52,6 +53,7 @@ import static com.adobe.cq.wcm.core.components.internal.ContentFragmentUtils.PN_
 import static com.day.cq.commons.jcr.JcrConstants.JCR_CONTENT;
 import static com.day.cq.commons.jcr.JcrConstants.JCR_TITLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ContentFragmentUtilsTest {
 
@@ -304,6 +306,25 @@ public class ContentFragmentUtilsTest {
         // THEN
         Assertions.assertEquals(componentExporter, exporterMap.get("bar"));
         Assertions.assertEquals(componentExporter, exporterMap.get("qux"));
+    }
+
+    @Test
+    public void testGetElementMetaType() {
+        ContentElement element = Mockito.mock(ContentElement.class);
+        ElementTemplate elementTemplate = Mockito.mock(ElementTemplate.class);
+        Resource resource = Mockito.mock(Resource.class);
+        ValueMap valueMap = new MockValueMap(resource);
+
+        Mockito.when(element.adaptTo(ElementTemplate.class)).thenReturn(elementTemplate);
+        Mockito.when(elementTemplate.adaptTo(Resource.class)).thenReturn(resource);
+        Mockito.when(resource.getValueMap()).thenReturn(valueMap);
+
+        String metaType = ContentFragmentUtils.getElementMetaType(element);
+        assertNull(metaType);
+
+        valueMap.put("metaType", "testMetaType");
+        metaType = ContentFragmentUtils.getElementMetaType(element);
+        assertEquals("testMetaType", metaType);
     }
 
     /**


### PR DESCRIPTION
 * fixed selenium test ContentFragmentIT.testSetSingleElement , where DAMContentFragmentImpl.isMultiline() returned wrong value due to changed underlying CF implementation behaviour


The test ContentFragmentIT.testSetSingleElement() failed with the message:

Content Fragment first element title should be correctly displayed ==> expected: <true> but was: <false>

The content fragment element title was not displayed for a single line text element representing a title because isMultiline() was incorrectly returning true for this element. In that case the component renders the element not as an element but as a paragraph which doesn't display the element title.
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-16183
| Patch: Bug Fix?          | yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
