### PR TITLE
#2872 update AEM mocks

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkBuilderImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkBuilderImpl.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -246,7 +247,10 @@ public class LinkBuilderImpl implements LinkBuilder {
      */
     @NotNull
     private String getPageLinkURL(@NotNull Page page) {
-        return page.getPath() + HTML_EXTENSION;
+        Resource resource = page.adaptTo(Resource.class);
+        assert resource!=null;
+        ResourceResolver resolver = resource.getResourceResolver();
+        return resolver.map(page.getPath()) + HTML_EXTENSION;
     }
 
     /**

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/commons/link/LinkManagerTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/commons/link/LinkManagerTest.java
@@ -113,7 +113,7 @@ public class LinkManagerTest {
                 PN_LINK_URL, page.getPath());
         context.currentResource(linkResource);
         Link link = getUnderTest().get(linkResource).build();
-        assertValidLink(link, page.getPath() + ".html");
+        assertValidLink(link, context.resourceResolver().map(page.getPath()) + ".html");
         assertEquals(page, link.getReference());
         assertEquals((page.getPath() + ".html").replaceAll("^\\/content\\/links\\/site1\\/(.+)","/content/site1/$1"),
                 link.getMappedURL());
@@ -142,8 +142,8 @@ public class LinkManagerTest {
     void testPageLink() {
         Link link = getUnderTest().get(page).build();
 
-        assertValidLink(link, page.getPath() + ".html");
-        assertEquals("https://example.org" + page.getPath() + ".html", link.getExternalizedURL());
+        assertValidLink(link, context.resourceResolver().map(page.getPath()) + ".html");
+        assertEquals("https://example.org" + context.resourceResolver().map(page.getPath()) + ".html", link.getExternalizedURL());
         assertEquals(page, link.getReference());
     }
 
@@ -167,7 +167,7 @@ public class LinkManagerTest {
     void testLinkURLPageLinkWithTarget() {
         Link link = getUnderTest().get(page.getPath()).withLinkTarget("_blank").build();
 
-        assertValidLink(link, page.getPath() + ".html", "_blank");
+        assertValidLink(link, context.resourceResolver().map(page.getPath()) + ".html", "_blank");
         assertEquals(page, link.getReference());
     }
 
@@ -198,8 +198,8 @@ public class LinkManagerTest {
         Link link = getUnderTest().get(linkResource).build();
 
         assertTrue(link.isValid());
-        assertValidLink(link, targetPage2.getPath() + ".html");
-        assertEquals("https://example.org" + targetPage2.getPath() + ".html", link.getExternalizedURL());
+        assertValidLink(link, context.resourceResolver().map(targetPage2.getPath()) + ".html");
+        assertEquals("https://example.org" + context.resourceResolver().map(targetPage2.getPath()) + ".html", link.getExternalizedURL());
         assertEquals(targetPage2, link.getReference());
     }
 
@@ -225,8 +225,8 @@ public class LinkManagerTest {
         Link link = getUnderTest().get(linkResource).build();
 
         assertTrue(link.isValid());
-        assertValidLink(link, targetPage1.getPath() + ".html");
-        assertEquals("https://example.org" + targetPage1.getPath() + ".html", link.getExternalizedURL());
+        assertValidLink(link, context.resourceResolver().map(targetPage1.getPath()) + ".html");
+        assertEquals("https://example.org" + context.resourceResolver().map(targetPage1.getPath()) + ".html", link.getExternalizedURL());
         assertEquals(targetPage1, link.getReference());
     }
 
@@ -255,8 +255,8 @@ public class LinkManagerTest {
         Link link = getUnderTest().get(linkResource).build();
 
         assertTrue(link.isValid());
-        assertValidLink(link, targetPage1.getPath() + ".html");
-        assertEquals("https://example.org" + targetPage1.getPath() + ".html", link.getExternalizedURL());
+        assertValidLink(link, context.resourceResolver().map(targetPage1.getPath()) + ".html");
+        assertEquals("https://example.org" + context.resourceResolver().map(targetPage1.getPath()) + ".html", link.getExternalizedURL());
         assertEquals(targetPage1, link.getReference());
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessorTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessorTest.java
@@ -117,7 +117,7 @@ class DefaultPathProcessorTest {
         DefaultPathProcessor underTest = context.registerInjectActivateService(new DefaultPathProcessor(), ImmutableMap.of(
                 "vanityConfig", "shouldBeDefault"));
         assertEquals("/content/site1/en.html", underTest.map(page.getPath() + HTML_EXTENSION, context.request()));
-        assertEquals("https://example.org/content/links/site1/en.html", underTest.externalize(page.getPath() + HTML_EXTENSION, context.request()));
+        assertEquals("https://example.org/content/site1/en.html", underTest.externalize(page.getPath() + HTML_EXTENSION, context.request()));
         context.request().setContextPath("/cp");
         underTest = context.registerInjectActivateService(new DefaultPathProcessor(), ImmutableMap.of(
                 "vanityConfig", DefaultPathProcessor.VanityConfig.ALWAYS.getValue()));

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -796,7 +796,7 @@
             <dependency>
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
-                <version>5.5.2</version>
+                <version>5.6.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | Fixes #2872 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

Update the AEM Mocks to the latest version; due to changes in https://wcm.io/testing/aem-mock/changes-report.html#a5.5.4 I had to adjust a few locations which are using the Externalizer.

To reduce the effort, I have decided to adjust ``LinkBuilder.buildLink`` so it will do a ``ResourceResolver.map()`` call to calculate the ``url`` parameter for the Link. Which is not a problem per see, as it would still meet the constraints of the API. But it's no longer identical to the repository path.

(Doing it differently would require a major overhaul of the test suite of the inner working of ``LinkBuilderImpl`` and ``LinkImpl``.)




