### PR TITLE
SITES-25240 Call to Action fields in the Teaser Modal do not have a visible label

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -358,12 +358,12 @@
                                                     expression="${cqDesign.actionsDisabled}"/>
                                             </actionsDisabled>
                                             <actions
-                                                granite:class="foundation-toggleable cmp-teaser__editor-multifield_actions"
+                                                granite:class="foundation-toggleable cmp-teaser__editor-multifield_actions cmp-teaser_v1__editor-multifield_actions"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
                                                 composite="{Boolean}true">
                                                 <field
-                                                    granite:class="cmp-teaser__editor-action"
+                                                    granite:class="cmp-teaser__editor-action cmp-teaser-v1__editor-action"
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/container"
                                                     name="./actions">
@@ -373,6 +373,7 @@
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                             emptyText="Link"
+                                                            fieldLabel="Link"
                                                             name="link"
                                                             required="{Boolean}true"
                                                             rootPath="/content">
@@ -385,6 +386,7 @@
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                             emptyText="Text"
+                                                            fieldLabel="Text"
                                                             name="text"
                                                             required="{Boolean}true">
                                                             <granite:data

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/clientlibs/editor/css/teaser.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/clientlibs/editor/css/teaser.less
@@ -33,3 +33,12 @@
     width: 20%;
     margin-left: @cmp-teaser__editor-actions-spacing;
 }
+
+.cmp-teaser_v1__editor-multifield_actions .cmp-teaser-v1__editor-action {
+    display: flex;
+    justify-content: space-between;
+}
+
+.cmp-teaser_v1__editor-multifield_actions ._coral-Multifield-remove, .cmp-teaser_v1__editor-multifield_actions ._coral-Multifield-move {
+    top: 2.1rem;
+}

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/clientlibs/editor/css/teaser.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/clientlibs/editor/css/teaser.less
@@ -42,3 +42,12 @@
 .cmp-teaser_v1__editor-multifield_actions ._coral-Multifield-remove, .cmp-teaser_v1__editor-multifield_actions ._coral-Multifield-move {
     top: 2.1rem;
 }
+
+.cmp-teaser_v1__editor-multifield_actions .coral3-Multifield-remove, .cmp-teaser_v1__editor-multifield_actions .coral3-Multifield-move {
+    top: 1.7rem;
+}
+
+.cmp-teaser_v1__editor-multifield_actions .cmp-teaser-v1__editor-action .cmp-teaser__editor-actionField {
+    margin: 0;
+    width: auto;
+}

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/_cq_dialog/.content.xml
@@ -39,7 +39,7 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/include"
                                                 path="/mnt/overlay/core/wcm/components/commons/editor/dialog/link/v1/link/edit/link"/>
                                             <actions
-                                                granite:class="foundation-toggleable cmp-teaser__editor-multifield_actions"
+                                                granite:class="foundation-toggleable cmp-teaser__editor-multifield_actions cmp-teaser_v2__editor-multifield_actions"
                                                 granite:hide="${cqDesign.actionsDisabled}"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
@@ -47,7 +47,7 @@
                                                 fieldDescription="Allows to link the teaser to multiple destinations. The page linked in the first call to action is used when inheriting the teaser title, description or image."
                                                 fieldLabel="Call-to-actions">
                                                 <field
-                                                    granite:class="cmp-teaser__editor-action"
+                                                    granite:class="cmp-teaser__editor-action cmp-teaser-v2__editor-action"
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/container"
                                                     name="./actions">
@@ -57,6 +57,7 @@
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="cq/gui/components/coral/common/form/pagefield"
                                                             emptyText="Link"
+                                                            fieldLabel="Link"
                                                             name="link"
                                                             required="{Boolean}true"
                                                             rootPath="/content">
@@ -82,6 +83,7 @@
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                             emptyText="Text"
+                                                            fieldLabel="Text"
                                                             name="text"
                                                             required="{Boolean}true">
                                                             <granite:data

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/clientlibs/editor/css/teaser.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser/clientlibs/editor/css/teaser.less
@@ -38,3 +38,17 @@
 .cmp-teaser__editor-action coral-tooltip {
     min-width: 100px;
 }
+
+.cmp-teaser_v2__editor-multifield_actions .cmp-teaser-v2__editor-action .cmp-teaser__editor-actionField-linkUrl, .cmp-teaser_v2__editor-multifield_actions .cmp-teaser-v2__editor-action .cmp-teaser__editor-actionField-linkText {
+    width: 90%;
+    margin: 0;
+}
+
+.cmp-teaser_v2__editor-multifield_actions .cmp-teaser-v2__editor-action .coral-Form-fieldwrapper--singleline {
+    top: 35px;
+    margin-right: 15px;
+}
+
+.cmp-teaser_v2__editor-multifield_actions ._coral-Multifield-remove, .cmp-teaser_v2__editor-multifield_actions ._coral-Multifield-move {
+    top: 35px;
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | [SITES-25240](https://jira.corp.adobe.com/browse/SITES-25240)<!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 
| Minor: New Feature?      | adding visual labels for the fields
| Major: Breaking Change?  |
| Tests Added + Pass?      | no added tests
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

650:
Before
<img width="721" height="664" alt="650-before" src="https://github.com/user-attachments/assets/65a70338-7814-44e3-b431-ee5d3391591a" />


After
<img width="740" height="692" alt="650-after" src="https://github.com/user-attachments/assets/06d1d344-9429-4fb9-97c8-4b39c38caf13" />


cloud: 
Teaser v2 

Before

<img width="678" height="689" alt="teaser_v2_cloud before" src="https://github.com/user-attachments/assets/41600c0e-23da-4579-93ee-5222431a5fab" />


After
<img width="617" height="287" alt="teaser_v2 cloud after" src="https://github.com/user-attachments/assets/d599e96a-3ac8-4beb-9093-3203eaf89e81" />

Teaser V1

Before
<img width="669" height="610" alt="teaser_v1 cloud after before" src="https://github.com/user-attachments/assets/cd6b4e43-448f-4372-bfea-75dfcea78741" />

After
<img width="658" height="358" alt="teaser_v1 cloud after" src="https://github.com/user-attachments/assets/a96ce14d-6428-4231-a744-2a808c0d114e" />

