### PR TITLE
[Breadcrumb] Add lang attribute to foreign language breadcrumb links

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v3/breadcrumb/breadcrumb.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v3/breadcrumb/breadcrumb.html
@@ -23,6 +23,7 @@
     <ol class="cmp-breadcrumb__list"
         itemscope itemtype="http://schema.org/BreadcrumbList"
         data-sly-list.navItem="${breadcrumb.items}">
+        <sly data-sly-set.lang="${navItem.page.properties.contentLang}"/>
         <li class="cmp-breadcrumb__item${navItem.active ? ' cmp-breadcrumb__item--active' : ''}"
             aria-current="${navItem.active ? 'page' : false}"
             data-cmp-data-layer="${navItem.data.json}"
@@ -30,6 +31,8 @@
             <a data-sly-attribute="${navItem.link.htmlAttributes}"
                class="cmp-breadcrumb__item-link"
                itemprop="item"
+               lang="${lang}"
+               hreflang="${lang}"
                data-cmp-clickable="${breadcrumb.data ? true : false}"
                data-sly-unwrap="${navItem.active || !navItem.link.valid}">
                 <span itemprop="name">${navItem.title}</span>


### PR DESCRIPTION
## Feature Request

**Current Behavior** : 
In the breadcrumb, the title of pages written in a foreign language (with a custom language defined in advanced properties) are not well rendered to assistive tool (like the NVDA screen reader)

**Expected behavior/code** : 
Each page title in the breadcrumb should be vocalized in its appropriate language.

**Environment**
- AEM 6.5.19
- Core Components version 2.23.4 - [breadcrumb component v3](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v3/breadcrumb/breadcrumb.html)

**Possible Solution** :
Get the language of each destination page in the properties using
<sly data-sly-set.lang="${navItem.page.properties.contentLang}"/>
Add a conditional lang attribute on the <a> or <span> element when a custom language is defined in advanced property of the page. 
An additional test could be added to display this attribute only when the language attribute of the element is different of the language of the page.

**Additional context** :
WCAG 2.1 : 3.1.2 Language of Parts (https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts) 
WCAG 2.1 : Technique H58 (https://www.w3.org/WAI/WCAG21/Techniques/html/H58)
RGAA 4.1.2 / RAWeb 1 : 8.7.1 https://accessibilite.public.lu/fr/raweb1/criteres.html#test-8-7-1 (in french)
