### PR TITLE
SITES-26627 - WCM components examples are not compatible with AEM 6.6

### DIFF
--- a/examples/ui.config/pom.xml
+++ b/examples/ui.config/pom.xml
@@ -144,12 +144,12 @@
         <dependency>
             <groupId>io.wcm</groupId>
             <artifactId>io.wcm.caconfig.editor</artifactId>
-            <version>1.8.6</version>
+            <version>1.16.6</version>
         </dependency>
         <dependency>
             <groupId>io.wcm</groupId>
             <artifactId>io.wcm.caconfig.extensions</artifactId>
-            <version>1.8.6</version>
+            <version>1.9.6</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
 * updated examples ui.config with newer version of io.wcm.caconfig.editor and io.wcm.caconfig.extensions which are compatible with AEM 6.6

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `SITES-26627` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
