### PR TITLE
[SITES-30372] Fixed Smart Crop with named renditions for Image(V2)

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/image.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/image.html
@@ -35,7 +35,7 @@
        class="cmp-image__link" href="${image.link}"
        data-cmp-clickable="${image.data ? true : false}"
        data-cmp-hook-image="link">
-        <noscript data-sly-unwrap="${image.smartCropRendition != 'SmartCrop:Auto' && (!image.lazyEnabled && image.widths.length <= 1 && !image.areas)}" data-cmp-hook-image="noscript">
+        <noscript data-sly-unwrap="${!image.smartCropRendition && (!image.lazyEnabled && image.widths.length <= 1 && !image.areas)}" data-cmp-hook-image="noscript">
             <sly data-sly-test.usemap="${'{0}{1}' @ format=['#', resource.path]}"></sly>
             <img src="${image.src}" class="cmp-image__image" itemprop="contentUrl" data-cmp-hook-image="image"
                  data-sly-attribute.usemap="${image.areas ? usemap : ''}"


### PR DESCRIPTION
Jira: https://jira.corp.adobe.com/browse/SITES-30372
Previously, the code assumed that no client-side processing is needed for named renditions such as `Large` or `Medium`
But these do include the `dpr` wildcard and it needs to be set client-side since the url below
> https://smartimagingbfc3.scene7.com/is/image/TechSupport/large-wallpaper%3ASmall?ts=1743424872455&amp;dpr=on,{dpr}

is not valid and is cut off from image `SRC` by the HTL XSS protection