### PR TITLE
SITES-35218 - [SLA3] Some AEM core component does not render empty alt tag properly

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
@@ -237,7 +237,7 @@ public interface Image extends Component {
 
     /**
      * Returns a Map with attributes for HTML {@code img} tag if the attributes have a non-empty value.
-     * If an attribute has empty vlue the attribute is not added to the map.
+     * If an attribute has empty value the attribute is not added to the map.
      * Currently only alt is returned by this method in order to properly render alt="" in HTL.
      *
      * @return {@link Map} with HTML-specific {@code img} attributes with non-empty values*

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
@@ -15,8 +15,11 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.models;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ConsumerType;
@@ -230,6 +233,18 @@ public interface Image extends Component {
      */
     default String getAlt() {
         return null;
+    }
+
+    /**
+     * Returns the value for the {@code alt} attribute of the image as a map.
+     *
+     * @return the value for the image's {@code alt} attribute as map with a single key 'alt' and value if one was set,
+     * or empty map otherwise
+     * @since com.adobe.cq.wcm.core.components.models 12.30.0
+     */
+    default Map<String, String> getAltAsMap() {
+        final String alt = getAlt();
+        return StringUtils.isBlank(alt) ? Collections.emptyMap() : Collections.singletonMap("alt", alt);
     }
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
@@ -236,13 +236,15 @@ public interface Image extends Component {
     }
 
     /**
-     * Returns the value for the {@code alt} attribute of the image as a map.
+     * Returns a Map with attributes for HTML {@code img} tag if the attributes have a non-empty value.
+     * If an attribute has empty vlue the attribute is not added to the map.
+     * Currently only alt is returned by this method in order to properly render alt="" in HTL.
      *
-     * @return the value for the image's {@code alt} attribute as map with a single key 'alt' and value if one was set,
-     * or empty map otherwise
+     * @return {@link Map} with HTML-specific {@code img} attributes with non-empty values*
      * @since com.adobe.cq.wcm.core.components.models 12.30.0
      */
-    default Map<String, String> getAltAsMap() {
+    @NotNull
+    default Map<String, String> getHtmlAttributes() {
         final String alt = getAlt();
         return StringUtils.isBlank(alt) ? Collections.emptyMap() : Collections.singletonMap("alt", alt);
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.29.0")
+@Version("12.30.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/models/ImageTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/models/ImageTest.java
@@ -27,29 +27,29 @@ import static org.mockito.Mockito.when;
 public class ImageTest {
 
     @Test
-    public void testGetAltAsMap() {
+    public void testGetHtmlAttributes() {
         Image mockImage = mock(Image.class);
 
         // Test with non-empty alt text
         when(mockImage.getAlt()).thenReturn("Sample alt text");
-        when(mockImage.getAltAsMap()).thenCallRealMethod();
-        Map<String, String> altMap = mockImage.getAltAsMap();
+        when(mockImage.getHtmlAttributes()).thenCallRealMethod();
+        Map<String, String> altMap = mockImage.getHtmlAttributes();
         assertEquals(1, altMap.size());
         assertEquals("Sample alt text", altMap.get("alt"));
 
         // Test with empty alt text
         when(mockImage.getAlt()).thenReturn("");
-        altMap = mockImage.getAltAsMap();
+        altMap = mockImage.getHtmlAttributes();
         assertTrue(altMap.isEmpty());
 
         // Test with null alt text
         when(mockImage.getAlt()).thenReturn(null);
-        altMap = mockImage.getAltAsMap();
+        altMap = mockImage.getHtmlAttributes();
         assertTrue(altMap.isEmpty());
 
         // Test with whitespace-only alt text
         when(mockImage.getAlt()).thenReturn("   ");
-        altMap = mockImage.getAltAsMap();
+        altMap = mockImage.getHtmlAttributes();
         assertTrue(altMap.isEmpty());
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/models/ImageTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/models/ImageTest.java
@@ -1,0 +1,55 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2025 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.models;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ImageTest {
+
+    @Test
+    public void testGetAltAsMap() {
+        Image mockImage = mock(Image.class);
+
+        // Test with non-empty alt text
+        when(mockImage.getAlt()).thenReturn("Sample alt text");
+        when(mockImage.getAltAsMap()).thenCallRealMethod();
+        Map<String, String> altMap = mockImage.getAltAsMap();
+        assertEquals(1, altMap.size());
+        assertEquals("Sample alt text", altMap.get("alt"));
+
+        // Test with empty alt text
+        when(mockImage.getAlt()).thenReturn("");
+        altMap = mockImage.getAltAsMap();
+        assertTrue(altMap.isEmpty());
+
+        // Test with null alt text
+        when(mockImage.getAlt()).thenReturn(null);
+        altMap = mockImage.getAltAsMap();
+        assertTrue(altMap.isEmpty());
+
+        // Test with whitespace-only alt text
+        when(mockImage.getAlt()).thenReturn("   ");
+        altMap = mockImage.getAltAsMap();
+        assertTrue(altMap.isEmpty());
+    }
+}

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/image.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/image.html
@@ -39,7 +39,7 @@
              itemprop="contentUrl"
              width="${image.width}" height="${image.height}"
              sizes="${image.sizes}"
-             alt="${image.alt || true}" title="${image.displayPopupTitle && image.title}"/>
+             alt="" data-sly-attribute="${image.altAsMap}" title="${image.displayPopupTitle && image.title}"/>
     </a>
     <span class="cmp-image__title" itemprop="caption" data-sly-test="${!image.displayPopupTitle && image.title}">${image.title}</span>
     <meta itemprop="caption" content="${image.title}" data-sly-test="${image.displayPopupTitle && image.title}">

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/image.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/image.html
@@ -39,7 +39,7 @@
              itemprop="contentUrl"
              width="${image.width}" height="${image.height}"
              sizes="${image.sizes}"
-             alt="" data-sly-attribute="${image.altAsMap}" title="${image.displayPopupTitle && image.title}"/>
+             alt="" data-sly-attribute="${image.htmlAttributes}" title="${image.displayPopupTitle && image.title}"/>
     </a>
     <span class="cmp-image__title" itemprop="caption" data-sly-test="${!image.displayPopupTitle && image.title}">${image.title}</span>
     <meta itemprop="caption" content="${image.title}" data-sly-test="${image.displayPopupTitle && image.title}">


### PR DESCRIPTION
* return alt property for ing element as a map to be able to render alt=""

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-35218
| Patch: Bug Fix?          | Y
| Minor: New Feature?      | 
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
