### PR TITLE
SITES-28693 - Teaser Component Renders Broken HTML When Title is Empty

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImpl.java
@@ -82,7 +82,7 @@ public class TeaserImpl extends com.adobe.cq.wcm.core.components.internal.models
         overriddenImageResourceProperties.put(PN_ID, String.join(ID_SEPARATOR, this.getId(), IMAGE_ID_PREFIX));
 
         // Only allow image to render links if all other elements are empty
-        if (!(StringUtils.isAllEmpty(getTitle(), getPretitle(), getDescription()) && getTeaserActions().isEmpty())) {
+        if (!(StringUtils.isAllBlank(getTitle(), getPretitle(), getDescription()) && getTeaserActions().isEmpty())) {
             overriddenImageResourceProperties.put(Teaser.PN_IMAGE_LINK_HIDDEN, Boolean.TRUE.toString());
         }
         super.initImage();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImpl.java
@@ -81,7 +81,8 @@ public class TeaserImpl extends com.adobe.cq.wcm.core.components.internal.models
         overriddenImageResourceProperties.put(Teaser.PN_ACTIONS_ENABLED, Boolean.valueOf(actionsEnabled).toString());
         overriddenImageResourceProperties.put(PN_ID, String.join(ID_SEPARATOR, this.getId(), IMAGE_ID_PREFIX));
 
-        if (StringUtils.isNotEmpty(getTitle()) || getTeaserActions().size() > 0) {
+        // Only allow image to render links if all other elements are empty
+        if (!(StringUtils.isAllEmpty(getTitle(), getPretitle(), getDescription()) && getTeaserActions().isEmpty())) {
             overriddenImageResourceProperties.put(Teaser.PN_IMAGE_LINK_HIDDEN, Boolean.TRUE.toString());
         }
         super.initImage();

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/TeaserImplTest.java
@@ -17,9 +17,6 @@ package com.adobe.cq.wcm.core.components.internal.models.v2;
 
 import java.util.Objects;
 
-import com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig;
-import com.adobe.cq.wcm.core.components.models.Component;
-import com.adobe.cq.wcm.core.components.testing.MockNextGenDynamicMediaConfig;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,16 +25,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.adobe.cq.wcm.core.components.Utils;
 import com.adobe.cq.wcm.core.components.commons.link.Link;
+import com.adobe.cq.wcm.core.components.models.Component;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.models.Teaser;
+import com.adobe.cq.wcm.core.components.testing.MockNextGenDynamicMediaConfig;
+import com.day.cq.wcm.foundation.Image;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 import static com.adobe.cq.wcm.core.components.internal.link.LinkTestUtils.assertValidLink;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 @ExtendWith(AemContextExtension.class)
 public class TeaserImplTest extends com.adobe.cq.wcm.core.components.internal.models.v1.TeaserImplTest {
@@ -45,6 +43,8 @@ public class TeaserImplTest extends com.adobe.cq.wcm.core.components.internal.mo
     private static final String TEST_BASE = "/teaser/v2";
     private static final String TEASER_25 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-25";
     private static final String TEASER_26 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-26";
+    private static final String TEASER_27 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-27";
+    private static final String TEASER_28 = TEST_ROOT_PAGE + TEST_ROOT_PAGE_GRID + "/teaser-28";
 
     @BeforeEach
     protected void setUp() {
@@ -205,5 +205,29 @@ public class TeaserImplTest extends com.adobe.cq.wcm.core.components.internal.mo
         }
         assertEquals("Teasers Test", teaser.getTitle());
         Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(testBase, "teaser26"));
+    }
+
+    @Test
+    protected void testTeaserWithImageAndLinkAndNoTitleAndPretitleAndNoDescription() {
+        Teaser teaser = getTeaserUnderTest(TEASER_27);
+        assertEquals("Teaser Pre-title", teaser.getPretitle());
+        assertNull(teaser.getTitle());
+        assertNull(teaser.getDescription());
+        ValueMap imageValueMap = teaser.getImageResource().getValueMap();
+        assertEquals("/content/page1", imageValueMap.get(Image.PN_LINK_URL));
+        assertTrue(imageValueMap.get(Teaser.PN_IMAGE_LINK_HIDDEN, Boolean.class));
+        Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(testBase, "teaser27"));
+    }
+
+    @Test
+    protected void testTeaserWithImageAndLinkAndNoTitleAndNoPretitleAndNoDescription() {
+        Teaser teaser = getTeaserUnderTest(TEASER_28);
+        assertNull(teaser.getPretitle());
+        assertNull(teaser.getTitle());
+        assertNull(teaser.getDescription());
+        ValueMap imageValueMap = teaser.getImageResource().getValueMap();
+        assertEquals("/content/page1", imageValueMap.get(Image.PN_LINK_URL));
+        assertNull(imageValueMap.get(Teaser.PN_IMAGE_LINK_HIDDEN, Boolean.class));
+        Utils.testJSONExport(teaser, Utils.getTestExporterJSONPath(testBase, "teaser28"));
     }
 }

