### PR TITLE
Fix flaky test

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -534,6 +534,12 @@
             <version>4.7.2</version>
             <scope>compile</scope>
         </dependency>
+          <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
### Description
- Fixed flaky test: com.adobe.cq.wcm.core.components.internal.models.v2.PageImplTest#testPage
- The flakiness was due to the nondeterministic order of key-value pairs of the `JSONObject` returned by `expectedReader.read()` and `outputReader.read()`, thereby causing JUnit's `assertEquals()` method to potentially fail in the `testJSONExport()` method
https://github.com/adobe/aem-core-wcm-components/blob/5f29cc86b17b6db36cc617805295eb951b6504a1/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/PageImplTest.java#L137
https://github.com/adobe/aem-core-wcm-components/blob/5f29cc86b17b6db36cc617805295eb951b6504a1/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/Utils.java#L79
- This proposed method changes JUnit's `assertEquals()` to the `NON_EXTENSIBLE` comparison mode in `JSONAssert.assertEquals()` that matches all key-value pairs without the strict ordering constraint 

### How was this tested?
-  Version of `aem-core-wcm-components`
SHA: [5f29cc](https://github.com/adobe/aem-core-wcm-components/commit/5f29cc86b17b6db36cc617805295eb951b6504a1)
- JVM Version
  ``` 
  openjdk 11.0.24 2024-07-16
  OpenJDK Runtime Environment (build 11.0.24+8-post-Ubuntu-1ubuntu322.04)
  OpenJDK 64-Bit Server VM (build 11.0.24+8-post-Ubuntu-1ubuntu322.04, mixed mode, sharing)
  ```
- The way to reproduce the flaky test failure
  1. Clone the repo:
      ```
      https://github.com/adobe/aem-core-wcm-components
      cd aem-core-wcm-components
      git checkout 5f29cc86b17b6db36cc617805295eb951b6504a1
      ```
  2. Run with [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool
      ```
      mvn install -pl core -am -DskipTests
      mvn -pl bundles/core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.adobe.cq.wcm.core.components.internal.models.v2.PageImplTest#testPage
      ```
  3. Test failure screenshot:
      ![image](https://github.com/user-attachments/assets/9058faa9-167e-4e21-8fce-3636302d4958)



