### PR TITLE
SITES-35060 [SLA3] Regression – Title Component Policy Dialog Throws False “Select at least one size option” Error (SDK 2025.4+)

### DIFF
--- a/testing/it/it.ui.apps/package-lock.json
+++ b/testing/it/it.ui.apps/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "com.adobe.cq.core.wcm.components.it.ui.apps",
+    "name": "com.adobe.cq.core.wcm.components.it.content",
     "version": "2.30.3-SNAPSHOT",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "com.adobe.cq.core.wcm.components.it.ui.apps",
+            "name": "com.adobe.cq.core.wcm.components.it.content",
             "version": "2.30.3-SNAPSHOT",
             "license": "Apache-2.0",
             "devDependencies": {


### PR DESCRIPTION
[SITES-35060](https://jira.corp.adobe.com/browse/SITES-35060)
[SLA3] Regression – Title Component Policy Dialog Throws False “Select at least one size option” Error (SDK 2025.4+)

**Problem Description**
When editing a Title component policy (design dialog - Template Editor):
• The Allowed Types / Sizes list shows six check-boxes (H1 … H6).
• If an author deselects any one size while at least one other size remains checked, the dialog immediately displays error "Select at least one size option" and does not allow to Save (clicking Done button does not do anything)
• The error should appear only when all sizes are unchecked.


**Summary**
Fixes incorrect validation in the Title component design dialog: the dialog no longer recognized the full group of size checkboxes due to updated Coral markup, causing inconsistent warnings and the Done button not being disabled when all sizes were unchecked.

**Fix**

- Updated the validator to correctly gather all size checkboxes from the shared container.
- Restored proper group-level validation: error shown only when all sizes are unchecked.
- Re-enabled dialog-level invalid state so the Done button is correctly disabled again.

**Result**
Validation works as originally intended:
- at least one size selected → dialog valid, Done enabled
- all sizes unselected → error shown, Done disabled


<img width="1224" height="550" alt="image" src="https://github.com/user-attachments/assets/ee299dd5-a410-4098-b73f-d555ff959b7a" />


<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  [SITES-35060](https://jira.corp.adobe.com/browse/SITES-35060)
[SLA3] Regression – Title Component Policy Dialog Throws False “Select at least one size option” Error (SDK 2025.4+)
| Patch: Bug Fix?          | Bug Fix
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
