### PR TITLE
[SITES-21038] Core Tabs Component Accessibility Issue - Invalid ARIA attribute value

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
@@ -38,7 +38,7 @@
     </ol>
     <div data-sly-repeat.item="${items}"
          data-sly-resource="${item.resource @ decorationTagName='div'}"
-         id="${item.id}"
+         id="${item.id}-tabpanel"
          role="tabpanel"
          aria-labelledby="${item.id}-tab"
          tabindex="0"


### PR DESCRIPTION
Updating tab panel id value, to have connection with tab item aria-controls value, for passing lighthouse report accessibility successfully  

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