--- a/bundles/core/src/test/resources/teaser/v2/exporter-teaser27.json
+++ b/bundles/core/src/test/resources/teaser/v2/exporter-teaser27.json
@@ -1,0 +1,20 @@
+{
+    "id"             : "teaser-721d56e29c",
+    "pretitle"       : "Teaser Pre-title",
+    "actionsEnabled" : true,
+    "imageLinkHidden": false,
+    "titleLinkHidden": false,
+    "actions"        : [],
+    "link"           : {
+        "valid": true,
+        "url"  : "/core/content/page1.html"
+    },
+    "imagePath"      : "/core/content/teasers/_jcr_content/root/responsivegrid/teaser-27.coreimg.png/1490005239000/adobe-systems-logo-and-wordmark.png",
+    ":type"          : "core/wcm/components/teaser/v2/teaser",
+    "dataLayer"      : {
+        "teaser-721d56e29c": {
+            "@type"         : "core/wcm/components/teaser/v2/teaser",
+            "xdm:linkURL"   : "/core/content/page1.html"
+        }
+    }
+}

--- a/bundles/core/src/test/resources/teaser/v2/exporter-teaser28.json
+++ b/bundles/core/src/test/resources/teaser/v2/exporter-teaser28.json
@@ -1,0 +1,19 @@
+{
+    "id"             : "teaser-2dda15a9bc",
+    "actionsEnabled" : true,
+    "imageLinkHidden": false,
+    "titleLinkHidden": false,
+    "actions"        : [],
+    "link"           : {
+        "valid": true,
+        "url"  : "/core/content/page1.html"
+    },
+    "imagePath"      : "/core/content/teasers/_jcr_content/root/responsivegrid/teaser-28.coreimg.png/1490005239000/adobe-systems-logo-and-wordmark.png",
+    ":type"          : "core/wcm/components/teaser/v2/teaser",
+    "dataLayer"      : {
+        "teaser-2dda15a9bc": {
+            "@type"         : "core/wcm/components/teaser/v2/teaser",
+            "xdm:linkURL"   : "/core/content/page1.html"
+        }
+    }
+}

--- a/bundles/core/src/test/resources/teaser/v2/test-content.json
+++ b/bundles/core/src/test/resources/teaser/v2/test-content.json
@@ -317,6 +317,23 @@
               "sling:resourceType": "core/wcm/components/teaser/v2/teaser",
               "titleFromPage": true,
               "descriptionFromPage": true
+          },
+          "teaser-27"          : {
+            "jcr:primaryType"     : "nt:unstructured",
+            "linkURL"             : "/content/page1",
+            "fileReference"       : "/content/dam/core/images/Adobe_Systems_logo_and_wordmark.png",
+            "sling:resourceType"  : "core/wcm/components/teaser/v2/teaser",
+            "pretitle"            : "Teaser Pre-title",
+            "titleFromPage"       : false,
+            "descriptionFromPage" : false
+          },
+          "teaser-28"          : {
+            "jcr:primaryType"     : "nt:unstructured",
+            "linkURL"             : "/content/page1",
+            "fileReference"       : "/content/dam/core/images/Adobe_Systems_logo_and_wordmark.png",
+            "sling:resourceType"  : "core/wcm/components/teaser/v2/teaser",
+            "titleFromPage"       : false,
+            "descriptionFromPage" : false
           }
         }
       }

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/teaser.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/teaser.html
@@ -26,7 +26,7 @@
      data-cmp-data-layer="${teaser.data.json}">
     <a class="cmp-teaser__link"
        data-sly-attribute="${teaser.link.htmlAttributes}"
