### PR TITLE
[Tabs] Accessibility improvments

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/css/tabs.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/css/tabs.less
@@ -16,7 +16,8 @@
 
 .cmp-tabs__tablist {
     display: flex;
-    flex-wrap: wrap;
+    overflow: auto hidden;
+    flex-wrap: nowrap;
     padding-left: 0;
     list-style: none;
 }

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
@@ -254,12 +254,14 @@
                         if (i === parseInt(that._active)) {
                             tabpanels[i].classList.add(selectors.active.tabpanel);
                             tabpanels[i].removeAttribute("aria-hidden");
+                            tabpanels[i].setAttribute("tabindex", "0");
                             tabs[i].classList.add(selectors.active.tab);
                             tabs[i].setAttribute("aria-selected", true);
-                            tabs[i].setAttribute("tabindex", "0");
+                            tabs[i].removeAttribute("tabindex" );
                         } else {
                             tabpanels[i].classList.remove(selectors.active.tabpanel);
                             tabpanels[i].setAttribute("aria-hidden", true);
+                            tabpanels[i].removeAttribute("tabindex" );
                             tabs[i].classList.remove(selectors.active.tab);
                             tabs[i].setAttribute("aria-selected", false);
                             tabs[i].setAttribute("tabindex", "-1");

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
@@ -21,21 +21,23 @@
      data-cmp-is="tabs"
      data-cmp-data-layer="${tabs.data.json}"
      data-placeholder-text="${wcmmode.edit && 'Please drag Tab components here' @ i18n}">
-    <ol data-sly-set.items="${tabs.children || tabs.items}"
+    <div data-sly-set.items="${tabs.children || tabs.items}"
         data-sly-test="${items && items.size > 0}"
         data-sly-list.tab="${items}"
         role="tablist"
         class="cmp-tabs__tablist"
         aria-label="${tabs.accessibilityLabel}"
+        tabindex="0"
         aria-multiselectable="false">
         <sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
-        <li role="tab"
+        <button role="tab"
             id="${tab.id}-tab"
             class="cmp-tabs__tab${isActive ? ' cmp-tabs__tab--active' : ''}"
+            type="button"
             aria-controls="${tab.id}-tabpanel"
-            tabindex="${isActive ? '0' : '-1'}"
-            data-cmp-hook-tabs="tab">${tab.title}</li>
-    </ol>
+            tabindex="${isActive ? '' : '-1'}"
+            data-cmp-hook-tabs="tab">${tab.title}</button>
+    </div>
     <div data-sly-repeat.item="${items}"
          data-sly-resource="${item.resource @ decorationTagName='div'}"
          id="${item.id}-tabpanel"


### PR DESCRIPTION
### Feature Request

**Is your feature request related to a problem? Please describe.**
In a recent accessibility audit, it was observed that the Tabs component does not follow the structure of the W3C design pattern : Tabs indicator should use the "button" tag with the role="tab" (element with"button" tag already have an implicit "tabindex" and natively support the enter/space keyboard activation)

To take into account the case of multiple tabs (or tabs with a long text content), we organized some user test. It seems that it's better to have all the tabs in one row in desktop and mobile with an horizontal scroll. To fix-it, we also add a tabindex="0" attribute on the tablist container and we do a small improvment to the CSS file. 

We are also thinking about adding an "Orientation" parameter to describe if the tablist will be displayed horizontally or vertically ( [branch also available on github](https://github.com/renow-luxembourg/aem-core-wcm-components/tree/renow_fix_tabs_orientation))

**Environment**
AEM 6.5
Core Components version 2.28.0

**Documentation**
We have to implement the properties specified in the design pattern of tabs :
https://www.w3.org/WAI/ARIA/apg/patterns/tabs/