### PR TITLE
SITES-22059 - Unlocalized "File preview not available" string in Core Components site > PDF Viewer

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/pdfviewer/v1/pdfviewer/clientlibs/site/js/pdfviewer.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/pdfviewer/v1/pdfviewer/clientlibs/site/js/pdfviewer.js
@@ -60,7 +60,7 @@
             clientId: component.dataset.cmpClientId,
             divId: component.id + "-content",
             reportSuiteId: component.dataset.cmpReportSuiteId,
-            locale: Granite.I18n.getLocale()
+            locale: Granite && Granite.I18n ? Granite.I18n.getLocale() : navigator.language || navigator.userLanguage
         });
         adobeDCView.previewFile({
             content: { location: { url: component.dataset.cmpDocumentPath } },


### PR DESCRIPTION
* null-safe locale handling

