### PR TITLE
SITES-28486 - [SLA3] Inconsistency in Inplace Editing Redirecting to Old Content Fragment Editor

### DIFF
--- a/content/karma.conf.js
+++ b/content/karma.conf.js
@@ -30,11 +30,12 @@ module.exports = function(config) {
 
         // list of files / patterns to load in the browser
         files: [
+            'test/mocks.js',
             'src/content/jcr_root/apps/core/wcm/components/commons/site/clientlibs/**/js/*.js',
             'src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/site/**/js/*.js',
+            'src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/editAction.js',
             'test/**/*Test.js',
-            'test/**/*Test.html',
-            'spec/**/*Test.html'
+            'test/**/*Test.html'
         ],
 
 

--- a/content/package-lock.json
+++ b/content/package-lock.json
@@ -2362,9 +2362,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001572",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001572.tgz",
-            "integrity": "sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw==",
+            "version": "1.0.30001702",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001702.tgz",
+            "integrity": "sha512-LoPe/D7zioC0REI5W73PeR1e1MLCipRGq/VkovJnd6Df+QVqT+vT33OXCp8QUd7kA7RZrHWxb1B36OQKI/0gOA==",
             "dev": true,
             "funding": [
                 {
@@ -2379,7 +2379,8 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ]
+            ],
+            "license": "CC-BY-4.0"
         },
         "node_modules/caseless": {
             "version": "0.12.0",
@@ -13681,9 +13682,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001572",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001572.tgz",
-            "integrity": "sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw==",
+            "version": "1.0.30001702",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001702.tgz",
+            "integrity": "sha512-LoPe/D7zioC0REI5W73PeR1e1MLCipRGq/VkovJnd6Df+QVqT+vT33OXCp8QUd7kA7RZrHWxb1B36OQKI/0gOA==",
             "dev": true
         },
         "caseless": {

--- a/content/test/clientlibs/contentfragment/editActionTest.js
+++ b/content/test/clientlibs/contentfragment/editActionTest.js
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright 2025 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+describe("Test content fragment edit action for", function() {
+
+    beforeAll(function () {
+        fixture.setBase('test/fixtures/contentfragment')
+        Granite.author.CFM.Fragments.mappings.set(
+            "/content/dam/wknd-shared/en/adventures/riverside-camping-australia/riverside-camping-australia",
+            { variation: "master" }
+        );
+        Granite.author.CFM.Fragments.mappings.set(
+            "/content/dam/wknd-shared/en/adventures/napa-wine-tasting/napa-wine-tasting",
+            { variation: "other" }
+        );
+    })
+
+    afterAll(function () {
+       Granite.author.CFM.Fragments.mappings.clear();
+    });
+
+    beforeEach(function () {
+        this.result = fixture.load('editActionTest.html');
+        spyOn(window, 'open');
+    });
+
+    afterEach(function () {
+        fixture.cleanup()
+    });
+
+    it("empty content fragment", function() {
+        const editable = { dom: fixture.el.children.item(0)};
+        Granite.author.editor.contentfragment.setUp(editable);
+
+        const canEdit = Granite.author.editor.contentfragment.canEdit(editable);
+        Granite.author.editor.contentfragment.setUp(editable);
+
+        expect(canEdit).toBeFalse();
+        expect(window.open).toHaveBeenCalledTimes(0);
+    });
+
+    it("content fragment master variation and feature toggle disabled", function() {
+        Granite.Toggles.enabled = false;
+        const editable = { dom: fixture.el.children.item(1)};
+
+        const canEdit = Granite.author.editor.contentfragment.canEdit(editable);
+        Granite.author.editor.contentfragment.setUp(editable);
+
+        expect(canEdit).toBeTrue();
+        const expectedUrl = '/editor.html/content/dam/wknd-shared/en/adventures/riverside-camping-australia/riverside-camping-australia';
+        expect(window.open).toHaveBeenCalledOnceWith(expectedUrl);
+    });
+
+    it("content fragment master variation and feature toggle enabled", function() {
+        Granite.Toggles.enabled = true;
+        const editable = { dom: fixture.el.children.item(1)};
+
+        const canEdit = Granite.author.editor.contentfragment.canEdit(editable);
+        Granite.author.editor.contentfragment.setUp(editable);
+
+        expect(canEdit).toBeTrue();
+        const expectedUrl = 'https://experience.adobe.com/?repo=localhost#/aem/cf/editor/content/dam/wknd-shared/en/adventures/riverside-camping-australia/riverside-camping-australia';
+        expect(window.open).toHaveBeenCalledOnceWith(expectedUrl);
+    });
+
+    it("content fragment other variation and feature toggle disabled", function() {
+        Granite.Toggles.enabled = false;
+        const editable = { dom: fixture.el.children.item(2)};
+
+        const canEdit = Granite.author.editor.contentfragment.canEdit(editable);
+        Granite.author.editor.contentfragment.setUp(editable);
+
+        expect(canEdit).toBeTrue();
+        const expectedUrl = '/editor.html/content/dam/wknd-shared/en/adventures/napa-wine-tasting/napa-wine-tasting?variation=other';
+        expect(window.open).toHaveBeenCalledOnceWith(expectedUrl);
+    });
+
+    it("content fragment other variation and feature toggle enabled", function() {
+        Granite.Toggles.enabled = true;
+        const editable = { dom: fixture.el.children.item(2)};
+
+        const canEdit = Granite.author.editor.contentfragment.canEdit(editable);
+        Granite.author.editor.contentfragment.setUp(editable);
+
+        expect(canEdit).toBeTrue();
+        const expectedUrl = 'https://experience.adobe.com/?repo=localhost#/aem/cf/editor/content/dam/wknd-shared/en/adventures/napa-wine-tasting/napa-wine-tasting';
+        expect(window.open).toHaveBeenCalledOnceWith(expectedUrl);
+    });
+
+})

--- a/content/test/fixtures/contentfragment/editActionTest.html
+++ b/content/test/fixtures/contentfragment/editActionTest.html
@@ -1,0 +1,76 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2025 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<div class="contentfragment aem-GridColumn aem-GridColumn--default--12">
+    <div class="cq-placeholder cq-dd-contentfragment" data-emptytext="Content Fragment"></div>
+    <cq data-path="/content/wknd/us/en/test-page/jcr:content/root/container/contentfragment" data-config="{}"></cq>
+</div>
+<div class="contentfragment aem-GridColumn aem-GridColumn--default--12 cq-Editable-dom">
+    <article id="contentfragment-a379b545ca" class="cmp-contentfragment cmp-contentfragment--riverside-camping-australia"
+             data-cmp-contentfragment-model="wknd-shared/models/adventure" data-json="{}"
+             data-cmp-contentfragment-path="/content/dam/wknd-shared/en/adventures/riverside-camping-australia/riverside-camping-australia">
+        <h3 class="cmp-contentfragment__title">Riverside Camping Australia</h3>
+        <dl class="cmp-contentfragment__elements cq-dd-contentfragment">
+            <div class="cmp-contentfragment__element cmp-contentfragment__element--title" data-cmp-contentfragment-element-type="string">
+                <dt class="cmp-contentfragment__element-title">Title</dt>
+                <dd class="cmp-contentfragment__element-value">
+                    Riverside Camping Australia
+                </dd>
+            </div>
+            <div class="cmp-contentfragment__element cmp-contentfragment__element--slug" data-cmp-contentfragment-element-type="string">
+                <dt class="cmp-contentfragment__element-title">Slug</dt>
+                <dd class="cmp-contentfragment__element-value">
+                    riverside-camping-australia
+                </dd>
+            </div>
+            <div class="cmp-contentfragment__element cmp-contentfragment__element--description" data-cmp-contentfragment-element-type="string">
+                <dt class="cmp-contentfragment__element-title">Description</dt>
+                <dd class="cmp-contentfragment__element-value">
+                    <p>Escape the hustle and bustle of city life and recharge with a couple of peaceful days and return with tons of memories of camping in the bush and experiences that will last a lifetime. </p>
+                </dd>
+            </div>
+        </dl>
+    </article>
+    <cq data-path="/content/wknd/us/en/test-page/jcr:content/root/container/contentfragment" data-config="{}"></cq>
+</div>
+<div class="contentfragment aem-GridColumn aem-GridColumn--default--12">
+    <article id="contentfragment-a379b545cc" class="cmp-contentfragment cmp-contentfragment--napa-wine-tasting"
+             data-cmp-contentfragment-model="wknd-shared/models/adventure" data-json="{}"
+             data-cmp-contentfragment-path="/content/dam/wknd-shared/en/adventures/napa-wine-tasting/napa-wine-tasting">
+        <h3 class="cmp-contentfragment__title">Napa Wine Tasting</h3>
+        <dl class="cmp-contentfragment__elements cq-dd-contentfragment">
+            <div class="cmp-contentfragment__element cmp-contentfragment__element--title" data-cmp-contentfragment-element-type="string">
+                <dt class="cmp-contentfragment__element-title">Title</dt>
+                <dd class="cmp-contentfragment__element-value">
+                    Napa Wine Tasting
+                </dd>
+            </div>
+            <div class="cmp-contentfragment__element cmp-contentfragment__element--slug" data-cmp-contentfragment-element-type="string">
+                <dt class="cmp-contentfragment__element-title">Slug</dt>
+                <dd class="cmp-contentfragment__element-value">
+                    napa-wine-tasting
+                </dd>
+            </div>
+            <div class="cmp-contentfragment__element cmp-contentfragment__element--description" data-cmp-contentfragment-element-type="string">
+                <dt class="cmp-contentfragment__element-title">Description</dt>
+                <dd class="cmp-contentfragment__element-value">
+                    <h3>Enjoy spectacular wine tasting in the Napa Valley</h3>
+                    <p>Napa Valley is one of the most famous wine regions in the world. Located an hour north of San Francisco, Napa is renowned for their wine, pleasant temperatures and world class restaurants.</p>
+                </dd>
+            </div>
+        </dl>
+    </article>
+    <cq data-path="/content/wknd/us/en/test-page/jcr:content/root/container/contentfragment" data-config="{}"></cq>
+</div>

--- a/content/test/mocks.js
+++ b/content/test/mocks.js
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright 2025 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+class JQueryArray extends Array {
+    find(selector) {
+        const elem = this[0].querySelector(selector)
+        return elem ? new JQueryArray(elem) : new JQueryArray();
+    }
+
+    attr(name) {
+        return this[0] ? this[0].getAttribute(name) : null;
+    }
+}
+
+function jQuery(obj) {
+    return new JQueryArray(obj);
+}
+
+Granite = {
+    author: {
+        util: {
+            mixin: function (dest, src) {
+                for (var prop in src) {
+                    if (src.hasOwnProperty(prop)) {
+                        dest[prop] = src[prop];
+                    }
+                }
+            },
+            createClass: function (classDefinition) {
+                var methods = {};
+
+                if (!classDefinition.constructor) {
+                    classDefinition.constructor = function () {
+                    };
+                }
+
+                for (var prop in classDefinition) {
+                    if (classDefinition.hasOwnProperty(prop) && prop !== "constructor") {
+                        methods[prop] = classDefinition[prop];
+                    }
+                }
+
+                Granite.author.util.mixin(classDefinition.constructor.prototype, methods);
+
+                return classDefinition.constructor;
+            }
+        },
+        editor: {
+            register: function (type, editor) {
+                this[type] = editor;
+            }
+        },
+        CFM: {
+            Fragments: {
+                mappings: new Map(),
+                adaptToFragment: function (dom) {
+                    const fragmentElem = dom.querySelector('[data-cmp-contentfragment-path]');
+                    if (fragmentElem) {
+                        const fragmentPath = fragmentElem.getAttribute('data-cmp-contentfragment-path');
+                        return Granite.author.CFM.Fragments.mappings.get(fragmentPath);
+                    } else {
+                        return null;
+                    }
+                }
+            }
+        }
+    },
+    Toggles: {
+        enabled: false,
+        isEnabled: function (feature) {
+            return Granite.Toggles.enabled;
+        }
+    },
+    HTTP: {
+        externalize: function (url) {
+            return url;
+        }
+    },
+};


### PR DESCRIPTION
* added karma tests for contentfragment editAction

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-28486
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
