### PR TITLE
[Button] Improve icon-only button

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/button/v2/button/button.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/button/v2/button/button.html
@@ -21,6 +21,7 @@
         class="cmp-button"
         data-sly-attribute="${button.buttonLink.htmlAttributes}"
         aria-label="${button.accessibilityLabel}"
+        title="${button.text ? '' : button.accessibilityLabel}"
         data-cmp-clickable="${button.data ? true : false}"
         data-cmp-data-layer="${button.data.json}">
     <sly data-sly-call="${iconTemplate.icon @ icon=button.icon}"></sly>


### PR DESCRIPTION
## Feature Request

**Current Behavior** : 
In button component with svg only content, on mousehover there are no way to get a visible label. 
It's ok for known icons like the "burger menu" or the "magnifying glass", but it can be difficult for little-recognized icons.
It's also ok for people using screen reader because an aria-label attribute can be specified on the <button> element.

**Expected behavior/code** : 
To get a visible indication on hover (like the browser hover tooltip) for icon only button.

**Environment**
- AEM 6.5.19
- Core Components version 2.23.4 - [Button composant v2](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/button/v2/button/button.html)

**Possible Solution** :
Add a title attribute on the <button> element. It have to be equal to the aria-label attribute value (to avoid a double vocalisation by the screen reader).
I choose to add it by default when there isn't text content in the button. An alternative is to add a checkbox in the cq_dialog