### PR TITLE
SITES-19785: Strings is unlocalized in Core Components site > Tabs

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/childreneditor/v1/childreneditor/childreneditor.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/childreneditor/v1/childreneditor/childreneditor.html
@@ -45,7 +45,7 @@
                    name="./${item.name}/cq:panelTitle"
                    value="${item.value}"
                    data-sly-attribute.disabled="${item.isLiveCopy}"
-                   placeholder="${item.title}" required>
+                   placeholder="${item.title @ i18n}" required>
         </div>
     </coral-multifield-item>
     <input type="hidden" name="itemOrder" data-cmp-hook-childreneditor="order">

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/childreneditor/v1/childreneditor/icon.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/dialog/childreneditor/v1/childreneditor/icon.html
@@ -16,12 +16,12 @@
 <sly data-sly-template.icon="${@ item}">
     <span class="cmp-childreneditor__item-icon"
           data-cmp-hook-childreneditor="itemIcon">
-        <coral-icon data-sly-test="${item.iconName}" icon="${item.iconName}" title="${item.title}"></coral-icon>
-        <img data-sly-test="${!item.iconName && item.iconPath}" src="${item.iconPath}" title="${item.title}"/>
+        <coral-icon data-sly-test="${item.iconName}" icon="${item.iconName}" title="${item.title @ i18n}"></coral-icon>
+        <img data-sly-test="${!item.iconName && item.iconPath}" src="${item.iconPath}" title="${item.title @ i18n}"/>
         <coral-tag data-sly-test="${!item.iconName && !item.iconPath && item.iconAbbreviation}"
                    class="cmp-childreneditor__item-tag"
                    color="grey"
                    size="M"
-                   title="${item.title}">${item.iconAbbreviation}</coral-tag>
+                   title="${item.title @ i18n}">${item.iconAbbreviation}</coral-tag>
     </span>
 </sly>

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/languagenavigation/.content.xml
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/languagenavigation/.content.xml
@@ -18,6 +18,6 @@
     cq:icon="globeGrid"
     jcr:description="Global language structure navigation"
     jcr:primaryType="cq:Component"
-    jcr:title="Language Navigation "
+    jcr:title="Language Navigation"
     sling:resourceSuperType="core/wcm/components/languagenavigation/v2/languagenavigation"
     componentGroup="Core Components Examples"/>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

Fixes [SITES-19785](https://jira.corp.adobe.com/browse/SITES-19785)

Localize titles in `Tabs` configuration dialog

<img width="1920" height="1040" alt="tabs" src="https://github.com/user-attachments/assets/c854f42d-8212-44a5-b565-67f26280906f" />



| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
