### PR TITLE
#2853 The AdaptiveImageServlet should send redirects to blobs 

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -634,7 +634,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
                 LOGGER.warn("Found rendition {}/{} has a width of {}px and does not require a resize for requested width of {}px " +
                                 "but the rendition is not of the requested type {}, cannot convert so serving as is",
                         rendition.getAsset().getPath(), rendition.getName(), dimension != null ? dimension.getWidth() : null, resizeWidth, imageType);
-                deliverRendition(response, rendition.getRendition(), imageType, imageName);
+                deliverRendition(response, rendition.getRendition(), rendition.getMimeType(), imageName);
             } else {
                 LOGGER.debug("Found rendition {}/{} has a width of {}px and does not require a resize for requested width of {}px " +
                                 "but the rendition is not of the requested type {}, need to convert",

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -115,6 +115,8 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
     private static final String SELECTOR_WIDTH_KEY = "width";
     private int defaultResizeWidth;
     private int maxInputWidth;
+    
+    protected boolean deliverExistingRenditionsViaRedirect;
 
     private AdaptiveImageServletMetrics metrics;
 
@@ -123,12 +125,13 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
     private transient AssetStore assetStore;
 
     public AdaptiveImageServlet(MimeTypeService mimeTypeService, AssetStore assetStore, AdaptiveImageServletMetrics metrics,
-            int defaultResizeWidth, int maxInputWidth) {
+            int defaultResizeWidth, int maxInputWidth, boolean deliverRenditionsViaRedirect) {
         this.mimeTypeService = mimeTypeService;
         this.assetStore = assetStore;
         this.metrics = metrics;
         this.defaultResizeWidth = defaultResizeWidth > 0 ? defaultResizeWidth : DEFAULT_RESIZE_WIDTH;
         this.maxInputWidth = maxInputWidth > 0 ? maxInputWidth : DEFAULT_MAX_SIZE;
+        this.deliverExistingRenditionsViaRedirect = deliverRenditionsViaRedirect;
     }
 
     @Override
@@ -650,7 +653,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
              String imageName) throws IOException {
         Binary originalBinary = rendition.getBinary();
         final boolean downloadable = (originalBinary instanceof BinaryDownload);
-        if (USE_DELIVERY_VIA_BLOBSTORE && downloadable) {
+        if (this.deliverExistingRenditionsViaRedirect && downloadable) {
             BinaryDownload binaryDownload = (BinaryDownload) originalBinary;
             BinaryDownloadOptions downloadOptions = BinaryDownloadOptions.builder()
                     .withMediaType(rendition.getMimeType())

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumer.java
@@ -171,7 +171,8 @@ public class AdaptiveImageServletMappingConfigurationConsumer {
                                         assetStore,
                                         metrics,
                                         oldAISDefaultResizeWidth > 0 ? oldAISDefaultResizeWidth : config.getDefaultResizeWidth(),
-                                        config.getMaxSize()),
+                                        config.getMaxSize(),
+                                        config.getDeliverExistingRenditionsViaRedirect()),
                                 properties
                         )
                 );

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactory.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactory.java
@@ -80,6 +80,13 @@ public class AdaptiveImageServletMappingConfigurationFactory {
                         "it and will throw an exception, to avoid running out of memory."
         )
         int maxSize() default AdaptiveImageServlet.DEFAULT_MAX_SIZE;
+        
+        
+        @AttributeDefinition(
+                name="Use Redirects",
+                description="If enabled, when an existing rendition can be used, a redirect to download URI of the blob is "
+                    + "sent; otherwise the binary will be streamed")
+        boolean deliverExistingRenditionsViaRedirect() default false;
 
     }
 
