### PR TITLE
SITES-22059: Unlocalized strings in PDF Viewer

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/pdfviewer/v1/pdfviewer/clientlibs/site/js/pdfviewer.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/pdfviewer/v1/pdfviewer/clientlibs/site/js/pdfviewer.js
@@ -59,7 +59,8 @@
         var adobeDCView = new window.AdobeDC.View({
             clientId: component.dataset.cmpClientId,
             divId: component.id + "-content",
-            reportSuiteId: component.dataset.cmpReportSuiteId
+            reportSuiteId: component.dataset.cmpReportSuiteId,
+            locale: Granite.I18n.getLocale()
         });
         adobeDCView.previewFile({
             content: { location: { url: component.dataset.cmpDocumentPath } },

--- a/content/src/content/jcr_root/apps/core/wcm/components/pdfviewer/v1/pdfviewer/pdfviewer.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/pdfviewer/v1/pdfviewer/pdfviewer.html
@@ -23,8 +23,8 @@
      data-cmp-document-path="${pdfViewer.documentPath}"
      data-cmp-document-file-name="${pdfViewer.documentFileName}"
      data-cmp-viewer-config-json="${pdfViewer.viewerConfigJson}"
-     data-sly-set.clientIdError="${'Please setup Context Aware Configuration (com.adobe.cq.wcm.core.components.internal.services.pdfviewer.PdfViewerCaConfig) in /conf and link it using sling:configRef on any current/parent node.' @ i18n}"
-     data-sly-set.documentPathError="${'Please select a document to display.' @ i18n}"
+     data-sly-set.clientIdError="${'Please setup Context Aware Configuration (com.adobe.cq.wcm.core.components.internal.services.pdfviewer.PdfViewerCaConfig) in /conf and link it using sling:configRef on any current/parent node.' @ i18n, locale=request.locale}"
+     data-sly-set.documentPathError="${'Please select a document to display.' @ i18n, locale=request.locale}"
      data-sly-set.error="${!pdfViewer.clientId ? clientIdError : (!pdfViewer.documentPath ? documentPathError : false)}"
      data-sly-test="${!error}"
      data-cmp-data-layer="${pdfViewer.data.json}">


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

Fixes [SITES-22059](https://jira.corp.adobe.com/browse/SITES-22059), [SITES-21743](https://jira.corp.adobe.com/browse/SITES-21743) & [SITES-10498](https://jira.corp.adobe.com/browse/SITES-10498) 

Pass request locale for validation errors & page locale for pdf viewer instance

<img width="1920" height="1040" alt="pdf viewer" src="https://github.com/user-attachments/assets/0695a702-63dd-4875-ba0a-4cf603b47c55" />



| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
