### PR TITLE
[Navigation] Add role attribute on navigation

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v3/breadcrumb/breadcrumb.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v3/breadcrumb/breadcrumb.html
@@ -19,7 +19,8 @@
      class="cmp-breadcrumb"
      aria-label="${'Breadcrumb' @ i18n}"
      data-sly-test="${breadcrumb.items.size > 0}"
-     data-cmp-data-layer="${breadcrumb.data.json}">
+     data-cmp-data-layer="${breadcrumb.data.json}"
+     role="navigation">
     <ol class="cmp-breadcrumb__list"
         itemscope itemtype="http://schema.org/BreadcrumbList"
         data-sly-list.navItem="${breadcrumb.items}">

--- a/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v2/languagenavigation/languagenavigation.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v2/languagenavigation/languagenavigation.html
@@ -18,9 +18,10 @@
      data-sly-use.groupTemplate="group.html"
      data-sly-call="${groupTemplate.group @ items=languageNavigation.items}"
      data-sly-test.hasContent="${languageNavigation.items.size > 0}"
-	 data-cmp-data-layer="${languageNavigation.data.json}"
+     data-cmp-data-layer="${languageNavigation.data.json}"
      id="${languageNavigation.id}"
      class="cmp-languagenavigation"
-     aria-label="${languageNavigation.accessibilityLabel}">
+     aria-label="${languageNavigation.accessibilityLabel}"
+     role="navigation">
 </nav>
 <sly data-sly-call="${commonsTemplates.placeholder @ isEmpty = !hasContent, classAppend='cmp-languagenavigation'}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v2/navigation/navigation.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v2/navigation/navigation.html
@@ -21,7 +21,8 @@
      id="${navigation.id}"
      class="cmp-navigation"
      itemscope itemtype="http://schema.org/SiteNavigationElement"
-	 data-cmp-data-layer="${navigation.data.json}"
-     aria-label="${navigation.accessibilityLabel}">
+     data-cmp-data-layer="${navigation.data.json}"
+     aria-label="${navigation.accessibilityLabel}"
+     role="navigation">
 </nav>
 <sly data-sly-call="${template.placeholder @ isEmpty=!hasContent, classAppend='cmp-navigation'}"></sly>


### PR DESCRIPTION
## Feature Request

**Current Behavior** : 
In european countries using the French Accessibility Guidelines (RGAA) or the Luxembourg guideline (RAWeb1), a role attribute is mandatory on each landmark.
The reason is to keep a compatibility with old browser (that don't support HTML5) or old version of assistive tools.

**Expected behavior/code** : 
Navigation menu should have an ARIA nav with attribute role="navigation"

**Environment**
- AEM 6.5.19
- Core Components version 2.23.4 ( [Breadcrumb component v3](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v3/breadcrumb/breadcrumb.html), [Language navigation v2](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v2/languagenavigation/languagenavigation.html), [Navigation component v2](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/navigation/v2/navigation/navigation.html) )

**Possible Solution** :
Add a role attribute on each navigation landmarks.

**Additional context** :
WAI wiki : https://www.w3.org/WAI/GL/wiki/Using_HTML5_nav_element#Example:The_.3Cnav.3E_element
RGAA 4.1.2 / RAWeb 1 : 12.6.1 https://accessibilite.public.lu/fr/raweb1/criteres.html#test-12-6-1 (in french)