### PR TITLE
SITES-42542 - Disable Page v3 structured data IT until foundation feature lands

### DIFF
--- a/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/page/v3/PageIT.java
+++ b/testing/it/http/src/test/java/com/adobe/cq/wcm/core/components/it/http/page/v3/PageIT.java
@@ -20,6 +20,7 @@ import java.util.regex.Pattern;
 import org.apache.sling.testing.clients.ClientException;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
@@ -81,6 +82,7 @@ public class PageIT {
     }
 
     @Test
+    @Ignore("Disabled until the feature is available in cq/foundation (SITES-42542).")
     @RunIfToggleEnabled("FT_SITES-42542")
     public void testStructuredData() throws ClientException {
         String message = "The page head should contain the JSON-LD script tag for the cq:structuredData block";


### PR DESCRIPTION


Mark testStructuredData with @Ignore so the build does not depend on FT_SITES-42542 being toggled on with a foundation bundle that ships the StructuredData Sling Model.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-42542
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
