### PR TITLE
[SITES-40889] [Core Components] Improve VCF placeholder copy and route literals through i18n()

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/vcfRenderer.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/vcfRenderer.js
@@ -33,8 +33,9 @@
 
     /**
      * Builds placeholder markup for the author preview; uses DOM so translated strings are escaped.
+     * The {@code title} and {@code detail} arguments are expected to already be localized.
      */
-    function buildVcfPlaceholderOuterHtml(modifier, role, surfaceCss, accentCss, titleMessage, detailMessage) {
+    function buildVcfPlaceholderOuterHtml(modifier, role, surfaceCss, accentCss, title, detail) {
         var root = document.createElement("div");
         root.className = "cmp-contentfragment__vcf-placeholder cmp-contentfragment__vcf-placeholder--" + modifier;
         root.setAttribute("role", role);
@@ -57,10 +58,10 @@
             "text-transform:uppercase",
             "letter-spacing:.06em"
         ].join(";");
-        titleEl.textContent = i18n(titleMessage);
+        titleEl.textContent = title;
 
         var detailEl = document.createElement("span");
-        detailEl.textContent = i18n(detailMessage);
+        detailEl.textContent = detail;
 
         root.appendChild(titleEl);
         root.appendChild(detailEl);
@@ -73,8 +74,8 @@
             "alert",
             "border:2px dashed #d7373f;border-radius:8px;background:#fff4f4",
             "color:#c9252d",
-            "Visual Content Fragment could not be loaded",
-            "Check that preview services are available and the fragment configuration is valid."
+            i18n("Visual Content Fragment could not be loaded"),
+            i18n("The Visual Content Fragment could not be displayed.")
         );
     }
 
@@ -84,8 +85,8 @@
             "status",
             "border:2px dashed #b0b0b0;border-radius:8px;background:#f5f5f5",
             "color:#6e6e6e",
-            "Visual Content Fragment preview unavailable",
-            "A preview URL is not available for this content fragment in the editor."
+            i18n("Visual Content Fragment unavailable"),
+            i18n("A preview URL is not available for this content fragment.")
         );
     }
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/site/js/vcf.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/site/js/vcf.js
@@ -29,8 +29,9 @@
 
     /**
      * Builds placeholder markup for the VCF shadow root; uses DOM so translated strings are escaped.
+     * The {@code title} and {@code detail} arguments are expected to already be localized.
      */
-    function buildVcfPlaceholderOuterHtml(modifier, role, surfaceCss, accentCss, titleMessage, detailMessage) {
+    function buildVcfPlaceholderOuterHtml(modifier, role, surfaceCss, accentCss, title, detail) {
         var root = document.createElement("div");
         root.className = "cmp-contentfragment__vcf-placeholder cmp-contentfragment__vcf-placeholder--" + modifier;
         root.setAttribute("role", role);
@@ -53,10 +54,10 @@
             "text-transform:uppercase",
             "letter-spacing:.06em"
         ].join(";");
-        titleEl.textContent = i18n(titleMessage);
+        titleEl.textContent = title;
 
         var detailEl = document.createElement("span");
-        detailEl.textContent = i18n(detailMessage);
+        detailEl.textContent = detail;
 
         root.appendChild(titleEl);
         root.appendChild(detailEl);
@@ -69,8 +70,8 @@
             "alert",
             "border:2px dashed #d7373f;border-radius:8px;background:#fff4f4",
             "color:#c9252d",
-            "Visual Content Fragment could not be loaded",
-            "The Visual Content Fragment could not be displayed."
+            i18n("Visual Content Fragment could not be loaded"),
+            i18n("The Visual Content Fragment could not be displayed.")
         );
     }
 

--- a/content/test/clientlibs/contentfragment/vcfRendererTest.js
+++ b/content/test/clientlibs/contentfragment/vcfRendererTest.js
@@ -106,7 +106,7 @@ describe("Test VCF renderer for", function() {
 
         setTimeout(function() {
             expect(vcfElement.innerHTML).toContain("cmp-contentfragment__vcf-placeholder");
-            expect(vcfElement.innerHTML).toContain("Visual Content Fragment preview unavailable");
+            expect(vcfElement.innerHTML).toContain("Visual Content Fragment unavailable");
             done();
         }, 50);
     });


### PR DESCRIPTION
…

- Author "no preview" placeholder: reword title from "Visual Content Fragment preview unavailable" to "Visual Content Fragment unavailable" and drop the editor-specific detail suffix.
- Author "load failed" detail no longer references "preview services" (always available on publish) or "fragment configuration" (opaque to authors); align with the publish-side wording "The Visual Content Fragment could not be displayed."
- Move the literal strings inside i18n("...") calls at the placeholder-builder site so the literals are visible to translation tooling, rather than being passed positionally and translated inside the HTML builder.
- Update vcfRendererTest.js assertion to match the new title.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | follow up for https://jira.corp.adobe.com/browse/SITES-40889
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
