### PR TITLE
[Carousel] Remove attribut duplication on "previous" button

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/controls.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/controls.html
@@ -19,7 +19,6 @@
         <button class="cmp-carousel__action cmp-carousel__action--previous"
                 type="button"
                 aria-label="${carousel.accessibilityPrevious || 'Previous' @ i18n}"
-                aria-label="${'Previous' @ i18n}"
                 data-cmp-hook-carousel="previous">
             <span class="cmp-carousel__action-icon"></span>
             <span class="cmp-carousel__action-text">${carousel.accessibilityPrevious || 'Previous' @ i18n}</span>


### PR DESCRIPTION
Bug Report

**Current Behavior :** 
In the carousel component, we can define a label and an aria-label attribute on carousel control buttons.
It work well on the "Next" button.
On the "Previous" button, we can change only the label, its aria-label attribut isn't customizable. 
This causes restitution differences for people using assistive tool (like the NVDA screen reader).

**Expected behavior/code :** 
Keep the same behavior for both "Next" and "Previous" control button.

**Environment :**
- AEM 6.5.19
- Core Components version 2.23.4

**Possible Solution :**
Removing the aria-label attribut duplication solve the issue.