### PR TITLE
Issue #2728 [Image v3] Add a lang attribute on image

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
@@ -153,6 +153,7 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
         super.initModel();
         boolean altValueFromDAM = properties.get(PN_ALT_VALUE_FROM_DAM, currentStyle.get(PN_ALT_VALUE_FROM_DAM, true));
         boolean titleValueFromDAM = properties.get(PN_TITLE_VALUE_FROM_DAM, currentStyle.get(PN_TITLE_VALUE_FROM_DAM, true));
+        boolean langValueFromDAM = properties.get(PN_LANG_VALUE_FROM_DAM, currentStyle.get(PN_LANG_VALUE_FROM_DAM, true));
         boolean isDmFeaturesEnabled = currentStyle.get(PN_DESIGN_DYNAMIC_MEDIA_ENABLED, false);
         displayPopupTitle = properties.get(PN_DISPLAY_POPUP_TITLE, currentStyle.get(PN_DISPLAY_POPUP_TITLE, true));
         boolean uuidDisabled = currentStyle.get(PN_UUID_DISABLED, false);
@@ -181,6 +182,9 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
                     }
                     if (titleValueFromDAM) {
                         title = StringUtils.trimToNull(asset.getMetadataValue(DamConstants.DC_TITLE));
+                    }
+                    if (langValueFromDAM) {
+                        lang = asset.getMetadataValue(DamConstants.DC_LANGUAGE);
                     }
 
                     //check "Enable DM features" checkbox

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/image.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/image.html
@@ -28,6 +28,7 @@
      data-cmp-hook-image="imageV3"
      class="cmp-image${!wcmmode.disabled ? ' cq-dd-image' : ''}"
      itemscope itemtype="http://schema.org/ImageObject">
+    <sly data-sly-set.contentLang="${navItem.page.properties.contentLang}"/>
     <a data-sly-unwrap="${!image.imageLink.valid}"
        class="cmp-image__link"
        data-sly-attribute="${image.imageLink.htmlAttributes}"
@@ -37,9 +38,12 @@
              loading="${image.lazyEnabled ? 'lazy' : ''}"
              class="cmp-image__image"
              itemprop="contentUrl"
-             width="${image.width}" height="${image.height}"
+             width="${image.width}"
+             height="${image.height}"
              sizes="${image.sizes}"
-             alt="${image.alt || true}" title="${image.displayPopupTitle && image.title}"/>
+             alt="${image.alt || true}"
+             title="${image.displayPopupTitle && image.title}"
+             lang="${image.lang && image.lang != contentLang ? image.lang : ''}"/>
     </a>
     <span class="cmp-image__title" itemprop="caption" data-sly-test="${!image.displayPopupTitle && image.title}">${image.title}</span>
     <meta itemprop="caption" content="${image.title}" data-sly-test="${image.displayPopupTitle && image.title}">


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | Fixes #2728 
| Patch: Bug Fix?          |
| Minor: New Feature?      | Yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

Steps :
1. Get the content of ./jcr:content/metadata/dc:language from the Image DAM properties
2. Compare this value with the current page language
3. If value are different, add a lang attribut on the img tag
