### PR TITLE
ASSETS-46423 Support authoring preview versions of assets in sites core component

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/PreviewTokenBuilderUtils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/PreviewTokenBuilderUtils.java
@@ -1,0 +1,80 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2025 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.AbstractMap;
+import java.util.Date;
+import java.util.Map;
+import java.util.TimeZone;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PreviewTokenBuilderUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PreviewTokenBuilderUtils.class);
+
+    private final static String HMAC_SHA256 = "HmacSHA256";
+    private final static String DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    private final static String PREVIEW_KEY = "previewKey";
+    private final static String UTC = "UTC";
+
+    private static final ThreadLocal<SimpleDateFormat> dateFormat = ThreadLocal.withInitial(() -> {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_PATTERN);
+        dateFormat.setTimeZone(TimeZone.getTimeZone(UTC));
+        return dateFormat;
+    });
+
+    public static Map.Entry<String, String> buildPreviewToken(String assetId) {
+        try {
+            String secretKey = readKeyFromEnvVar(PREVIEW_KEY);
+            if (assetId == null || StringUtils.isBlank(secretKey)) {
+                throw new Exception("Invalid input parameters");
+            }
+            LocalDateTime nowPlusThirty = LocalDateTime.now().plusMinutes(30);
+            Date expirationTime = Date.from(nowPlusThirty.atZone(ZoneId.systemDefault()).toInstant());
+            final String expiryTimeStr = dateFormat.get().format(expirationTime);
+            return new AbstractMap.SimpleEntry<>(computeSignature(assetId, expiryTimeStr, secretKey), expiryTimeStr);
+        } catch (Exception e) {
+            LOG.warn("Could not generate preview token for asset {}", assetId, e);
+        }
+        return null;
+    }
+
+    private static String computeSignature(String assetId, String expiryTime, String secretKey) throws Exception {
+        try {
+            String stringToSign = expiryTime + ":" + assetId;
+            Mac mac = Mac.getInstance(HMAC_SHA256);
+            mac.init(new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
+            return Hex.encodeHexString(mac.doFinal(stringToSign.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException | InvalidKeyException nsae) {
+            throw new Exception("Failed to compute signature", nsae);
+        }
+    }
+
+    private static String readKeyFromEnvVar(String key) {
+        return System.getProperty(key, System.getenv(key));
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/ImageImpl.java
@@ -15,6 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v3;
 
+import com.adobe.cq.wcm.core.components.internal.PreviewTokenBuilderUtils;
 import java.awt.*;
 import java.io.IOException;
 import java.io.StringReader;
@@ -333,6 +334,9 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
         String smartCrop = properties.get("smartCropRendition", String.class);
         String modifiers = properties.get("imageModifiers", String.class);
         if (isNgdmImageReference(fileReference)) {
+            Scanner scanner = new Scanner(fileReference);
+            scanner.useDelimiter("/");
+            String assetId = scanner.next();
             int width = currentStyle.get(PN_DESIGN_RESIZE_WIDTH, DEFAULT_NGDM_ASSET_WIDTH);
             NextGenDMImageURIBuilder builder = new NextGenDMImageURIBuilder(nextGenDynamicMediaConfig, fileReference)
                 .withPreferWebp(true)
@@ -343,6 +347,14 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
             if (StringUtils.isNotEmpty(modifiers)) {
                 builder.withImageModifiers(modifiers);
             }
+
+            Map.Entry<String, String> previewTokenMap = PreviewTokenBuilderUtils.buildPreviewToken(assetId);
+            if (null != previewTokenMap) {
+                // append p: to indicate that this is a preview token.
+                // it can also be a token generated using private/public key pair or any other way
+                builder.withToken("p:" + previewTokenMap.getKey());
+                builder.withTokenExpiry(previewTokenMap.getValue());
+            }
             src = builder.build();
             ngdmImage = true;
             hasContent = true;
@@ -350,9 +362,6 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
                 client = clientBuilderFactory.newBuilder().build();
             }
             metadataDeliveryEndpoint = nextGenDynamicMediaConfig.getAssetMetadataPath();
-            Scanner scanner = new Scanner(fileReference);
-            scanner.useDelimiter("/");
-            String assetId = scanner.next();
             metadataDeliveryEndpoint = metadataDeliveryEndpoint.replace(PATH_PLACEHOLDER_ASSET_ID, assetId);
         }
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/NextGenDMImageURIBuilder.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/NextGenDMImageURIBuilder.java
@@ -37,6 +37,8 @@ public class NextGenDMImageURIBuilder {
     private NextGenDynamicMediaConfig config;
     private String fileReference;
     private String smartCropName;
+    private String token;
+    private String tokenExpiry;
     private int width = DEFAULT_NGDM_ASSET_WIDTH;
 
     private int height;
@@ -96,6 +98,25 @@ public class NextGenDMImageURIBuilder {
     }
 
     /**
+     * Set token to be set in delivery URL. It can be a preview token or a token generated
+     * with public/private key pair
+     * @param token - a token to check what version of asset should be delivered
+     */
+    public NextGenDMImageURIBuilder withToken(String token) {
+        this.token = token;
+        return this;
+    }
+
+    /**
+     * Set expiry of the token.
+     * @param tokenExpiry - a string indicating whether the token is valid
+     */
+    public NextGenDMImageURIBuilder withTokenExpiry(String tokenExpiry) {
+        this.tokenExpiry = tokenExpiry;
+        return this;
+    }
+
+    /**
      * Use this to create a NextGen Dynamic Media Image URI.
      * @return a uri.
      */
@@ -126,6 +147,12 @@ public class NextGenDMImageURIBuilder {
             }
             if (StringUtils.isNotEmpty(this.smartCropName)) {
                 params.put("smartcrop", this.smartCropName);
+            }
+            if (StringUtils.isNotEmpty(this.token)) {
+                params.put("token", this.token);
+            }
+            if (StringUtils.isNotEmpty(this.tokenExpiry)) {
+                params.put("expiryTime", this.tokenExpiry);
             }
             if(params.size() > 0) {
                 uriBuilder.append("?");

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/PreviewTokenBuilderUtilsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/PreviewTokenBuilderUtilsTest.java
@@ -1,0 +1,64 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2025 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal;
+
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class PreviewTokenBuilderUtilsTest {
+
+    private static final String ASSET_ID = "testAsset";
+    private static final String SECRET_KEY = "testSecretKey";
+    private static final String PREVIEW_KEY = "previewKey";
+
+    PreviewTokenBuilderUtils previewTokenBuilderUtils;
+
+    @BeforeEach
+    void setUp() {
+        System.setProperty(PREVIEW_KEY, SECRET_KEY);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        System.clearProperty(PREVIEW_KEY);
+    }
+
+    @Test
+    void testBuildPreviewToken_Success() {
+        Map.Entry<String, String> result = PreviewTokenBuilderUtils.buildPreviewToken(ASSET_ID);
+        assertNotNull(result);
+        assertNotNull(result.getKey());
+        assertNotNull(result.getValue());
+    }
+
+    @Test
+    void testBuildPreviewToken_NullAssetId() {
+        Map.Entry<String, String> result = PreviewTokenBuilderUtils.buildPreviewToken(null);
+        assertNull(result);
+    }
+
+    @Test
+    void testBuildPreviewToken_MissingSecretKey() {
+        System.clearProperty(PREVIEW_KEY);
+        Map.Entry<String, String> result = PreviewTokenBuilderUtils.buildPreviewToken(ASSET_ID);
+        assertNull(result);
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v3/NextgenDMImageURIBuilderTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v3/NextgenDMImageURIBuilderTest.java
@@ -95,4 +95,18 @@ public class NextgenDMImageURIBuilderTest {
         uriBuilder = new NextGenDMImageURIBuilder(config, "");
         assertTrue(uriBuilder.build() == null);
     }
+
+    @Test
+    public void testUrlWithPreviewToken() {
+        uriBuilder.withToken("p:RandomToken");
+        String uri = uriBuilder.build();
+        assertTrue(uri.contains("token=p:RandomToken"));
+    }
+
+    @Test
+    public void testUrlWithPreviewTokenExpiry() {
+        uriBuilder.withTokenExpiry("2025-02-27T10:17:59.300Z");
+        String uri = uriBuilder.build();
+        assertTrue(uri.contains("expiryTime=2025-02-27T10:17:59.300Z"));
+    }
 }


### PR DESCRIPTION
Add a preview token builder which, on getting a preview key in environment variables, will always generate and append the preview token to DM with OpenAPIs images. This preview token will ensure that preview version of an asset is visible in image component if it exists. For customers who do not have the preview secret key set in their environment variables, the existing delivery URL will be generated.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