@@ -92,6 +99,8 @@ public class AdaptiveImageServletMappingConfigurationFactory {
     private int defaultResizeWidth;
 
     private int maxSize;
+    
+    private boolean deliverExistingRenditionsViaRedirect;
 
     /**
      * Invoked when a configuration is created or modified.
@@ -106,6 +115,7 @@ public class AdaptiveImageServletMappingConfigurationFactory {
         extensions = getValues(config.extensions());
         defaultResizeWidth = config.defaultResizeWidth();
         maxSize = config.maxSize();
+        deliverExistingRenditionsViaRedirect = config.deliverExistingRenditionsViaRedirect();
     }
 
     /**
@@ -154,6 +164,15 @@ public class AdaptiveImageServletMappingConfigurationFactory {
     public int getMaxSize() {
         return maxSize;
     }
+    
+    /**
+     * Indicates if a redirect to existing binary blobs will sent (if possible) or if the result will always be streamed
+     * @return
+     */
+    public boolean getDeliverExistingRenditionsViaRedirect() {
+    	return deliverExistingRenditionsViaRedirect;
+    }
+    
 
     /**
      * Internal helper for filtering out null and empty values from the configuration options.
@@ -175,7 +194,11 @@ public class AdaptiveImageServletMappingConfigurationFactory {
 
     @Override
     public String toString() {
-        return "{resourceTypes: " + resourceTypes.toString() + ", selectors: " + selectors.toString() + ", extensions: " + extensions
-                .toString() + ", defaultResizeWidth: " + defaultResizeWidth + "}";
+    	return String.format("{resourceTypes: %s, selectors: %s, extensions: %s, defaultResizeWidth: %s, deliverExistingRenditionsViaRedirect: %s}",
+    			resourceTypes.toString(),
+    			selectors.toString(),
+    			extensions.toString(),
+    			defaultResizeWidth,
+    			deliverExistingRenditionsViaRedirect);
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactory.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactory.java
@@ -194,11 +194,11 @@ public class AdaptiveImageServletMappingConfigurationFactory {
 
     @Override
     public String toString() {
-    	return String.format("{resourceTypes: %s, selectors: %s, extensions: %s, defaultResizeWidth: %s, deliverExistingRenditionsViaRedirect: %s}",
-    			resourceTypes.toString(),
-    			selectors.toString(),
-    			extensions.toString(),
-    			defaultResizeWidth,
-    			deliverExistingRenditionsViaRedirect);
+        return String.format("{resourceTypes: %s, selectors: %s, extensions: %s, defaultResizeWidth: %s, deliverExistingRenditionsViaRedirect: %s}",
+            resourceTypes.toString(),
+            selectors.toString(),
+            extensions.toString(),
+            defaultResizeWidth,
+            deliverExistingRenditionsViaRedirect);
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactoryTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactoryTest.java
@@ -58,11 +58,16 @@ public class AdaptiveImageServletMappingConfigurationFactoryTest {
             public int maxSize() {
                 return AdaptiveImageServlet.DEFAULT_MAX_SIZE;
             }
+
+            @Override
+            public boolean deliverExistingRenditionsViaRedirect() {
+                return false;
+            } 
         });
         testValues(new String[] {"core/image"}, configurationFactory.getResourceTypes());
         testValues(new String[] {"coreimg"}, configurationFactory.getSelectors());
         testValues(new String[] {"jpg", "gif", "png"}, configurationFactory.getExtensions());
-        assertEquals("{resourceTypes: [core/image], selectors: [coreimg], extensions: [jpg, gif, png], defaultResizeWidth: 1280}",
+        assertEquals("{resourceTypes: [core/image], selectors: [coreimg], extensions: [jpg, gif, png], defaultResizeWidth: 1280, deliverExistingRenditionsViaRedirect: false}", 
                 configurationFactory.toString());
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletTest.java
@@ -45,7 +45,6 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.commons.metrics.Timer;
-import org.apache.sling.event.dea.DEAConstants;
 import org.apache.sling.testing.mock.sling.servlet.MockRequestPathInfo;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -796,7 +796,7 @@
             <dependency>
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
-                <version>5.5.2</version>
+                <version>5.6.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION

| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | Fixes #2853 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

The AdaptiveImageServlet always streams its result through the JVM, even if its an already existing rendition with a matching blob in the blobstore. In AEM CS can delivered more efficiently with sending a redirect to the blobstore, and then the Fastly CDN follows this redirect and pulls the data directly from the blobstore. Then AEM does not need to stream that binary through the JVM.

This patch improves the handling not to stream the binary when possible. The feature is configurable and off by default.


(A word to the tests: In JUnit5 it's not possible to parametrize entire test classes anymore, which would have been my preferred way for the tests. Instead you would have to parametrize the tests on their own. To avoid that I duplicated the tests which were failing with the new  feature turned and tagged the duplicates accordingly. Now the ``setup()`` can initialize the AdaptiveImageServlet accordingly. Happy to learn about a way, which allows to run each tests with the new feature turned off and on, without annotating each test.

Existing tests were not changed, to make sure that all the changes did not affect the default behavior.


