### PR TITLE
SITES-42596 Core Image Component floods logs with “LinkUtil abs_path requested” when Dynamic Media hotspot images are drag-dropped - avoid logging error for standard quickview urls since they are supported product functionality

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtil.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtil.java
@@ -155,6 +155,8 @@ public class LinkUtil {
 
         } catch (Exception e) {
             if (parsed != null && isQuickviewLink(parsed.getScheme())) {
+                // SITES-42596 Since quickview URLs are supported OOTB by the product,
+                // do not log error for them
                 LOG.info("Quickview URL detected, using fallback construction: {}", path);
             } else {
                 LOG.error(e.getMessage(), e);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtil.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtil.java
@@ -154,10 +154,10 @@ public class LinkUtil {
             }
 
         } catch (Exception e) {
-            if (parsed != null && isQuickviewLink(parsed.getScheme())) {
+            if (parsed != null && isQuickviewScheme(parsed.getScheme())) {
                 // SITES-42596 Since quickview URLs are supported OOTB by the product,
                 // do not log error for them
-                LOG.info("Quickview URL detected, using fallback construction: {}", path);
+                LOG.debug("Quickview URL detected, using fallback construction: {}", path);
             } else {
                 LOG.error(e.getMessage(), e);
             }
@@ -296,11 +296,7 @@ public class LinkUtil {
         }
     }
 
-    private static boolean isQuickviewLink(String link) {
-        if (link != null) {
-            return link.startsWith(QUICKVIEW_PATTERN);
-        } else {
-            return false;
-        }
+    private static boolean isQuickviewScheme(String scheme) {
+        return QUICKVIEW_PATTERN.equals(scheme);
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtil.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtil.java
@@ -65,6 +65,8 @@ public class LinkUtil {
 
     private static final String TEL_PATTERN = "tel";
 
+    private static final String QUICKVIEW_PATTERN = "quickview";
+
     //SITES-18137: imitate the exact behavior of com.google.common.net.URL_FRAGMENT_ESCAPER
     private static final BitSet URL_FRAGMENT_SAFE_CHARS = new BitSet(256);
 
@@ -152,7 +154,11 @@ public class LinkUtil {
             }
 
         } catch (Exception e) {
-            LOG.error(e.getMessage(), e);
+            if (parsed != null && isQuickviewLink(parsed.getScheme())) {
+                LOG.info("Quickview URL detected, using fallback construction: {}", path);
+            } else {
+                LOG.error(e.getMessage(), e);
+            }
             StringBuilder sb = new StringBuilder(path);
             if (queryString != null) {
                 sb.append("?").append(maskedQueryString);
@@ -283,6 +289,14 @@ public class LinkUtil {
     private static boolean isTelLink(String link) {
         if (link != null) {
             return link.startsWith(TEL_PATTERN);
+        } else {
+            return false;
+        }
+    }
+
+    private static boolean isQuickviewLink(String link) {
+        if (link != null) {
+            return link.startsWith(QUICKVIEW_PATTERN);
         } else {
             return false;
         }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtilTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtilTest.java
@@ -94,7 +94,7 @@ class LinkUtilTest {
     @Test
     void escape_nullInputs() {
         String escaped = LinkUtil.escape(null, null, null);
-        assertNull(null, escaped);
+        assertEquals("", escaped);
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtilTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtilTest.java
@@ -90,4 +90,17 @@ class LinkUtilTest {
         String escapedQuickview = LinkUtil.escape(path, null, null);
         assertEquals(path, escapedQuickview);
     }
+
+    @Test
+    void escape_nullInputs() {
+        String escaped = LinkUtil.escape(null, null, null);
+        assertNull(null, escaped);
+    }
+
+    @Test
+    void escape_customLinkResultEqualToInput() {
+        String path = "custom:abc";
+        String escaped = LinkUtil.escape(path, null, null);
+        assertEquals(path, escaped);
+    }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtilTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtilTest.java
@@ -85,7 +85,7 @@ class LinkUtilTest {
     }
 
     @Test
-    void escape_quickviewLinkResultEqualToInput(){
+    void escape_quickviewLinkResultEqualToInput() {
         String path = "quickview:fragment=Camping in Western Australia&size=400,300&reservedVal_productPath=/content/experience-fragments/wknd/ca/en/featured/camping-western-australia";
         String escapedQuickview = LinkUtil.escape(path, null, null);
         assertEquals(path, escapedQuickview);

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtilTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtilTest.java
@@ -71,16 +71,23 @@ class LinkUtilTest {
     }
 
     @Test
-    void escape_mailToLinkNotThrowException() throws UnsupportedEncodingException {
+    void escape_mailToLinkNotThrowException() {
         String path = "mailto:mail@example.com";
         String escapedMailTo = LinkUtil.escape(path, null, null);
         assertEquals(path, escapedMailTo);
     }
 
     @Test
-    void escape_telLinkNotThrowException() throws UnsupportedEncodingException {
+    void escape_telLinkNotThrowException() {
         String path = "tel:1800";
         String escapedTel = LinkUtil.escape(path, null, null);
         assertEquals(path, escapedTel);
+    }
+
+    @Test
+    void escape_quickviewLinkResultEqualToInput(){
+        String path = "quickview:fragment=Camping in Western Australia&size=400,300&reservedVal_productPath=/content/experience-fragments/wknd/ca/en/featured/camping-western-australia";
+        String escapedQuickview = LinkUtil.escape(path, null, null);
+        assertEquals(path, escapedQuickview);
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtilTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkUtilTest.java
@@ -16,7 +16,14 @@
 package com.adobe.cq.wcm.core.components.internal.link;
 
 import java.io.UnsupportedEncodingException;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class LinkUtilTest {
@@ -85,22 +92,63 @@ class LinkUtilTest {
     }
 
     @Test
-    void escape_quickviewLinkResultEqualToInput() {
+    void escape_quickviewLink_resultEqualToInputAndLogsDebug() {
         String path = "quickview:fragment=Camping in Western Australia&size=400,300&reservedVal_productPath=/content/experience-fragments/wknd/ca/en/featured/camping-western-australia";
+
+        Logger appLogger = (Logger) LoggerFactory.getLogger(LinkUtil.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        appLogger.addAppender(appender);
+        appLogger.setLevel(Level.DEBUG);
+
         String escapedQuickview = LinkUtil.escape(path, null, null);
         assertEquals(path, escapedQuickview);
+
+        assertEquals(1, appender.list.stream()
+            .filter(entry -> Level.DEBUG.equals(entry.getLevel()))
+            .count()
+        );
+
+        assertEquals(0, appender.list.stream()
+            .filter(entry -> Level.ERROR.equals(entry.getLevel()))
+            .count()
+        );
     }
 
     @Test
-    void escape_nullInputs() {
+    void escape_nullInputs_returnsEmptyStringAndLogsError() {
+
+        Logger appLogger = (Logger) LoggerFactory.getLogger(LinkUtil.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        appLogger.addAppender(appender);
+        appLogger.setLevel(Level.DEBUG);
+
         String escaped = LinkUtil.escape(null, null, null);
         assertEquals("", escaped);
+
+        assertEquals(1, appender.list.stream()
+            .filter(entry -> Level.ERROR.equals(entry.getLevel()))
+            .count()
+        );
     }
 
     @Test
-    void escape_customLinkResultEqualToInput() {
+    void escape_customLink_resultEqualToInputAndLogsError() {
+
+        Logger appLogger = (Logger) LoggerFactory.getLogger(LinkUtil.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        appLogger.addAppender(appender);
+        appLogger.setLevel(Level.DEBUG);
+
         String path = "custom:abc";
         String escaped = LinkUtil.escape(path, null, null);
         assertEquals(path, escaped);
+
+        assertEquals(1, appender.list.stream()
+            .filter(entry -> Level.ERROR.equals(entry.getLevel()))
+            .count()
+        );
     }
 }


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?           | Jira [SITES-42596](https://jira.corp.adobe.com/browse/SITES-42596)
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

Jira [SITES-42596](https://jira.corp.adobe.com/browse/SITES-42596)

## Summary

After dragging an image onto an Image V2 or V3 component that was previously configured for Dynamic Media with hotspots, rendering the image produced unnecessary **error** logs. The `quickview:` URL is treated as invalid by `LinkUtil.escape`, which logged an error even though fallback URL construction still succeeds.

Quickview is supported OOTB for Dynamic Media interactive images, so this scenario should not be logged as an error. The change logs a **debug** message when the quickview scheme is detected in the escape fallback path (helpful for tracing hotspot usage) and keeps **error** logging for other failures.

**Code changes**

- `LinkUtil.escape`: on exception, if the parsed scheme is `quickview`, log at DEBUG with a short message; otherwise keep existing ERROR logging.
- `LinkUtilTest`: Logback `ListAppender` tests assert quickview paths emit DEBUG and no ERROR; null inputs and a custom scheme still emit ERROR as before. Minor cleanup: remove unnecessary `throws` on mailto/tel tests.

## Reproduction (WKND)

- Configure a Dynamic Media image with a hotspot per [interactive images](https://experienceleague.adobe.com/en/docs/experience-manager-65/content/assets/dynamic/interactive-images).
- Add Image V2 or V3 to a page and drag-drop that asset onto the component.

Previously, logs showed `LinkUtil` / `URIException: abs_path requested` at ERROR. With this PR, quickview cases log at DEBUG instead.

## Alternatives considered

- Filter quickview URLs in Image V2 `ImageImpl.buildAreas()` — would drop areas from the model and HTL output.
- Special-case quickview before URI construction — would encode the URL and change behavior for customer code relying on the raw quickview string ([interactive images – Cloud Service](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/assets/dynamicmedia/interactive-images)).