-       data-sly-unwrap="${!teaser.link.valid || !teaser.actions.empty}"
+       data-sly-unwrap="${!teaser.link.valid || !teaser.actions.empty || !(teaser.pretitle || teaser.title || teaser.description)}"
        data-cmp-clickable="${teaser.data ? true : false}">
         <div class="cmp-teaser__content">
             <sly data-sly-call="${pretitleTemplate.pretitle @ teaser=teaser}"></sly>

--- a/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/TeaserIT.java
+++ b/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/TeaserIT.java
@@ -1,9 +1,23 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2025 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.it.http;
 
 import org.apache.sling.testing.clients.ClientException;
 import org.jsoup.Jsoup;
 import org.jsoup.select.Elements;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;

--- a/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/TeaserIT.java
+++ b/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/TeaserIT.java
@@ -1,0 +1,51 @@
+package com.adobe.cq.wcm.core.components.it.http;
+
+import org.apache.sling.testing.clients.ClientException;
+import org.jsoup.Jsoup;
+import org.jsoup.select.Elements;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+
+import com.adobe.cq.testing.client.CQClient;
+import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
+import com.adobe.cq.testing.junit.rules.CQRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class TeaserIT {
+    @ClassRule
+    public static final CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
+
+    @Rule
+    public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule, cqBaseClassRule.publishRule);
+
+    @Rule
+    public ErrorCollector collector = new ErrorCollector();
+
+    static CQClient adminPublish;
+
+    @BeforeClass
+    public static void beforeClass() {
+        adminPublish = cqBaseClassRule.publishRule.getAdminClient(CQClient.class);
+    }
+
+    @Test
+    public void testNoNestedLinkElements() throws ClientException {
+        String content = adminPublish.doGet("/content/core-components/teaser/teaser-links.html", 200).getContent();
+        Elements html = Jsoup.parse(content).select("html");
+        assertNotNull(html);
+        // Expect no nesting of <a> tags
+        assertEquals("Expected no nested links", 0, html.select("a a").size());
+        // Expect only teaser with not CTAs and not content to have image link
+        assertEquals("Mismatched image links", 1, html.select("a > img").size());
+        // Expect only teaser with no CTAs and content to have global link
+        assertEquals("Mismatched teaser content links", 1, html.select("a .cmp-teaser__content").size());
+        // Expect teasers with CTAs to have CTA links
+        assertEquals("Mismatched teaser content links", 2, html.select("a.cmp-teaser__action-link").size());
+    }
+}

