### PR TITLE
Issue 2516: Wait on Brandslug Override coral checkbox to be ready

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v1/page/clientlibs/editor/js/brandSlugTuple.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v1/page/clientlibs/editor/js/brandSlugTuple.js
@@ -30,13 +30,15 @@
         var $brandSlugTextfield = $(brandSlugTextfieldSelector, $brandSlugSection);
 
         if ($brandSlugCheckbox.length > 0 && $brandSlugTextfield.length > 0) {
-            var inheritedValue = $brandSlugTextfield.data("inheritedValue");
-            var specifiedValue = $brandSlugTextfield.data("specifiedValue");
-            var textfieldFoundation = $brandSlugTextfield.adaptTo("foundation-field");
-            var checkboxFoundation  = $brandSlugCheckbox.adaptTo("foundation-field");
-            changeTextFieldState(textfieldFoundation, checkboxFoundation.getValue() === "true", inheritedValue, specifiedValue);
-            $brandSlugCheckbox.on("change", function() {
-                changeTextFieldState(textfieldFoundation, this.checked, inheritedValue, specifiedValue);
+            $brandSlugCheckbox.on("coral-component:attached", function() {
+                var inheritedValue = $brandSlugTextfield.data("inheritedValue");
+                var specifiedValue = $brandSlugTextfield.data("specifiedValue");
+                var textfieldFoundation = $brandSlugTextfield.adaptTo("foundation-field");
+                var checkboxFoundation  = $brandSlugCheckbox.adaptTo("foundation-field");
+                changeTextFieldState(textfieldFoundation, checkboxFoundation.getValue() === "true", inheritedValue, specifiedValue);
+                $brandSlugCheckbox.on("change", function() {
+                    changeTextFieldState(textfieldFoundation, this.checked, inheritedValue, specifiedValue);
+                });
             });
         }
     });

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/clientlibs/editor/js/brandSlugTuple.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/clientlibs/editor/js/brandSlugTuple.js
@@ -30,13 +30,15 @@
         var $brandSlugTextfield = $(brandSlugTextfieldSelector, $brandSlugSection);
 
         if ($brandSlugCheckbox.length > 0 && $brandSlugTextfield.length > 0) {
-            var inheritedValue = $brandSlugTextfield.data("inheritedValue");
-            var specifiedValue = $brandSlugTextfield.data("specifiedValue");
-            var textfieldFoundation = $brandSlugTextfield.adaptTo("foundation-field");
-            var checkboxFoundation  = $brandSlugCheckbox.adaptTo("foundation-field");
-            changeTextFieldState(textfieldFoundation, checkboxFoundation.getValue() === "true", inheritedValue, specifiedValue);
-            $brandSlugCheckbox.on("change", function() {
-                changeTextFieldState(textfieldFoundation, this.checked, inheritedValue, specifiedValue);
+            $brandSlugCheckbox.on("coral-component:attached", function() {
+                var inheritedValue = $brandSlugTextfield.data("inheritedValue");
+                var specifiedValue = $brandSlugTextfield.data("specifiedValue");
+                var textfieldFoundation = $brandSlugTextfield.adaptTo("foundation-field");
+                var checkboxFoundation  = $brandSlugCheckbox.adaptTo("foundation-field");
+                changeTextFieldState(textfieldFoundation, checkboxFoundation.getValue() === "true", inheritedValue, specifiedValue);
+                $brandSlugCheckbox.on("change", function() {
+                    changeTextFieldState(textfieldFoundation, this.checked, inheritedValue, specifiedValue);
+                });
             });
         }
     });


### PR DESCRIPTION


<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2516  
| Patch: Bug Fix?          |
| Minor: New Feature?      | X
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
A race condition occurred with the "Brandslug Override" Coral checkbox, where interactions were taking place before it was fully ready. Now, interactions will only happen once the Coral component is attached to the DOM.