### PR TITLE
SITES-30959: Unlocalized strings in Page Editor > Image component

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/pageimagethumbnail/v1/pageimagethumbnail/pageimagethumbnail.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/pageimagethumbnail/v1/pageimagethumbnail/pageimagethumbnail.html
@@ -32,9 +32,9 @@
                     </svg>
                 </coral-icon>
             </div>
-            <button data-sly-test="${hasSrc}" type="button" class="cq-FileUpload-edit _coral-Button _coral-Button--primary _coral-Button--quiet" disabled data-cq-fileupload-filereference="${thumbnail.fileReference}"><coral-button-label class="_coral-Button-label">Edit</coral-button-label></button>
-            <button data-sly-test="${hasSrc}" type="button" class="cq-FileUpload-clear _coral-Button _coral-Button--primary _coral-Button--quiet" disabled><coral-button-label class="_coral-Button-label">Clear</coral-button-label></button>
-            <button data-sly-test="${hasSrc}" type="button" class="cq-FileUpload-picker _coral-Button _coral-Button--primary _coral-Button--quiet" disabled><coral-button-label class="_coral-Button-label">Pick</coral-button-label></button>
+            <button data-sly-test="${hasSrc}" type="button" class="cq-FileUpload-edit _coral-Button _coral-Button--primary _coral-Button--quiet" disabled data-cq-fileupload-filereference="${thumbnail.fileReference}"><coral-button-label class="_coral-Button-label">${'Edit' @ i18n}</coral-button-label></button>
+            <button data-sly-test="${hasSrc}" type="button" class="cq-FileUpload-clear _coral-Button _coral-Button--primary _coral-Button--quiet" disabled><coral-button-label class="_coral-Button-label">${'Clear' @ i18n}</coral-button-label></button>
+            <button data-sly-test="${hasSrc}" type="button" class="cq-FileUpload-picker _coral-Button _coral-Button--primary _coral-Button--quiet" disabled><coral-button-label class="_coral-Button-label">${'Pick' @ i18n}</coral-button-label></button>
         </div>
     </coral-fileupload>
 </div>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

Fixes [SITES-30959](https://jira.corp.adobe.com/browse/SITES-30959)

Translate button labels using `i18n`

<img width="1920" height="1040" alt="buttons" src="https://github.com/user-attachments/assets/b9b2920d-c861-44c2-8271-0ec573e6968b" />


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
