### PR TITLE
[SITES-25240] Call to Action fields in the Teaser Modal do not have a visible label

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -373,6 +373,7 @@
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                             emptyText="Link"
+                                                            fieldLabel="Link"
                                                             name="link"
                                                             required="{Boolean}true"
                                                             rootPath="/content">
@@ -385,6 +386,7 @@
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                             emptyText="Text"
+                                                            fieldLabel="Text"
                                                             name="text"
                                                             required="{Boolean}true">
                                                             <granite:data

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/clientlibs/editor/css/teaser.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/clientlibs/editor/css/teaser.less
@@ -22,6 +22,11 @@
 
 .cmp-teaser__editor-action {
     display: flex;
+    justify-content: space-between;
+}
+
+.cmp-teaser__editor-multifield_actions .coral3-Multifield-remove, .cmp-teaser__editor-multifield_actions .coral3-Multifield-move {
+    top: 1.5rem;
 }
 
 .cmp-teaser__editor-action .cmp-teaser__editor-actionField-linkUrl.coral-Form-field {


### PR DESCRIPTION
… 

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

Ticket: [SITES-25240](https://jira.corp.adobe.com/browse/SITES-25240)

Description: added labels for Link and Text inputs in the multifield element


