### PR TITLE
SITES-19937: remove caching in LanguageNavigationSiteRootSelectionStrategy.java

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/seo/LanguageNavigationSiteRootSelectionStrategy.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/seo/LanguageNavigationSiteRootSelectionStrategy.java
@@ -70,15 +70,6 @@ public class LanguageNavigationSiteRootSelectionStrategy implements SiteRootSele
     @Reference
     private LiveRelationshipManager liveRelationshipManager;
 
-    /**
-     * This cache is used to cache subsequent invocations of the interface's public methods for the same object (knowingly accepting a key
-     * comparison using the == operator). It was not intended to cache invocations with equal objects beyond the life time of a single
-     * request for example. This is because the values returned by the {@link SiteRootSelectionStrategy} are likely to be used together,
-     * meaning a consumer will call the public methods of this interface close after each other passing the same {@link Page} object to each
-     * method call. In this case, we don't need to traverse multiple times.
-     */
-    private final WeakHashMap<Page, Optional<Resource>> languageNavigationCache = new WeakHashMap<>();
-
     @Override
     @Nullable
     public Page getSiteRoot(@NotNull Page page) {
@@ -96,15 +87,7 @@ public class LanguageNavigationSiteRootSelectionStrategy implements SiteRootSele
     }
 
     private Optional<Resource> findLanguageNavigation(Page page) {
-        Optional<Resource> resource = languageNavigationCache.get(page);
-        if (resource == null) {
-            resource = findLanguageNavigation(page.getContentResource(), page);
-            if (resource == null || !resource.isPresent()) {
-                resource = Optional.empty();
-            }
-            languageNavigationCache.put(page, resource);
-        }
-        return resource;
+        return findLanguageNavigation(page.getContentResource(), page);
     }
 
     private Optional<Resource> findLanguageNavigation(Resource contentResource, Page containingPage) {


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-19937
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | 
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

The weak hash map cache causes a flaky behaviour eventually leading to accessing a repository object which's session has already been closed.
