### PR TITLE
SITES-20993 - Identifier com.adobe.cq.wcm.core.components.models.ComponentFiles cannot be correctly instantiated by the Use API

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibrariesImpl.java
@@ -44,7 +44,6 @@ import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.RequestAttribute;
-import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentFilesImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentFilesImpl.java
@@ -33,7 +33,7 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
-import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.RequestAttribute;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -55,13 +55,13 @@ public class ComponentFilesImpl implements ComponentFiles {
      */
     public static final String COMPONENTS_SERVICE = "components-service";
 
-    @ScriptVariable(name=OPTION_RESOURCE_TYPES)
+    @RequestAttribute(name=OPTION_RESOURCE_TYPES)
     Object resourceTypes;
 
-    @ScriptVariable(name=OPTION_FILTER_REGEX)
+    @RequestAttribute(name=OPTION_FILTER_REGEX)
     String filterRegex;
 
-    @ScriptVariable(name=OPTION_INHERITED)
+    @RequestAttribute(name=OPTION_INHERITED)
     @Default(booleanValues = OPTION_INHERITED_DEFAULT)
     boolean inherited;
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentFilesImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentFilesImplTest.java
@@ -25,16 +25,15 @@ import java.util.Objects;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.apache.sling.api.scripting.SlingBindings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.ComponentFiles;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
-import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -181,11 +180,9 @@ public class ComponentFilesImplTest {
         Resource resource = context.currentResource(path);
         if (resource != null) {
             if (attributes != null) {
-                SlingBindings slingBindings = (SlingBindings) context.request().getAttribute(SlingBindings.class.getName());
                 for (Map.Entry<String,Object> entry : attributes.entrySet()) {
-                    slingBindings.put(entry.getKey(), entry.getValue());
+                    context.request().setAttribute(entry.getKey(), entry.getValue());
                 }
-                context.request().setAttribute(SlingBindings.class.getName(), slingBindings);
             }
             context.request().setResource(resource);
             return context.request().adaptTo(ComponentFiles.class);

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/head.socialmedia.html
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/page/v1/page/head.socialmedia.html
@@ -1,0 +1,15 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2024 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->

--- a/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/page/amp/v1/AmpPageIT.java
+++ b/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/page/amp/v1/AmpPageIT.java
@@ -1,0 +1,53 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2024 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.it.http.page.amp.v1;
+
+import org.apache.sling.testing.clients.ClientException;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+
+import com.adobe.cq.testing.client.CQClient;
+import com.adobe.cq.testing.junit.assertion.GraniteAssert;
+import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
+import com.adobe.cq.testing.junit.rules.CQRule;
+
+public class AmpPageIT {
+
+    @ClassRule
+    public static final CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
+
+    @Rule
+    public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule, cqBaseClassRule.publishRule);
+
+    @Rule
+    public ErrorCollector collector = new ErrorCollector();
+
+    static CQClient adminAuthor;
+
+    @BeforeClass
+    public static void beforeClass() {
+        adminAuthor = cqBaseClassRule.authorRule.getAdminClient(CQClient.class);
+    }
+
+    @Test
+    public void testAmpVersion() throws ClientException {
+        String content = adminAuthor.doGet("/content/core-components/simple-page/amp-page-v1.amp.html", 200).getContent();
+        GraniteAssert.assertRegExFind(content, "AMP Title");
+    }
+}

--- a/testing/it/it.ui.content/src/content/jcr_root/content/core-components/simple-page/amp-page-v1/.content.xml
+++ b/testing/it/it.ui.content/src/content/jcr_root/content/core-components/simple-page/amp-page-v1/.content.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2024 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:lastModified="{Date}2024-03-29T09:33:24.972+02:00"
+        cq:lastModifiedBy="admin"
+        cq:template="/conf/core-components/settings/wcm/templates/simple-template-v3"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="AMP Page V1"
+        sling:resourceType="core/wcm/extensions/amp/components/page/v1/page"
+        ampMode="pairedAmp"
+        pwaCachestrategy="staleWhileRevalidate"
+        pwaDisplay="standalone"
+        pwaOrientation="any">
+        <root
+            jcr:lastModified="{Date}2022-02-28T21:16:58.722+01:00"
+            jcr:lastModifiedBy="admin"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="core/wcm/components/container/v1/container">
+            <container
+                jcr:created="{Date}2022-02-28T21:39:47.218+01:00"
+                jcr:createdBy="admin"
+                jcr:lastModified="{Date}2022-02-28T21:39:55.841+01:00"
+                jcr:lastModifiedBy="admin"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="core/wcm/components/container/v1/container"
+                layout="responsiveGrid">
+                <title
+                    jcr:created="{Date}2022-02-28T21:41:13.598+01:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2022-02-28T21:41:13.598+01:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="AMP Title"
+                    sling:resourceType="core/wcm/components/title/v3/title"/>
+            </container>
+        </root>
+        <cq:featuredimage
+            jcr:lastModified="{Date}2024-03-29T09:33:24.966+02:00"
+            jcr:lastModifiedBy="admin"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="core/wcm/components/image/v3/image"
+            altValueFromDAM="false"/>
+    </jcr:content>
+</jcr:root>


### PR DESCRIPTION
* Replaced injector annotations
* Added test and test content for AMP page rendering
* Cleanup unused import
* Added empty head.socialmedia.html to avoid error logging in case the custom components do not provide one
