### PR TITLE
SITES-30116 AEM Teaser/Image Core Component Alternative Text Field Issue

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
@@ -173,6 +173,14 @@
                         captionTuple.hideCheckbox(true);
                     }
                 }
+
+                // Ensure alt text from page is visible on initial load if imageFromPageImage is checked
+                if (imageFromPageImage && imageFromPageImage.checked) {
+                    var isAltFromPageImageChecked = document.querySelector('coral-checkbox[name="./altValueFromPageImage"]').checked;
+                    if (isAltFromPageImageChecked && altTextFromPage) {
+                        $altTextField.adaptTo("foundation-field").setValue(altTextFromPage);
+                    }
+                }
             });
         }
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
@@ -45,6 +45,7 @@
     var $pageImageThumbnail;
     var altTextFromPage;
     var altTextFromDAM;
+    var altFromPageCheckboxSelector = "coral-checkbox[name='./altValueFromPageImage']";
     var altCheckboxSelector = "coral-checkbox[name='./altValueFromDAM']";
     var altInputSelector = "input[name='./alt']";
     var altInputAlertIconSelector = "input[name='./alt'] + coral-icon[icon='alert']";
@@ -97,7 +98,7 @@
 
             imageFromPageImage = dialogContent.querySelector("coral-checkbox[name='./imageFromPageImage']");
 
-            altFromPageTuple = new CheckboxTextfieldTuple(dialogContent, "coral-checkbox[name='./altValueFromPageImage']", "input[name='./alt']");
+            altFromPageTuple = new CheckboxTextfieldTuple(dialogContent, altFromPageCheckboxSelector, "input[name='./alt']");
             $pageImageThumbnail = $dialogContent.find(pageImageThumbnailSelector);
             altTextFromPage = $dialogContent.find(pageImageThumbnailImageSelector).attr("alt");
 
@@ -176,7 +177,7 @@
 
                 // Ensure alt text from page is visible on initial load if imageFromPageImage is checked
                 if (imageFromPageImage && imageFromPageImage.checked) {
-                    var isAltFromPageImageChecked = document.querySelector('coral-checkbox[name="./altValueFromPageImage"]').checked;
+                    var isAltFromPageImageChecked = document.querySelector(altFromPageCheckboxSelector).checked;
                     if (isAltFromPageImageChecked && altTextFromPage) {
                         $altTextField.adaptTo("foundation-field").setValue(altTextFromPage);
                     }
@@ -208,7 +209,7 @@
             var altFromDAM = document.querySelector('coral-checkbox[name="./altValueFromDAM"]');
             var isAltFromDAMChecked = altFromDAM.checked;
             var isAltFromDAMDisabled = altFromDAM.disabled;
-            var isAltFromPageImageChecked = document.querySelector('coral-checkbox[name="./altValueFromPageImage"]').checked;
+            var isAltFromPageImageChecked = document.querySelector(altFromPageCheckboxSelector).checked;
             var isDecorativeChecked = document.querySelector("coral-checkbox[name='./isDecorative']").checked;
             var assetWithoutDescriptionErrorMessage = "Error: Please provide an asset which has a description that can be used as alt text.";
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
@@ -98,7 +98,7 @@
 
             imageFromPageImage = dialogContent.querySelector("coral-checkbox[name='./imageFromPageImage']");
 
-            altFromPageTuple = new CheckboxTextfieldTuple(dialogContent, altFromPageCheckboxSelector, "input[name='./alt']");
+            altFromPageTuple = new CheckboxTextfieldTuple(dialogContent, altFromPageCheckboxSelector, altInputSelector);
             $pageImageThumbnail = $dialogContent.find(pageImageThumbnailSelector);
             altTextFromPage = $dialogContent.find(pageImageThumbnailImageSelector).attr("alt");
 


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `SITES-30116` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes (existing)
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Jira [SITES-30116](https://jira.corp.adobe.com/browse/SITES-30116)

Fixes alt text from page image not being shown inside image / teaser components on initial load.

Steps to reproduce:

0. Add a page image with alt text to a page inside WKND content, such as /content/wknd/es/es
1. Drag and drop an image or teaser component.
2. Select the "Inherit alternative text from page" checkbox in the Asset tab.
3. Observe the alternative text field, which should be populated but is instead disabled and blank.
4. Uncheck and then recheck the "Inherit alternative text from page" checkbox to see if the field populates correctly.

In the usual case it does not populate directly, likely due to a race condition because in certain cases, such as when console / debugger is open, the alt text is in fact populated correctly.

Issue is fixed by explicitly adding the alt text from page to the text field if it exists and the inherit alt text from page image checkbox is checked. The fix applies to both Image and Teaser Components since they use the same code here.

This scenario is covered by an existing IT, which was already passing though - [see here](https://github.com/adobe/aem-core-wcm-components/blob/main/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/image/ImageTests.java#L417), likely due to the unpredictable nature of the race condition + added slowness by the Selenium IT environment

Additionally slightly cleaned up the code to use preexisting vars for selectors in a few places
