### PR TITLE
WCM components examples are not compatible with AEM 6.5

### DIFF
--- a/examples/ui.config/pom.xml
+++ b/examples/ui.config/pom.xml
@@ -68,6 +68,18 @@
                             <groupId>io.wcm</groupId>
                             <artifactId>io.wcm.caconfig.extensions</artifactId>
                         </embedded>
+                        <embedded>
+                            <groupId>org.apache.sling</groupId>
+                            <artifactId>org.apache.sling.caconfig.api</artifactId>
+                        </embedded>
+                        <embedded>
+                            <groupId>org.apache.sling</groupId>
+                            <artifactId>org.apache.sling.caconfig.spi</artifactId>
+                        </embedded>
+                        <embedded>
+                            <groupId>org.apache.sling</groupId>
+                            <artifactId>org.apache.sling.caconfig.impl</artifactId>
+                        </embedded>
                     </embeddeds>
                 </configuration>
             </plugin>
@@ -150,6 +162,22 @@
             <groupId>io.wcm</groupId>
             <artifactId>io.wcm.caconfig.extensions</artifactId>
             <version>1.9.6</version>
+        </dependency>
+        <!-- Updated Sling Context-Aware Configuration APIs to stay compatible with AEM 6.5 -->
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.caconfig.api</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.caconfig.spi</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.caconfig.impl</artifactId>
+            <version>1.6.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
in #2888 the deployment of the examples was fixed for AEM 6.5 by updating the libraries `io.wcm.caconfig.editor` and `io.wcm.caconfig.extensions`.

however, with this update, it's not longer possible to deploy to AEM 6.5.22 as those updated libraries depend on more recent version of `org.apache.sling.caconfig.spi` and `org.apache.sling.caconfig.impl`. those version are are included in AEM 6.6 and AEMaaCS SDK, but not in AEM 6.5 and it's lastest service packs.

this PR adds the three relevant Sling Context-Aware Context libraries and updates them to the versions contained in AEM 6.6, thus being compatible to be deployed to AEM 6.5.22, AEM 6.6 and AEMaaCS SDK.