### PR TITLE
Fix: Table of Contents not rendering on page history viewer

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/TableOfContentsFilter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/TableOfContentsFilter.java
@@ -70,7 +70,7 @@ import com.day.cq.wcm.api.WCMMode;
 )
 @SlingServletFilter(
     scope = {SlingServletFilterScope.REQUEST},
-    pattern = "/content/.*",
+    pattern = "(/content|/tmp/versionhistory)/.*",
     resourceTypes = "cq:Page",
     extensions = {"html"},
     methods = {"GET"}


### PR DESCRIPTION
Updated the servlet filter pattern to include /tmp/versionhistory paths, allowing the Table of Contents component to render when viewing historical versions of a page.

Fixes #3013

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
