### PR TITLE
SITES-31669: Unlocalized strings 'This page redirects to' in Tools > Sites > Launches

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/redirect.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/redirect.html
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <template data-sly-template.redirect="${ @ redirectTarget}">
-    <p class="cmp-page__redirect">${'This page redirects to' @ i18n}
+    <p class="cmp-page__redirect">${'This page redirects to' @ i18n, locale=request.locale}
         <a href="${redirectTarget.getURL}">${redirectTarget.page.title || redirectTarget.getURL}</a>
     </p>
 </template>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/redirect.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/redirect.html
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <template data-sly-template.redirect="${ @ redirectTarget}">
-    <p class="cmp-page__redirect">${'This page redirects to' @ i18n}
+    <p class="cmp-page__redirect">${'This page redirects to' @ i18n, locale=request.locale}
         <a data-sly-attribute="${redirectTarget.link.htmlAttributes}" data-sly-unwrap="${!redirectTarget.link.valid}">${redirectTarget.page.title || redirectTarget.link.URL}</a>
     </p>
 </template>


### PR DESCRIPTION
Fixes [SITES-31669](https://jira.corp.adobe.com/browse/SITES-31669) 

Pass request locale

<img width="1920" height="1040" alt="redirect" src="https://github.com/user-attachments/assets/d44bb108-3c0c-4caf-bca8-f9575edb59af" />


<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
