### PR TITLE
SITES-26750 Accordion : Content editor dialog is adding "None" twice in Expanded Items field

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
@@ -187,8 +187,8 @@
         var cmpChildrenEditor = $(childrenEditor).adaptTo("cmp-childreneditor");
         if (cmpChildrenEditor) {
             if (singleExpansion) {
-                // Check "None" option exists or not, if not then add textcontent
-                if(!expandedSelect.items._container.textContent.includes("None")){
+                // Check if "None" option exists or not, if not then add textContent
+                if (!expandedSelect.items._container.textContent.includes("None")) {
                     expandedSelect.items.add({
                         selected: (selectedValues.length === 0),
                         content: {

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
@@ -187,14 +187,12 @@
         var cmpChildrenEditor = $(childrenEditor).adaptTo("cmp-childreneditor");
         if (cmpChildrenEditor) {
             if (singleExpansion) {
-                if(!expandedSelect.items._container.textContent.includes("None")){
-                    expandedSelect.items.add({
-                        selected: (selectedValues.length === 0),
-                        content: {
-                            textContent: Granite.I18n.get("None")
-                        }
-                    });
-                }
+                expandedSelect.items.add({
+                    selected: (selectedValues.length === 0),
+                    content: {
+                        textContent: Granite.I18n.get("None")
+                    }
+                });
                 expandedSelect.items.first().set("value", null, true);
             }
             cmpChildrenEditor.items().forEach(function(item) {

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
@@ -187,8 +187,8 @@
         var cmpChildrenEditor = $(childrenEditor).adaptTo("cmp-childreneditor");
         if (cmpChildrenEditor) {
             if (singleExpansion) {
-                // Check if "None" option exists or not, if not then add textContent
-                if (!expandedSelect.items._container.textContent.includes("None")) {
+                // Check "None" option exists or not, if not then add textcontent
+                if(!expandedSelect.items._container.textContent.includes("None")){
                     expandedSelect.items.add({
                         selected: (selectedValues.length === 0),
                         content: {

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
@@ -187,6 +187,7 @@
         var cmpChildrenEditor = $(childrenEditor).adaptTo("cmp-childreneditor");
         if (cmpChildrenEditor) {
             if (singleExpansion) {
+                // Check "None" option exists or not, if not then add textcontent
                 if(!expandedSelect.items._container.textContent.includes("None")){
                     expandedSelect.items.add({
                         selected: (selectedValues.length === 0),

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
@@ -187,12 +187,14 @@
         var cmpChildrenEditor = $(childrenEditor).adaptTo("cmp-childreneditor");
         if (cmpChildrenEditor) {
             if (singleExpansion) {
-                expandedSelect.items.add({
-                    selected: (selectedValues.length === 0),
-                    content: {
-                        textContent: Granite.I18n.get("None")
-                    }
-                });
+                if(!expandedSelect.items._container.textContent.includes("None")){
+                    expandedSelect.items.add({
+                        selected: (selectedValues.length === 0),
+                        content: {
+                            textContent: Granite.I18n.get("None")
+                        }
+                    });
+                }
                 expandedSelect.items.first().set("value", null, true);
             }
             cmpChildrenEditor.items().forEach(function(item) {

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
@@ -179,9 +179,7 @@
     function updateExpandedSelect(childrenEditor, expandedSelect, expandedItemValues, singleExpansion) {
         var selectedValues = (expandedSelect.values.length) ? expandedSelect.values : expandedItemValues;
         expandedSelect.items.getAll().forEach(function(item) {
-            if (item.value !== "") {
-                expandedSelect.items.remove(item);
-            }
+            expandedSelect.items.remove(item);
         });
 
         var cmpChildrenEditor = $(childrenEditor).adaptTo("cmp-childreneditor");

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/clientlibs/editor/js/accordion.js
@@ -187,7 +187,6 @@
         var cmpChildrenEditor = $(childrenEditor).adaptTo("cmp-childreneditor");
         if (cmpChildrenEditor) {
             if (singleExpansion) {
-                // Check "None" option exists or not, if not then add textcontent
                 if(!expandedSelect.items._container.textContent.includes("None")){
                     expandedSelect.items.add({
                         selected: (selectedValues.length === 0),


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | No
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

Steps to reproduce bug:
1. Add an accordion component and include three items, such as text components.
2. Navigate to the properties tab and select the "Single item expansion" checkbox.
3. Open the dropdown menu, which displays all three items along with an extra "None" option.
4. Go to the Items tab and delete one item, for example, item 2.
5. Return to the properties tab and open the dropdown menu again, observing that there are now two "None" options.

This is caused by the way expanded select is updated: it removes all the current items where value is not "", then adds "None", then readds items from children editor. Issue is fixed by also cleaning up "None" value, whereas this didn't happen before. Adapts fix from https://github.com/adobe/aem-core-wcm-components/pull/2857