--- a/testing/it/it.ui.content/src/content/jcr_root/content/core-components/teaser/teaser-links/.content.xml
+++ b/testing/it/it.ui.content/src/content/jcr_root/content/core-components/teaser/teaser-links/.content.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:template="/conf/core-components/settings/wcm/templates/responsive-template"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="Teaser Links"
+        sling:resourceType="core/wcm/components/page/v2/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="core/wcm/components/container/v1/container"
+            layout="responsiveGrid">
+            <main
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="core/wcm/components/container/v1/container"
+                layout="responsiveGrid">
+                <container_v1
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-component/components/container-v1">
+                    <cq:responsive jcr:primaryType="nt:unstructured">
+                        <default
+                            jcr:primaryType="nt:unstructured"
+                            offset="0"
+                            width="4"/>
+                    </cq:responsive>
+                    <title_v3_176962574
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Teasers With CTAs"
+                        sling:resourceType="core-component/components/title-v3"
+                        linkTarget="_self"
+                        type="h2"/>
+                    <title_v3
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="No Title"
+                        sling:resourceType="core-component/components/title-v3"
+                        linkTarget="_self"
+                        type="h3"/>
+                    <teaser_v2
+                        jcr:description="&lt;p>Teaser description&lt;/p>&#xd;&#xa;"
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-component/components/teaser-v2"
+                        altValueFromDAM="true"
+                        descriptionFromPage="false"
+                        fileReference="/content/dam/core-components/core-comp-test-image.jpg"
+                        id="no-title-teaser"
+                        imageFromPageImage="false"
+                        isDecorative="false"
+                        linkTarget="_self"
+                        linkURL="/content/core-components/teaser"
+                        pretitle="Teaser Pretitle"
+                        textIsRich="true"
+                        titleFromPage="false">
+                        <actions jcr:primaryType="nt:unstructured">
+                            <item0
+                                jcr:primaryType="nt:unstructured"
+                                link="/content/core-components/teaser"
+                                linkTarget="_self"
+                                text="Teaser"/>
+                        </actions>
+                    </teaser_v2>
+                    <title_v3_1270847366
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="No Title, No Description"
+                        sling:resourceType="core-component/components/title-v3"
+                        linkTarget="_self"
+                        type="h3"/>
+                    <teaser_v2_1192909202
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-component/components/teaser-v2"
+                        altValueFromDAM="true"
+                        descriptionFromPage="false"
+                        fileReference="/content/dam/core-components/core-comp-test-image.jpg"
+                        id="no-title-no-description-teaser"
+                        imageFromPageImage="false"
+                        isDecorative="false"
+                        linkTarget="_self"
+                        linkURL="/content/core-components/teaser"
+                        textIsRich="true"
+                        titleFromPage="false">
+                        <actions jcr:primaryType="nt:unstructured">
+                            <item0
+                                jcr:primaryType="nt:unstructured"
+                                link="/content/core-components/teaser"
+                                linkTarget="_self"
+                                text="Teaser"/>
+                        </actions>
+                    </teaser_v2_1192909202>
+                </container_v1>
+                <container_v1_667737784
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-component/components/container-v1">
+                    <cq:responsive jcr:primaryType="nt:unstructured">
+                        <default
+                            jcr:primaryType="nt:unstructured"
+                            offset="1"
+                            width="4"/>
+                    </cq:responsive>
+                    <title_v3
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Teasers Without CTAs"
+                        sling:resourceType="core-component/components/title-v3"
+                        linkTarget="_self"
+                        type="h2"/>
+                    <title_v3_111614642
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="No Title, No CTAs"
+                        sling:resourceType="core-component/components/title-v3"
+                        linkTarget="_self"
+                        type="h3"/>
+                    <teaser_v2_1776259748
+                        jcr:description="&lt;p>Teaser descriptiom&lt;/p>&#xd;&#xa;"
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-component/components/teaser-v2"
+                        altValueFromDAM="true"
+                        descriptionFromPage="false"
+                        fileReference="/content/dam/core-components/core-comp-test-image.jpg"
+                        imageFromPageImage="false"
+                        isDecorative="false"
+                        linkTarget="_self"
+                        linkURL="/content/core-components/teaser"
+                        pretitle="Teaser Pretitle"
+                        textIsRich="true"
+                        titleFromPage="false"/>
+                    <title_v3_319733326
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="No Title, No Description, No CTAs"
+                        sling:resourceType="core-component/components/title-v3"
+                        linkTarget="_self"
+                        type="h3"/>
+                    <teaser_v2_1868491878
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-component/components/teaser-v2"
+                        altValueFromDAM="true"
+                        descriptionFromPage="false"
+                        fileReference="/content/dam/core-components/core-comp-test-image.jpg"
+                        id="no-title-no-description-no-ctas-teaser"
+                        imageFromPageImage="false"
+                        isDecorative="false"
+                        linkTarget="_self"
+                        linkURL="/content/core-components/teaser"
+                        textIsRich="true"
+                        titleFromPage="false"/>
+                    <title_v3_2083027106
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Empty Teaser"
+                        sling:resourceType="core-component/components/title-v3"
+                        linkTarget="_self"
+                        type="h3"/>
+                    <teaser_v2_125774266
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-component/components/teaser-v2"
+                        descriptionFromPage="false"
+                        id="empty-teaser"
+                        imageFromPageImage="true"
+                        isDecorative="true"
+                        linkTarget="_self"
+                        linkURL="/content/core-components/teaser"
+                        textIsRich="true"
+                        titleFromPage="false"/>
+                </container_v1_667737784>
+            </main>
+            <aside
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="core/wcm/components/container/v1/container">
+                <tableofcontents_v1
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-component/components/tableofcontents-v1"
+                    listType="bulleted"
+                    startLevel="h2"
+                    stopLevel="h6"/>
+            </aside>
+        </root>
+    </jcr:content>
+</jcr:root>


### PR DESCRIPTION
* Updated teaser to only allow image to render links if all other elements are empty (pre-title, title, description, actions), in which case it will unwrap the general link on the teaser content.

Fixes #2660

