### PR TITLE
SITES-23664: Incorrect percentage format in Template Editor > "Progress Bar" components

### DIFF
--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/progressbar.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/progressbar.less
@@ -54,3 +54,14 @@
         background-color: rgb(46,108,163);
     }
 }
+
+:lang(de), :lang(es), :lang(fr) {
+    .cmp-progressbar {
+        .cmp-progressbar__label--completed:after {
+            content: ' %';
+        }
+    	.cmp-progressbar__label--remaining:after {
+            content: ' %';
+        }
+    }
+}


### PR DESCRIPTION

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

Fixes [SITES-23664](https://jira.corp.adobe.com/browse/SITES-23664)

Change format for specific locales

<img width="1920" height="1040" alt="progress" src="https://github.com/user-attachments/assets/013cd9d4-a1bb-40ad-9bc3-a5ca1b3d4fcf" />


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
