### PR TITLE
Fixed flakiness caused by HashSet ordering in PageImplTest

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -149,6 +150,7 @@ public class PageImpl extends AbstractComponentImpl implements Page {
 
 	private String[] buildKeywords() {
 		Tag[] tags = currentPage.getTags();
+        Arrays.sort(tags, Comparator.comparing(Tag::getName));
         String[] keywords = new String[tags.length];
         int index = 0;
         Locale language= currentPage.getLanguage(false);

--- a/bundles/core/src/test/resources/page/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/exporter-templated-page.json
@@ -18,8 +18,8 @@
             "xdm:template": "/conf/coretest/settings/wcm/templates/product-page",
             "repo:path": "/core/content/page/templated-page.html",
             "xdm:tags": [
-                "three",
                 "one",
+                "three",
                 "two"
             ]
         }

--- a/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/v2/exporter-templated-page.json
@@ -72,8 +72,8 @@
       "xdm:template": "/conf/coretest/settings/wcm/templates/product-page",
       "xdm:language": "en-GB",
       "xdm:tags": [
-        "three",
         "one",
+        "three",
         "two"
       ],
       "repo:path": "/core/content/page/templated-page.html"

--- a/bundles/core/src/test/resources/page/v3/exporter-templated-page.json
+++ b/bundles/core/src/test/resources/page/v3/exporter-templated-page.json
@@ -72,8 +72,8 @@
       "xdm:template": "/conf/coretest/settings/wcm/templates/product-page",
       "xdm:language": "en-GB",
       "xdm:tags": [
-        "three",
         "one",
+        "three",
         "two"
       ],
       "repo:path": "/core/content/page/templated-page.html"


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #2893 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      |  Yes
| Documentation Provided   |  No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

Simple bug fix to remove indeterministic test behavior from a few tests. More about it in the linked issue. 
