### PR TITLE
[SITES-22335] js parse error fix 2

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
@@ -196,7 +196,7 @@
         validate: function() {
             var seededValue = document.querySelector(altInputSelector).getAttribute("data-seeded-value");
             var imageFromPageImage = document.querySelector('coral-checkbox[name="./imageFromPageImage"]');
-            var isImageFromPageImageChecked = imageFromPageImage ? imageFromPageImage.checked || false;
+            var isImageFromPageImageChecked = imageFromPageImage ? (imageFromPageImage.checked || false) : false;
             var altFromDAM = document.querySelector('coral-checkbox[name="./altValueFromDAM"]');
             var isAltFromDAMChecked = altFromDAM.checked;
             var isAltFromDAMDisabled = altFromDAM.disabled;

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
@@ -196,7 +196,7 @@
         validate: function() {
             var seededValue = document.querySelector(altInputSelector).getAttribute("data-seeded-value");
             var imageFromPageImage = document.querySelector('coral-checkbox[name="./imageFromPageImage"]');
-            var isImageFromPageImageChecked = imageFromPageImage?.checked || false;
+            var isImageFromPageImageChecked = imageFromPageImage ? imageFromPageImage.checked || false;
             var altFromDAM = document.querySelector('coral-checkbox[name="./altValueFromDAM"]');
             var isAltFromDAMChecked = altFromDAM.checked;
             var isAltFromDAMDisabled = altFromDAM.disabled;


### PR DESCRIPTION
The ?. operator was included in ES2020, which is supported by Node 14 (released in April 2020). But we are currently using ES2015 (see content.xml)

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-22335 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
