### PR TITLE
[SITES-21939] Alt Text not persisting in Page Properties for Featured Image

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
@@ -396,9 +396,13 @@
                 // we need to get saved value of 'smartCropRendition' of Core Image component
                 smartCropRenditionFromJcr = data["smartCropRendition"];
             }
+            if (filePath.endsWith("/cq:featuredimage")) {
+                remoteFileReference = data["fileReference"];
+            }
             // we want to call retrieveDAMInfo after loading the dialog so that saved smartcrop rendition of remote asset
-            // can be shown on initial load.
-            if (remoteFileReference && remoteFileReference !== "" && remoteFileReference.includes("urn:aaid:aem")) {
+            // can be shown on initial load. Also adding condition filePath.endsWith("/cq:featuredimage") to trigger alt
+            // update for page properties.
+            if (remoteFileReference && remoteFileReference !== "" && (remoteFileReference.includes("urn:aaid:aem") || filePath.endsWith("/cq:featuredimage"))) {
                 retrieveDAMInfo(remoteFileReference);
             }
         });


### PR DESCRIPTION
Adding additional check, in case we are opening dialog for Page component image section and in that case updating value of remoteFileReference in order to execute retrieveInstanceInfo correctly for page component and update alt text field in dialog 

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://jira.corp.adobe.com/browse/SITES-22145 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
