### PR TITLE
SITES-43943: Export composite content fragment fields in model JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ core.wcm.components.commons.datalayer.*
 **/coverage/**
 node
 **/node_modules/**
+
+.cursor/

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -173,6 +173,8 @@
                                         <!-- private enum; cannot test valueOf / values -->
                                         <exclude>com/adobe/cq/wcm/core/components/internal/models/v1/SocialMediaHelperImpl$WebsiteMetadata$Type.class</exclude>
                                         <exclude>com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet$Source.class</exclude>
+                                        <!-- Reflection-only bridge to cq-dam-cfm-extensions; exercised on AEM, not unit-testable without CFM extension types -->
+                                        <exclude>com/adobe/cq/wcm/core/components/internal/ContentFragmentCompositeUtils.class</exclude>
                                     </excludes>
                                 </configuration>
                             </execution>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentCompositeUtils.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentCompositeUtils.java
@@ -1,0 +1,344 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2026 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.dam.cfm.ContentElement;
+import com.adobe.cq.dam.cfm.FragmentData;
+
+/**
+ * Builds structured payloads for composite content fragment fields using the CFM extensions API.
+ *
+ * <p>Export shape:</p>
+ * <ul>
+ *     <li><strong>Single-valued composite</strong> ({@link ContentElement} multi-value flag {@code false}):
+ *     one JSON object with optional {@value #JSON_PN_MODEL_PATH} plus field entries (no {@code items} wrapper).</li>
+ *     <li><strong>Multi-valued composite</strong> ({@code true}): JSON array of such objects.</li>
+ * </ul>
+ *
+ * <p>The Adobe {@code cq-dam-cfm-extensions} bundle is resolved at runtime on AEM; access is reflection-based so this
+ * module builds cleanly against the AEM uber-jar alone.</p>
+ */
+public final class ContentFragmentCompositeUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ContentFragmentCompositeUtils.class);
+
+    private static final String EXT_FRAGMENT_PKG = "com.adobe.cq.dam.cfm.extensions.fragment.";
+    private static final String COMPOSITE_ELEMENT_CLASS = EXT_FRAGMENT_PKG + "CompositeElement";
+    private static final String COMPOSITE_VARIATION_CLASS = EXT_FRAGMENT_PKG + "CompositeVariation";
+
+    private static final ConcurrentHashMap<ClassLoader, Optional<Class<?>>> COMPOSITE_ELEMENT_TYPES =
+            new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<ClassLoader, Optional<Class<?>>> COMPOSITE_VARIATION_TYPES =
+            new ConcurrentHashMap<>();
+
+    /**
+     * Variation name that refers to master content.
+     */
+    public static final String MASTER_VARIATION = "master";
+
+    /**
+     * JSON property name for the resolved composite model path on each exported item.
+     */
+    public static final String JSON_PN_MODEL_PATH = "_modelPath";
+
+    /**
+     * @deprecated Legacy wrapper key; composite export no longer nests instances under {@code items}. Kept for binary
+     * compatibility of constants only.
+     */
+    @Deprecated
+    public static final String JSON_PN_ITEMS = "items";
+
+    private ContentFragmentCompositeUtils() {
+    }
+
+    /**
+     * @param element content fragment field element
+     * @return {@code true} if the element is a composite field and the CFM extensions API is present
+     */
+    public static boolean isCompositeElement(@Nullable ContentElement element) {
+        if (element == null) {
+            return false;
+        }
+        Class<?> compositeType = resolveCompositeElementType(element.getClass().getClassLoader());
+        return compositeType != null && compositeType.isInstance(element);
+    }
+
+    /**
+     * Builds a structure suitable for Jackson JSON export.
+     *
+     * @param element             top-level or nested content element
+     * @param configuredVariation variation name from the content fragment component (may be blank or master)
+     * @return for single-valued composites, a {@link Map}; for multi-valued composites, a {@link List} of maps;
+     *         {@code null} when not composite or extensions unavailable
+     */
+    @Nullable
+    public static Object buildCompositeExport(@NotNull ContentElement element,
+                                              @Nullable String configuredVariation) {
+
+        if (!isCompositeElement(element)) {
+            return null;
+        }
+
+        boolean multi = isCompositeMultiValue(element);
+        Object composite = element;
+
+        if (useMasterCompositeExport(configuredVariation)) {
+            return buildMasterCompositePayload(composite, multi);
+        }
+
+        Object compositeVariation = invokeWithStringArg(composite, "getCompositeVariation", configuredVariation);
+        if (compositeVariation == null) {
+            LOG.debug("No composite variation '{}' for element '{}', falling back to master composite export.",
+                    configuredVariation, element.getName());
+            return buildMasterCompositePayload(composite, multi);
+        }
+
+        return buildVariationCompositePayload(compositeVariation, configuredVariation, multi);
+    }
+
+    private static boolean isCompositeMultiValue(@NotNull ContentElement element) {
+        FragmentData data = element.getValue();
+        return data != null && data.getDataType().isMultiValue();
+    }
+
+    /**
+     * Uses the field template when available (variation subtree).
+     */
+    private static boolean isFieldMultiValued(@Nullable Object fieldTemplate) {
+        if (fieldTemplate == null) {
+            return false;
+        }
+        try {
+            Object dataType = fieldTemplate.getClass().getMethod("getDataType").invoke(fieldTemplate);
+            if (dataType != null) {
+                Object mv = dataType.getClass().getMethod("isMultiValue").invoke(dataType);
+                return Boolean.TRUE.equals(mv);
+            }
+        } catch (ReflectiveOperationException e) {
+            LOG.debug("Could not read multi-value flag from field template {}", fieldTemplate.getClass().getName(), e);
+        }
+        return false;
+    }
+
+    private static boolean useMasterCompositeExport(@Nullable String configuredVariation) {
+        return StringUtils.isBlank(configuredVariation) || MASTER_VARIATION.equals(configuredVariation);
+    }
+
+    @Nullable
+    private static Class<?> loadClass(@Nullable ClassLoader classLoader, String className) {
+        if (classLoader == null) {
+            return null;
+        }
+        try {
+            return classLoader.loadClass(className);
+        } catch (ClassNotFoundException e) {
+            LOG.debug("Class not found (CFM extensions may be absent): {}", className);
+            return null;
+        }
+    }
+
+    @Nullable
+    private static Class<?> resolveCompositeElementType(@Nullable ClassLoader classLoader) {
+        if (classLoader == null) {
+            return null;
+        }
+        return COMPOSITE_ELEMENT_TYPES.computeIfAbsent(classLoader,
+                cl -> Optional.ofNullable(loadClass(cl, COMPOSITE_ELEMENT_CLASS))).orElse(null);
+    }
+
+    @Nullable
+    private static Class<?> resolveCompositeVariationType(@Nullable ClassLoader classLoader) {
+        if (classLoader == null) {
+            return null;
+        }
+        return COMPOSITE_VARIATION_TYPES.computeIfAbsent(classLoader,
+                cl -> Optional.ofNullable(loadClass(cl, COMPOSITE_VARIATION_CLASS))).orElse(null);
+    }
+
+    private static Object invokeNoArg(@Nullable Object target, String methodName) {
+        if (target == null) {
+            return null;
+        }
+        try {
+            return target.getClass().getMethod(methodName).invoke(target);
+        } catch (ReflectiveOperationException e) {
+            LOG.debug("Reflective invoke failed: {} on {}", methodName, target.getClass().getName(), e);
+            return null;
+        }
+    }
+
+    private static Object invokeWithStringArg(@Nullable Object target, String methodName, String arg) {
+        if (target == null) {
+            return null;
+        }
+        try {
+            return target.getClass().getMethod(methodName, String.class).invoke(target, arg);
+        } catch (ReflectiveOperationException e) {
+            LOG.debug("Reflective invoke failed: {} on {}", methodName, target.getClass().getName(), e);
+            return null;
+        }
+    }
+
+    private static Iterator<?> invokeIterator(@Nullable Object target, String methodName) {
+        Object raw = invokeNoArg(target, methodName);
+        if (raw instanceof Iterator) {
+            return (Iterator<?>) raw;
+        }
+        return Collections.emptyIterator();
+    }
+
+    private static boolean isCompositeVariationInstance(Object structuredVariation) {
+        Class<?> cvType = resolveCompositeVariationType(structuredVariation.getClass().getClassLoader());
+        return cvType != null && cvType.isInstance(structuredVariation);
+    }
+
+    @NotNull
+    private static Object normalizeContainerRows(@NotNull List<Map<String, Object>> rows, boolean multiValue) {
+        if (multiValue) {
+            return rows;
+        }
+        if (rows.isEmpty()) {
+            return new LinkedHashMap<String, Object>();
+        }
+        return rows.get(0);
+    }
+
+    @NotNull
+    private static Object buildMasterCompositePayload(@NotNull Object compositeElement, boolean multiValue) {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        Iterator<?> containers = invokeIterator(compositeElement, "getCompositeContainers");
+        while (containers.hasNext()) {
+            Object container = containers.next();
+            if (container != null) {
+                rows.add(buildMasterItem(container));
+            }
+        }
+        return normalizeContainerRows(rows, multiValue);
+    }
+
+    @NotNull
+    private static Map<String, Object> buildMasterItem(@NotNull Object container) {
+        Map<String, Object> item = new LinkedHashMap<>();
+        Object model = invokeNoArg(container, "getModel");
+        if (model != null) {
+            Object path = invokeNoArg(model, "getPath");
+            if (path instanceof String && StringUtils.isNotBlank((String) path)) {
+                item.put(JSON_PN_MODEL_PATH, path);
+            }
+        }
+        Iterator<?> fields = invokeIterator(container, "getElements");
+        while (fields.hasNext()) {
+            Object fieldObj = fields.next();
+            if (fieldObj instanceof ContentElement) {
+                putMasterField(item, (ContentElement) fieldObj);
+            }
+        }
+        return item;
+    }
+
+    private static void putMasterField(@NotNull Map<String, Object> item, @NotNull ContentElement field) {
+        Object nameObj = invokeNoArg(field, "getName");
+        String name = nameObj instanceof String ? (String) nameObj : field.getName();
+        if (isCompositeElement(field)) {
+            boolean nestedMulti = isCompositeMultiValue(field);
+            Object nested = buildMasterCompositePayload(field, nestedMulti);
+            item.put(name, nested);
+        } else {
+            Object dataObj = invokeNoArg(field, "getValue");
+            Object value = null;
+            if (dataObj instanceof FragmentData) {
+                value = ((FragmentData) dataObj).getValue();
+            }
+            item.put(name, value);
+        }
+    }
+
+    @NotNull
+    private static Object buildVariationCompositePayload(@NotNull Object compositeVariation,
+                                                         @NotNull String variationName,
+                                                         boolean multiValue) {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        Iterator<?> containers = invokeIterator(compositeVariation, "getCompositeContainers");
+        while (containers.hasNext()) {
+            Object container = containers.next();
+            if (container != null) {
+                rows.add(buildVariationItem(container, variationName));
+            }
+        }
+        return normalizeContainerRows(rows, multiValue);
+    }
+
+    @NotNull
+    private static Map<String, Object> buildVariationItem(@NotNull Object container,
+                                                          @NotNull String variationName) {
+        Map<String, Object> item = new LinkedHashMap<>();
+        Object model = invokeNoArg(container, "getModel");
+        if (model != null) {
+            Object path = invokeNoArg(model, "getPath");
+            if (path instanceof String && StringUtils.isNotBlank((String) path)) {
+                item.put(JSON_PN_MODEL_PATH, path);
+            }
+        }
+        Iterator<?> fields = invokeIterator(container, "getVariationFields");
+        while (fields.hasNext()) {
+            Object structuredVariation = fields.next();
+            if (structuredVariation == null) {
+                continue;
+            }
+            Object fieldObj = invokeNoArg(structuredVariation, "getField");
+            String fieldName = null;
+            if (fieldObj != null) {
+                Object fn = invokeNoArg(fieldObj, "getName");
+                if (fn instanceof String) {
+                    fieldName = (String) fn;
+                }
+            }
+            if (fieldName != null) {
+                item.put(fieldName, exportStructuredVariation(structuredVariation, variationName));
+            }
+        }
+        return item;
+    }
+
+    @Nullable
+    private static Object exportStructuredVariation(@NotNull Object structuredVariation,
+                                                    @NotNull String variationName) {
+        if (isCompositeVariationInstance(structuredVariation)) {
+            boolean nestedMulti = isFieldMultiValued(invokeNoArg(structuredVariation, "getField"));
+            return buildVariationCompositePayload(structuredVariation, variationName, nestedMulti);
+        }
+        Object dataObj = invokeNoArg(structuredVariation, "getValue");
+        if (dataObj instanceof FragmentData) {
+            return ((FragmentData) dataObj).getValue();
+        }
+        return null;
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/DAMContentFragmentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/DAMContentFragmentImpl.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.dam.cfm.converter.ContentTypeConverter;
 import com.adobe.cq.export.json.ExporterConstants;
+import com.adobe.cq.wcm.core.components.internal.ContentFragmentCompositeUtils;
 import com.adobe.cq.wcm.core.components.internal.ContentFragmentUtils;
 import com.adobe.cq.wcm.core.components.models.contentfragment.DAMContentFragment;
 
@@ -40,11 +41,6 @@ import com.adobe.cq.wcm.core.components.models.contentfragment.DAMContentFragmen
 public class DAMContentFragmentImpl implements DAMContentFragment {
 
     private static final Logger LOG = LoggerFactory.getLogger(DAMContentFragmentImpl.class);
-
-    /**
-     * The name of the master variation.
-     */
-    private static final String MASTER_VARIATION = "master";
 
     private final com.adobe.cq.dam.cfm.ContentFragment contentFragment;
     private final String variationName;
@@ -93,14 +89,15 @@ public class DAMContentFragmentImpl implements DAMContentFragment {
             while (contentElementIterator.hasNext()) {
                 final ContentElement contentElement = contentElementIterator.next();
                 ContentVariation variation = null;
-                if (StringUtils.isNotEmpty(variationName) && !MASTER_VARIATION.equals(variationName)) {
+                if (StringUtils.isNotEmpty(variationName)
+                        && !ContentFragmentCompositeUtils.MASTER_VARIATION.equals(variationName)) {
                     variation = contentElement.getVariation(variationName);
                     if (variation == null) {
                         LOG.warn("Non-existing variation '{}' of element '{}'", variationName, contentElement.getName());
                     }
                 }
                 this.exportedElements.put(contentElement.getName(),
-                        new DAMContentElementImpl(contentTypeConverter, contentElement, variation));
+                        new DAMContentElementImpl(contentTypeConverter, contentElement, variation, variationName));
             }
 
             this.elements = new ArrayList<>(exportedElements.values());
@@ -186,20 +183,28 @@ public class DAMContentFragmentImpl implements DAMContentFragment {
         private final ContentTypeConverter converter;
         private final ContentElement element;
         private final ContentVariation variation;
+        private final String configuredVariationName;
 
         private String htmlValue;
 
         /**
-         * @param converter the converter to use to convert the value of text elements to HTML
-         * @param element   the original element
-         * @param variation the configured variation of the element, or {@code null}
+         * @param converter                 the converter to use to convert the value of text elements to HTML
+         * @param element                     the original element
+         * @param variation                   the configured variation of the element, or {@code null}
+         * @param configuredVariationName     variation name from the component (may be blank or master)
          */
         public DAMContentElementImpl(@NotNull ContentTypeConverter converter,
                                      @NotNull ContentElement element,
-                                     @Nullable ContentVariation variation) {
+                                     @Nullable ContentVariation variation,
+                                     @Nullable String configuredVariationName) {
             this.converter = converter;
             this.element = element;
             this.variation = variation;
+            this.configuredVariationName = configuredVariationName;
+        }
+
+        private boolean isCompositeField() {
+            return ContentFragmentCompositeUtils.isCompositeElement(element);
         }
 
 
@@ -225,24 +230,42 @@ public class DAMContentFragmentImpl implements DAMContentFragment {
         @NotNull
         @Override
         public String getDataType() {
+            if (isCompositeField()) {
+                return DAMContentFragment.COMPOSITE_DATA_TYPE;
+            }
             return getData().getDataType().getTypeString();
         }
 
         @Nullable
         @Override
         public Object getValue() {
+            if (isCompositeField()) {
+                return null;
+            }
             return getData().getValue();
         }
 
         @Nullable
         @Override
         public <T> T getValue(Class<T> var1) {
+            if (isCompositeField()) {
+                return null;
+            }
             return getData().getValue(var1);
+        }
+
+        @Nullable
+        @Override
+        public Object getComposite() {
+            return ContentFragmentCompositeUtils.buildCompositeExport(element, configuredVariationName);
         }
 
         @NotNull
         @Override
         public String getExportedType() {
+            if (isCompositeField()) {
+                return DAMContentFragment.COMPOSITE_DATA_TYPE;
+            }
             final FragmentData value = getData();
             // Mime type for text-based data types
             String type = value.getContentType();
@@ -262,6 +285,9 @@ public class DAMContentFragmentImpl implements DAMContentFragment {
 
         @Override
         public boolean isMultiLine() {
+            if (isCompositeField()) {
+                return false;
+            }
             String metaType = ContentFragmentUtils.getElementMetaType(element);
             if ("text-multi".equals(metaType)) {
                 return true;
@@ -277,12 +303,19 @@ public class DAMContentFragmentImpl implements DAMContentFragment {
 
         @Override
         public boolean isMultiValue() {
+            if (isCompositeField()) {
+                FragmentData data = element.getValue();
+                return data != null && data.getDataType().isMultiValue();
+            }
             return getData().getDataType().isMultiValue();
         }
 
         @Nullable
         @Override
         public String getHtml() {
+            if (isCompositeField()) {
+                return null;
+            }
             // restrict this method to text elements
             if (!isMultiLine()) {
                 return null;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/datalayer/ContentFragmentDataImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/datalayer/ContentFragmentDataImpl.java
@@ -51,6 +51,9 @@ public class ContentFragmentDataImpl extends ComponentDataImpl implements Conten
 
         @Override
         public String getText() {
+            if (DAMContentFragment.COMPOSITE_DATA_TYPE.equals(contentElement.getDataType())) {
+                return null;
+            }
             return contentElement.getValue(String.class);
         }
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/CompositeValueHelper.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/CompositeValueHelper.java
@@ -1,0 +1,51 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2026 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.models.contentfragment;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * HTL helper to distinguish composite JSON shapes ({@link Map} vs {@link List}) for nested fields.
+ */
+public class CompositeValueHelper {
+
+    private final Object value;
+
+    public CompositeValueHelper(@Nullable Object value) {
+        this.value = value;
+    }
+
+    /**
+     * @return {@code true} when the composite payload is multi-valued (JSON array of objects).
+     */
+    public boolean isList() {
+        return value instanceof List;
+    }
+
+    /**
+     * @return {@code true} when the composite payload is single-valued (JSON object).
+     */
+    public boolean isMap() {
+        return value instanceof Map;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/DAMContentFragment.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/contentfragment/DAMContentFragment.java
@@ -26,6 +26,7 @@ import org.osgi.annotation.versioning.ConsumerType;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -60,6 +61,20 @@ public interface DAMContentFragment extends ComponentExporter {
      * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.0.0
      */
     String JSON_PN_ELEMENTS_ORDER = "elementsOrder";
+
+    /**
+     * Value of {@link DAMContentElement#getDataType()} for composite (nested structured) fields.
+     *
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.6.0
+     */
+    String COMPOSITE_DATA_TYPE = "composite";
+
+    /**
+     * Name of the property (in JSON export) that provides structured composite field data (nested maps/lists).
+     *
+     * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.6.0
+     */
+    String JSON_PN_COMPOSITE = "composite";
 
     /**
      * Represents a content element of a content fragment.
@@ -184,6 +199,21 @@ public interface DAMContentFragment extends ComponentExporter {
         @Nullable
         @JsonIgnore
         default String getHtml() {
+            return null;
+        }
+
+        /**
+         * Returns structured data for composite (nested) fields; {@code null} for scalar elements.
+         * For single-valued composites this is a {@link java.util.Map}; for multi-valued composites a
+         * {@link java.util.List} of maps (JSON array of objects).
+         *
+         * @return composite payload or {@code null}
+         * @since com.adobe.cq.wcm.core.components.models.contentfragment 1.6.0
+         */
+        @Nullable
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonProperty(JSON_PN_COMPOSITE)
+        default Object getComposite() {
             return null;
         }
     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentCompositeUtilsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/ContentFragmentCompositeUtilsTest.java
@@ -1,0 +1,43 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2026 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.adobe.cq.dam.cfm.ContentElement;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * {@link ContentFragmentCompositeUtils} integration against CFM extensions is validated on AEM; unit tests cover
+ * non-composite and absent-API paths that do not require the extensions bundle on the classpath.
+ */
+class ContentFragmentCompositeUtilsTest {
+
+    @Test
+    void buildCompositeExportReturnsNullForScalarElement() {
+        ContentElement scalar = Mockito.mock(ContentElement.class);
+        assertNull(ContentFragmentCompositeUtils.buildCompositeExport(scalar, null));
+    }
+
+    @Test
+    void isCompositeElementIsFalseForPlainMock() {
+        ContentElement scalar = Mockito.mock(ContentElement.class);
+        assertFalse(ContentFragmentCompositeUtils.isCompositeElement(scalar));
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/datalayer/ContentFragmentDataImplCompositeTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/datalayer/ContentFragmentDataImplCompositeTest.java
@@ -1,0 +1,46 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2026 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1.datalayer;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.adobe.cq.wcm.core.components.models.contentfragment.DAMContentFragment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ContentFragmentDataImplCompositeTest {
+
+    @Test
+    void elementDataTextIsNullForCompositeFields() {
+        DAMContentFragment.DAMContentElement element = Mockito.mock(DAMContentFragment.DAMContentElement.class);
+        Mockito.when(element.getDataType()).thenReturn(DAMContentFragment.COMPOSITE_DATA_TYPE);
+
+        ContentFragmentDataImpl.ElementDataImpl data = new ContentFragmentDataImpl.ElementDataImpl(element);
+        assertNull(data.getText());
+    }
+
+    @Test
+    void elementDataTextDelegatesForScalarFields() {
+        DAMContentFragment.DAMContentElement element = Mockito.mock(DAMContentFragment.DAMContentElement.class);
+        Mockito.when(element.getDataType()).thenReturn("string");
+        Mockito.when(element.getValue(String.class)).thenReturn("hello");
+
+        ContentFragmentDataImpl.ElementDataImpl data = new ContentFragmentDataImpl.ElementDataImpl(element);
+        assertEquals("hello", data.getText());
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/models/contentfragment/CompositeValueHelperTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/models/contentfragment/CompositeValueHelperTest.java
@@ -1,0 +1,51 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2026 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.models.contentfragment;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class CompositeValueHelperTest {
+
+    @Test
+    void detectsList() {
+        CompositeValueHelper h = new CompositeValueHelper(Collections.singletonList("a"));
+        Assertions.assertTrue(h.isList());
+        Assertions.assertFalse(h.isMap());
+        Assertions.assertEquals(Collections.singletonList("a"), h.getValue());
+    }
+
+    @Test
+    void detectsMap() {
+        LinkedHashMap<String, String> m = new LinkedHashMap<>();
+        m.put("k", "v");
+        CompositeValueHelper h = new CompositeValueHelper(m);
+        Assertions.assertFalse(h.isList());
+        Assertions.assertTrue(h.isMap());
+        Assertions.assertEquals(m, h.getValue());
+    }
+
+    @Test
+    void scalarNotListOrMap() {
+        CompositeValueHelper h = new CompositeValueHelper("x");
+        Assertions.assertFalse(h.isList());
+        Assertions.assertFalse(h.isMap());
+        Assertions.assertEquals("x", h.getValue());
+    }
+}

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/composite.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/composite.html
@@ -1,0 +1,65 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2026 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<template data-sly-template.composite="${@ composite='Structured composite element payload', multiValue}">
+    <div data-sly-test="${composite}" class="cmp-contentfragment__composite">
+        <sly data-sly-test="${multiValue}">
+            <div data-sly-list.row="${composite}" class="cmp-contentfragment__composite-item">
+                <sly data-sly-call="${compositeItem @ item=row}"></sly>
+            </div>
+        </sly>
+        <sly data-sly-test="${!multiValue}">
+            <div class="cmp-contentfragment__composite-item">
+                <sly data-sly-call="${compositeItem @ item=composite}"></sly>
+            </div>
+        </sly>
+    </div>
+</template>
+
+<template data-sly-template.compositeItem="${@ item='Single composite container map'}">
+    <div class="cmp-contentfragment__composite-item-inner">
+        <sly data-sly-test="${item['_modelPath']}">
+            <div class="cmp-contentfragment__composite-model">${item['_modelPath']}</div>
+        </sly>
+        <dl class="cmp-contentfragment__composite-fields" data-sly-list.entry="${item.entrySet}">
+            <sly data-sly-test="${entry.key != '_modelPath'}">
+                <dt class="cmp-contentfragment__composite-field-name">${entry.key}</dt>
+                <dd class="cmp-contentfragment__composite-field-value">
+                    <sly data-sly-call="${compositeFieldValue @ value=entry.value}"></sly>
+                </dd>
+            </sly>
+        </dl>
+    </div>
+</template>
+
+<template data-sly-template.compositeFieldValue="${@ value}">
+    <sly data-sly-use.vh="${'com.adobe.cq.wcm.core.components.models.contentfragment.CompositeValueHelper' @ value=value}">
+        <sly data-sly-test="${vh.list}">
+            <div class="cmp-contentfragment__composite cmp-contentfragment__composite--nested">
+                <div data-sly-list.sub="${vh.value}" class="cmp-contentfragment__composite-item cmp-contentfragment__composite-item--nested">
+                    <sly data-sly-call="${compositeItem @ item=sub}"></sly>
+                </div>
+            </div>
+        </sly>
+        <sly data-sly-test="${vh.map}">
+            <div class="cmp-contentfragment__composite cmp-contentfragment__composite--nested">
+                <sly data-sly-call="${compositeItem @ item=vh.value}"></sly>
+            </div>
+        </sly>
+        <sly data-sly-test="${!vh.list && !vh.map}">
+            <span class="cmp-contentfragment__composite-scalar">${(value) @ join='<br/>', context='html'}</span>
+        </sly>
+    </sly>
+</template>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/element.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/element.html
@@ -17,10 +17,13 @@
     <div class="cmp-contentfragment__element cmp-contentfragment__element--${element.name}" data-cmp-contentfragment-element-type="${element.dataType}">
         <dt class="cmp-contentfragment__element-title">${element.title}</dt>
         <dd class="cmp-contentfragment__element-value">
+            <sly data-sly-test="${element.dataType == 'composite'}"
+                 data-sly-use.compositeTpl="core/wcm/components/contentfragment/v1/contentfragment/composite.html"
+                 data-sly-call="${compositeTpl.composite @ composite=element.composite, multiValue=element.multiValue}"></sly>
             <sly data-sly-test="${element.dataType == 'calendar'}" data-sly-use.tpl="core/wcm/components/contentfragment/v1/contentfragment/calendar.html"
                  data-sly-call="${tpl.element @ date = element.value}"></sly>
             <sly data-sly-test="${element.dataType == 'boolean'}">${element.value ? "true" : "false"}</sly>
-            <sly data-sly-test="${element.dataType != 'calendar' && element.dataType != 'boolean'}">${(element.value) @join='<br/>', context='html'}</sly>
+            <sly data-sly-test="${element.dataType != 'composite' && element.dataType != 'calendar' && element.dataType != 'boolean'}">${(element.value) @join='<br/>', context='html'}</sly>
         </dd>
     </div>
 </template>

--- a/testing/it/it.ui.apps/package-lock.json
+++ b/testing/it/it.ui.apps/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "com.adobe.cq.core.wcm.components.it.content",
+    "name": "com.adobe.cq.core.wcm.components.it.ui.apps",
     "version": "2.30.5-SNAPSHOT",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "com.adobe.cq.core.wcm.components.it.content",
+            "name": "com.adobe.cq.core.wcm.components.it.ui.apps",
             "version": "2.30.5-SNAPSHOT",
             "license": "Apache-2.0",
             "devDependencies": {


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Jira **SITES-43943** (internal tracking; add GitHub issue link if applicable)
| Patch: Bug Fix?          |
| Minor: New Feature?      | Yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes (unit tests added; run `mvn verify -pl bundles/core` before merge)
| Documentation Provided   | Yes (JavaDoc, interface docs, HTL, sample export linked below)
| Any Dependency Changes?  | None for Maven; `testing/it/it.ui.apps/package-lock.json` only if touched for IT UI apps
| License                  | Apache License, Version 2.0

## Summary

Adds support for **composite (nested structured) content fragment fields** in the Core **Content Fragment** component so Sling Model JSON (e.g. **`.model.json`**) exposes structured data for CFM composite elements, not only scalar `FragmentData` values.

## Problem solved

- Composite CF fields are not plain `BasicDataType` scalars; exporting only **`value`** from `FragmentData` does not represent nested composite instances usefully for headless or SPA consumers.
- The export now uses **`dataType: "composite"`** and a dedicated **`composite`** property: **single-valued** composites as one JSON **object** (plus optional `_modelPath`), **multi-valued** as a JSON **array** of objects, with recursion for nested composites. Scalar **`value`** stays aligned with classic CFM semantics (`null` / omitted for composite elements).

## Implementation notes

- **`ContentFragmentCompositeUtils`** builds payloads via reflection against CFM extensions APIs so the core bundle does not require a compile-time dependency on `cq-dam-cfm-extensions` (extensions still required at runtime on AEM for composite types).
- **`DAMContentElement#getComposite()`** is serialized as **`composite`**; **`ContentFragmentDataImpl`** avoids treating composite as plain text in the data layer where appropriate.
- **HTL:** `element.html` + **`composite.html`**, with **`CompositeValueHelper`** for map vs list in templates.
- **Tests** for helper and data layer; JaCoCo exclude for **`ContentFragmentCompositeUtils`** (reflection-only).

## Sample export (generated with this code)

The following attachment is a **full-page `.model.json` sample** produced using the implementation from this PR (large file; includes nested page `:items`, content fragment **`elements`**, data layer, etc.):

**[sample_composite_model.json](https://github.com/user-attachments/files/27405675/sample_composite_model.json)**

In that export, inspect the content fragment’s **`elements`** map for composite fields (e.g. `primaryContact`, `contacts`, `preferredLanguage`): **`composite`** is either a **JSON object** (`multiValue: false`) or a **JSON array** of objects (`multiValue: true`), without a legacy `items` wrapper around the composite payload.