### PR TITLE
[SITES-19919] Fixed List (v4) missing teaser image for page with external redirect

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v4/ListImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v4/ListImpl.java
@@ -73,7 +73,7 @@ public class ListImpl extends com.adobe.cq.wcm.core.components.internal.models.v
     private Collection<ListItem> getStaticListItems() {
         Stream<AbstractListItemImpl> itemStream = getStaticItemResourceStream().map(linkResource -> {
             Link link = linkManager.get(linkResource).build();
-            if (LinkManagerImpl.isExternalLink(link.getURL())) {
+            if (LinkManagerImpl.isExternalLink(link.getURL()) && (link.getReference() == null)) {
                 return new ExternalLinkListItemImpl(link, linkResource, getId(), component);
             } else {
                 Object reference = link.getReference();


### PR DESCRIPTION
Jira: https://jira.corp.adobe.com/browse/SITES-19919
There are 3 distinct cases:
* internal page list item
* internal page list item with external redirect
* external page list item

First and third cases were handled correctly
But in the second case the page was treated as external (3rd case) leading to the missing teaser image
The current fix makes sure that in the 2nd case the page is considered internal just like in the 1st case