### PR TITLE
SITES-33527 remove Spotbugs Annotations Dependency in AEM Core WCM Components

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -529,12 +529,6 @@
             <artifactId>uber-jar</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <version>4.7.2</version>
-            <scope>compile</scope>
-        </dependency>
-          <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
             <version>1.5.1</version>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/embed/OEmbedXMLResponseImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/embed/OEmbedXMLResponseImpl.java
@@ -22,7 +22,6 @@ import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -49,7 +48,6 @@ public class OEmbedXMLResponseImpl implements OEmbedResponse, Serializable {
     private String html;
     private String url;
 
-    @SuppressFBWarnings(justification = "This field needs to be transient")
     protected transient List<Object> any = new ArrayList<>();
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbedUrlProcessorServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbedUrlProcessorServlet.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletResponse;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -62,7 +61,6 @@ public class EmbedUrlProcessorServlet extends SlingSafeMethodsServlet {
     private static final String PARAM_URL = "url";
     private static final long serialVersionUID = 2187626333327104828L;
 
-    @SuppressFBWarnings(justification = "This field needs to be transient")
     private transient List<UrlProcessor> urlProcessors = new ArrayList<>();
 
     @Override

--- a/bundles/core/src/test/resources/findbugs-exclude.xml
+++ b/bundles/core/src/test/resources/findbugs-exclude.xml
@@ -38,4 +38,15 @@
     <Match>
         <Bug pattern="EI_EXPOSE_REP2" />
     </Match>
+    <!-- The two fields below need to be transient -->
+    <Match>
+        <Class name="com.adobe.cq.wcm.core.components.internal.services.embed.OEmbedXMLResponseImpl" />
+        <Field name="any" />
+        <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED" />
+    </Match>
+    <Match>
+        <Class name="com.adobe.cq.wcm.core.components.internal.servlets.embed.EmbedUrlProcessorServlet" />
+        <Field name="urlProcessors" />
+        <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED" />
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Jira [SITES-33527](https://jira.corp.adobe.com/browse/SITES-33527)
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

Remove unneeded and barely used dependency, for which an alternative exists.

`spotbugs-annotations` provided a set of Java annotations used in static code scans at build time via Maven plugin. They were previously only used to exclude 2 fields from this scanning. This exclusion is now done in `findbugs-exclude.xml`, in the same manner as other preexisting exclusion rules


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
