### PR TITLE
SITES-33816 Image V3 – Dynamic Media dialog options not refreshed when toggling “Inherit featured image from page” option

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
@@ -347,6 +347,7 @@
             if (checkbox.checked) {
                 $cqFileUpload.hide();
                 $pageImageThumbnail.show();
+                $dynamicMediaGroup.hide();
             } else {
                 $cqFileUpload.show();
                 $pageImageThumbnail.hide();
@@ -440,7 +441,9 @@
                 if (isFileDM === undefined || isFileDM.trim() === "" || !areDMFeaturesEnabled) {
                     $dynamicMediaGroup.hide();
                 } else {
-                    $dynamicMediaGroup.show();
+                    if (!imageFromPageImage.checked) {
+                        $dynamicMediaGroup.show();
+                    }
                     getSmartCropRenditions(data["dam:scene7File"]);
                 }
             }
@@ -481,7 +484,9 @@
         imagePropertiesRequest.setRequestHeader("X-Adobe-Accept-Experimental", "1");
         imagePropertiesRequest.onload = function() {
             if (imagePropertiesRequest.status >= 200 && imagePropertiesRequest.status < 400) {
-                $dynamicMediaGroup.show();
+                if (!imageFromPageImage.checked) {
+                    $dynamicMediaGroup.show();
+                }
                 $(imagePresetRadio).parent().hide();
                 $(smartCropRadio).prop("checked", true);
                 var responseText = imagePropertiesRequest.responseText;

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/editor/js/image.js
@@ -347,6 +347,7 @@
             if (checkbox.checked) {
                 $cqFileUpload.hide();
                 $pageImageThumbnail.show();
+                // dynamic media options are not relevant if image is inherited from page image
                 $dynamicMediaGroup.hide();
             } else {
                 $cqFileUpload.show();
@@ -441,6 +442,7 @@
                 if (isFileDM === undefined || isFileDM.trim() === "" || !areDMFeaturesEnabled) {
                     $dynamicMediaGroup.hide();
                 } else {
+                    // show dynamic media options only if the shown image is not inherited from page image
                     if (!imageFromPageImage.checked) {
                         $dynamicMediaGroup.show();
                     }
@@ -484,6 +486,7 @@
         imagePropertiesRequest.setRequestHeader("X-Adobe-Accept-Experimental", "1");
         imagePropertiesRequest.onload = function() {
             if (imagePropertiesRequest.status >= 200 && imagePropertiesRequest.status < 400) {
+                // show dynamic media options only if the shown image is not inherited from page image
                 if (!imageFromPageImage.checked) {
                     $dynamicMediaGroup.show();
                 }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

Jira [SITES-33816](https://jira.corp.adobe.com/browse/SITES-33816)

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

Fix bug where under specific conditions, Dynamic Media related dialog options in Image V3 editor would still show if "Inherit featured image from page" checkbox is checked. Dynamic Media options should never show in these cases since they are not relevant for inherited images.

To reproduce:

1\. In a template where the component policy has “Enable DM features” selected, add an Image V3 component.
2\. Ensure a DM-processed asset is configured at page properties (Featured Image).
3\. Open the Image V3 dialog: “Inherit featured image from page” is selected by default and DM options are hidden – OK.
4\. Uncheck “Inherit featured image from page”, browse and select any DM-processed asset. DM options appear – OK.
5\. Re-check “Inherit featured image from page” (the inherited asset is DM-processed). Actual: DM options stay visible.
6\. Change the featured image at page properties, reopen the component dialog with “Inherit…” still checked.

Dynamic Media group is initially hidden and then shown if considered necessary.

Fix contains multiple aspects:

- in togglePageImageInherited function which is called when the "inherit featured image from page" checkbox is clicked, hide dynamic media group if checkbox is now checked and image is inherited from page image
- To ensure correct behavior when reopening page after having uploaded a DM enabled asset beforehand , case in which DM group would have been shown because of this: where dynamicMediaGroup is shown as part of the function retrieveDAMasset, avoid showing the DM options if image is inherited from page image
