### PR TITLE
SITES-44870: Unlocalized 'Image rendering is delegated to the component' string in Template Editor > Teaser Policy

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/ImageDelegateRenderCondition.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/ImageDelegateRenderCondition.java
@@ -50,7 +50,6 @@ public class ImageDelegateRenderCondition extends SlingSafeMethodsServlet {
 
     public static final String RESOURCE_TYPE = "core/wcm/components/renderconditions/imagedelegate";
     private static final String IMAGE_DELEGATE_DESCRIPTION = "imageDelegateDescription";
-    private static final String IMAGE_DELEGATE_DESCRIPTION_TEXT = "Image rendering is delegated to the {0} component.";
 
     @Override
     protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response)
@@ -73,8 +72,7 @@ public class ImageDelegateRenderCondition extends SlingSafeMethodsServlet {
                             I18n i18n = new I18n(request);
                             ExpressionCustomizer customizer = ExpressionCustomizer.from(request);
                             customizer.setVariable(AbstractImageDelegatingModel.IMAGE_DELEGATE, delegate);
-                            customizer.setVariable(IMAGE_DELEGATE_DESCRIPTION, i18n.getVar(IMAGE_DELEGATE_DESCRIPTION_TEXT, null,
-                                    i18n.getVar(delegate.getTitle())));
+                            customizer.setVariable(IMAGE_DELEGATE_DESCRIPTION, i18n.get("Image rendering is delegated to the {0} component.", "{0} - component title", i18n.getVar(delegate.getTitle())));
                         }
                     }
                 }


### PR DESCRIPTION

String externalization

<img width="1904" height="1016" alt="desc" src="https://github.com/user-attachments/assets/810c0330-6a2d-4f8c-9c1d-fcfe071ce4e7" />


<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes SITES-44870` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
