### PR TITLE
SITES-20101 - Ignored defaultValue in numberfield of component dialogs

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/form/container/v1/container/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/container/v1/container/_cq_design_dialog/.content.xml
@@ -56,7 +56,6 @@
                             <columns
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
-                                defaultValue=""
                                 fieldDescription="Number of columns in the grid"
                                 fieldLabel="Columns"
                                 min="1"

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/_cq_design_dialog/.content.xml
@@ -74,7 +74,6 @@
                             <columns
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
-                                defaultValue=""
                                 fieldDescription="Number of columns in the grid"
                                 fieldLabel="Columns"
                                 min="1"

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_design_dialog/.content.xml
@@ -33,7 +33,6 @@
                                         <field
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
-                                            defaultValue="{Long}1280"
                                             min="{Long}0"
                                             name="./allowedRenditionWidths"
                                             required="{Boolean}true"/>
@@ -47,8 +46,7 @@
                                         typeHint="Long"
                                         required="{Boolean}true"
                                         min="{Long}0"
-                                        max="{Long}100"
-                                        defaultValue="{Long}82" />
+                                        max="{Long}100"/>
                                     <disableLazyLoading
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_design_dialog/.content.xml
@@ -138,7 +138,6 @@
                                         <field
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
-                                            defaultValue="{Long}1280"
                                             min="{Long}0"
                                             name="./allowedRenditionWidths"
                                             required="{Boolean}true"/>
@@ -152,8 +151,7 @@
                                         typeHint="Long"
                                         required="{Boolean}true"
                                         min="{Long}0"
-                                        max="{Long}100"
-                                        defaultValue="{Long}82" />
+                                        max="{Long}100"/>
                                 </items>
                             </content>
                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/_cq_design_dialog/.content.xml
@@ -119,7 +119,6 @@
                                         name="./resizeWidth"
                                         typeHint="Long"
                                         required="{Boolean}false"
-                                        defaultValue="{Long}1280"
                                         min="{Long}1"
                                         max="{Long}3840"/>
                                     <heading
@@ -143,7 +142,6 @@
                                                 <field
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
-                                                    defaultValue="{Long}1280"
                                                     min="{Long}0"
                                                     name="./allowedRenditionWidths"
                                                     required="{Boolean}true"/>
@@ -170,8 +168,7 @@
                                         typeHint="Long"
                                         required="{Boolean}false"
                                         min="{Long}0"
-                                        max="{Long}100"
-                                        defaultValue="{Long}82" />
+                                        max="{Long}100" />
                                 </items>
                                 <granite:data
                                     jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
 * remove defaultValue of granite/ui/components/coral/foundation/form/numberfield in component dialogs

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-20101
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  | 
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
