### PR TITLE
SITES-31575: Info tooltip is not fully visible in Page editor > Carousel component > Properties

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/editor/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/clientlibs/editor/js/carousel.js
@@ -46,6 +46,15 @@
                 }
 
                 setupActiveSelect(dialogContent);
+
+                // Set tooltips boundary
+                var tooltips = $(selectors.autoplayGroup).find("coral-tooltip");
+                tooltips.each(function() {
+                    var tooltip = this;
+                    tooltip.set({
+                        within: $(selectors.autoplayGroup)
+                    });
+                });
             }
         }
     });


### PR DESCRIPTION
Fixes [SITES-31575](https://jira.corp.adobe.com/browse/SITES-31575)

Set boundary for tooltips in Carousel configuration dialog

<img width="1920" height="1040" alt="tooltip" src="https://github.com/user-attachments/assets/43b39540-844e-48d6-afdb-d8df896b058a" />


<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Set boundary for tooltips in Carousel configuration dialog` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
