### PR TITLE
Fix SITES-17531: Hardcoded "Smart crop preview" string in in Page Editor > Image > Smart Crop

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/nextgendmthumbnail/nextgendmthumbnail.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image/nextgendmthumbnail/nextgendmthumbnail.html
@@ -14,5 +14,5 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <sly data-sly-use.thumbnail="com.adobe.cq.wcm.core.components.commons.editor.nextgendm.NextGenDMThumbnail" data-sly-use.inheritedField="com.adobe.cq.wcm.core.components.commons.editor.dialog.inherited.InheritedField">
-     <img src="${thumbnail.src}"  class="${inheritedField.attrClass}" alt="${thumbnail.alt}"/>
+     <img src="${thumbnail.src}"  class="${inheritedField.attrClass}" alt="${thumbnail.alt @ i18n, locale=request.locale}"/>
 </sly>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes [SITES-17531](https://jira.corp.adobe.com/browse/SITES-17531)
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
