### PR TITLE
LLM Wiki

### DIFF
--- a/.clawdea/config.json
+++ b/.clawdea/config.json
@@ -1,0 +1,1 @@
+{"wikiPath":"docs/llm-wiki"}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ core.wcm.components.commons.datalayer.*
 **/coverage/**
 node
 **/node_modules/**
+.clawdea/wiki-state.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Adobe AEM WCM Core Components — a Maven reactor of OSGi bundles, content packages, and integration tests that ship ~29 production-ready HTL components for AEM (AEMaaCS, 6.5 LTS, 6.5). All component models are versioned (`v1`, `v2`, …) and coexist side by side.
+
+- Java source target: `aem.java.version=8` (parent `pom.xml`). CI matrix builds on JDK 11, 17, 21.
+- Artifact version lives in `parent/pom.xml` (`<version>`). `npm run sync-pom-version` keeps `content/package.json` in sync.
+- `main` is the trunk development branch; all PRs target `main`.
+
+## Reactor layout (root `pom.xml` modules)
+
+- `parent/` — dependency management and plugin config shared by every module.
+- `bundles/core/` — **the** OSGi bundle. Public API in `com.adobe.cq.wcm.core.components.{models,services,commons,util}`; Sling Model implementations and internal services in `com.adobe.cq.wcm.core.components.internal.{models/v1,v2,v3,v4,…,servlets,link,form,resource,helper,jackson,services}`. Version suffixes in package paths mirror the HTL component versions in `content/`.
+- `content/` — the `ui.apps`-style content package with `apps/core/wcm/components/<component>/<vN>/…`. Also an npm project that builds component clientlibs and runs Karma/Jasmine JS unit tests.
+- `config/` — runmode OSGi configurations.
+- `all/` — aggregator FileVault package installed to AEM.
+- `examples/` — sample pages / Component Library content.
+- `extensions/amp/` — AMP variant of the components (separate module tree).
+- `testing/junit/core/` — JUnit helpers for HTL/Sling-Model component tests.
+- `testing/aem-mock-plugin/` — wcm.io `aem-mock` plugin for unit-test setup.
+- `testing/it/{http,it.core,e2e-selenium,e2e-selenium-utils,it.ui.apps,it.ui.config,it.ui.content}` — HTTP integration tests, Selenide/Selenium E2E UI tests, and the test content packages they install.
+
+## Build & test
+
+All Maven commands run from repo root unless noted.
+
+```
+mvn clean install                              # full build + unit tests
+mvn clean install -pl bundles/core -am         # build one module and its deps
+mvn clean install -pl bundles/core -am -Dtest=ContentFragmentImplTest    # single JUnit test
+mvn clean install -PautoInstallPackage         # build + deploy to local AEM (default aem.host=localhost, aem.port=4502)
+mvn clean install -PautoInstallPackage,cloud   # AEMaaCS SDK: deploy into /libs instead of /apps
+mvn clean install -PautoInstallSinglePackage   # deploy `all/` aggregate to author
+mvn clean install -PautoInstallPackagePublish  # deploy to publish (aem.publish.host/port)
+```
+
+Override target instance with `-Daem.host=… -Daem.port=… -Dsling.user=… -Dsling.password=…`.
+
+Front-end (`content/` directory) — run from `content/`:
+
+```
+npm run lint        # eslint + stylelint in parallel
+npm run eslint[:fix]
+npm run stylelint[:fix]
+npm run unit        # Karma/Jasmine JS unit tests (fixtures in content/test/)
+npm run build       # aem-clientlib-generator — rebuild clientlibs (e.g. Data Layer embedding)
+npm run sync-pom-version
+```
+
+Integration/E2E tests live under `testing/it/*` and require a running AEM. They are built by the reactor but not typically run locally unless you have an instance wired up — see each module's own docs.
+
+## Architectural notes
+
+- **Sling Model = public interface in `models/` + `@Model` impl in `internal/models/vN/`.** Public interfaces in `com.adobe.cq.wcm.core.components.models` (e.g. `Image`, `Teaser`, `ContentFragment`) are the contract; `internal/models/vN/*Impl.java` is the versioned implementation bound via `resourceType`. To add a new version of a component, create `internal/models/vN+1/FooImpl.java` and the matching HTL under `content/.../foo/vN+1/`. Never break the public interface in `models/` without a new version.
+- **Component policy via Sling CA-config, not hardcoded constants.** Policies, config factories, and runmode OSGi configs are in `config/` and consumed through `@ScriptVariable` / context-aware configuration APIs — see `CONFIGS.md`.
+- **Data Layer.** Components populate the Adobe Client Data Layer via `models/datalayer/*`. See `DATA_LAYER_INTEGRATION.md`. `internal/DataLayerConfig.java` is the kill-switch.
+- **Link handling.** Use `internal/link/LinkManager` / `LinkBuilder` for all URL rendering — don't build links by hand in models or HTL.
+- **HTL only**, no JSP. Scripts live in `content/src/content/jcr_root/apps/core/wcm/components/<comp>/vN/<comp>/<comp>.html`. Dialogs under `_cq_dialog/`, editor config under `_cq_editConfig.xml`.
+- **XSS/encoding** is expected to be handled by HTL; never concatenate untrusted strings into markup. When touching JS/JSP/HTL, prefer `xssAPI`, `Granite.UI.Foundation.XSS`, or `CQ.shared.XSS` — see `fix-xss-vulnerability` skill for the canonical patterns.
+- **AMP** variants in `extensions/amp/` override selected HTL scripts; keep the Sling-Model layer shared.
+
+## Component versioning (critical)
+
+- Bumping a component to `vN+1` is an API event. Create new `models/vN/Foo.java` interface (or reuse if compatible), new `internal/models/vN/FooImpl.java`, new `content/.../foo/vN/foo`. Keep previous versions intact — users depend on them.
+- Version tables in `VERSIONS.md` must stay accurate.
+
+## Commit & PR conventions
+
+- PRs target `main`. Branch names: `issue/<number>`, `feature/<name>`, `release/<version>`.
+- PR title prefix with bracketed component when relevant (`[Image] …`). Many commits use `[SITES-xxxxx] …` or `[CQ-xxxxx] …` for Jira tickets.
+- PR description must follow `.github/pull_request_template.md` — the `Fixed Issues?`, `Patch/Minor/Major`, `Tests Added + Pass?` table is mandatory.
+- Every change is expected to ship with tests (JUnit for models, Karma for component JS, E2E under `testing/it/e2e-selenium` for UI flows).
+
+## CI
+
+GitHub Actions (`.github/workflows/maven-test.yml`) runs `mvn -B -U clean install -Pcloud,adobe-public` on JDK 11/17/21 plus a Node 14 JS job in `content/`. CodeQL runs on push/PR to `main`. Don't land a change that fails `-Pcloud,adobe-public`.
+
+## Docs already in the repo (read before guessing)
+
+- `README.md` — component list, system requirements (AEM/Java/Maven), build profiles.
+- `BUILDING.md` — full list of install profiles and npm scripts.
+- `CONFIGS.md` — OSGi + Sling CA-config inventory.
+- `DATA_LAYER_INTEGRATION.md` — Data Layer contract.
+- `VERSIONS.md` — historical system-requirements matrix.
+- `Guidelines.md` — production-ready component checklist (security/perf/a11y/i18n).
+- `CONTRIBUTING.md` — issue + PR workflow.
+
+## Wiki
+
+Detailed knowledge about individual subsystems lives in [`docs/llm-wiki/index.md`](docs/llm-wiki/index.md).
+Concept pages cover entry points, invariants, and source pointers per subsystem. Read
+the wiki page for a subsystem before grepping its source files.

--- a/docs/llm-wiki/.wiki-state.json
+++ b/docs/llm-wiki/.wiki-state.json
@@ -1,0 +1,1 @@
+{"lastSyncedCommit":"827d1d766cf2bca1be7375889a0495cc34b5c1eb","suggestions":[]}

--- a/docs/llm-wiki/concepts/adaptive-image-servlet.md
+++ b/docs/llm-wiki/concepts/adaptive-image-servlet.md
@@ -1,0 +1,39 @@
+# Adaptive Image servlet registration
+
+**Purpose** — explain how `AdaptiveImageServlet` (the servlet that serves resized renditions for the Image component) is **dynamically** registered from one or more OSGi factory configurations rather than via static `@Component(property=…)`.
+
+## Invariants
+
+- `AdaptiveImageServlet` is **not** registered by an `@Component` of its own; it is instantiated and registered as a Sling Servlet by [`AdaptiveImageServletMappingConfigurationConsumer`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumer.java) once at least one [`AdaptiveImageServletMappingConfigurationFactory`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactory.java) configuration is present.
+- Each factory configuration declares a tuple of `{resourceTypes, selectors, extensions}`. The consumer registers **one Sling servlet `ServiceRegistration` per configuration**. Removing the configuration unregisters that registration. The bundle ships out-of-the-box configs for: `RTs=[core/wcm/components/image], selectors=[img]` (Image v1) and `RTs=[core/wcm/components/image, cq/Page], selectors=[coreimg]` (Image v2+) over `[jpg, jpeg, gif, png, svg]` extensions — see header comment in [`AdaptiveImageServlet`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java).
+- The servlet expects **1, 2 or 3 selectors** in addition to the matched first selector (`img`/`coreimg`). Anything else throws `IllegalArgumentException` from `doGet` — see [`AdaptiveImageServlet.doGet`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java) (lines around the "Expected 1, 2 or 3 selectors" check).
+- Resource-type checks at request time use the Image v1 resource type constant `IMAGE_RESOURCE_TYPE` (`core/wcm/components/image`). A request whose resource is **not** of that type takes a different rendition path (delegated/page resource), so requests under `cq/Page` only render the page's featured image — see the `isResourceType(IMAGE_RESOURCE_TYPE)` branch in [`AdaptiveImageServlet`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java).
+- The consumer also tracks the legacy `defaultResizeWidth` value in `oldAISDefaultResizeWidth` so it can re-read and re-apply policy changes; do not assume the registration is immutable for the lifetime of the bundle.
+- Metrics are emitted via [`AdaptiveImageServletMetrics`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetrics.java) (Sling commons metrics). Removing the metrics service breaks instantiation — it is a mandatory `@Reference` on the consumer.
+
+## Resolution pipeline
+
+1. `AdaptiveImageServletMappingConfigurationFactory` is an OSGi factory PID. Each configuration creates a `Map<String, AdaptiveImageServletMappingConfigurationFactory>` entry on the consumer's `configs` map.
+2. On `bindAdaptiveImageServletMappingConfigurationFactory(...)`, the consumer:
+   - reads `resourceTypes`, `selectors`, `extensions`, `defaultResizeWidth`;
+   - constructs an `AdaptiveImageServlet` instance with `mimeTypeService`, `assetStore`, `metrics`, default width;
+   - builds Sling servlet properties (`sling.servlet.resourceTypes`, `sling.servlet.selectors`, `sling.servlet.extensions`, `sling.servlet.methods=GET`);
+   - calls `bundleContext.registerService(Servlet.class, ais, props)` and stores the `ServiceRegistration` in `serviceRegistrations`.
+3. On unbind / configuration removal, the matching `ServiceRegistration.unregister()` is called and the entry is removed from `configs`.
+4. At request time, Sling routes a GET like `…/jcr:content/root/image.coreimg.800.jpeg/1234567890.jpeg` to one of the registered servlet instances, based on resource-type + selector + extension match.
+5. `doGet` validates selector count, locates the underlying asset (or page-level featured image when the resource type is `cq/Page`), applies the size selector against the policy-configured allowed widths, and streams the resized rendition.
+
+## Anti-patterns
+
+- **Adding a new `selectors=[…]` to `AdaptiveImageServlet` via static `@Component(property=…)`** — duplicates the dynamic registration and produces ambiguous Sling servlet resolution. New mappings must be added by registering an OSGi factory configuration of `AdaptiveImageServletMappingConfigurationFactory`, not by editing the servlet class.
+- **Calling the servlet path with 4+ selectors** — throws on every request and is logged at WARN level. URL-construction logic in customer code or HTL must respect the 1–3 selector budget after `img`/`coreimg`.
+- **Assuming the servlet is always present at OSGi startup** — until the consumer's first config bind fires, no `AdaptiveImageServlet` is registered. Tests that probe the servlet must wait for the factory configuration; integration tests in `testing/it/it.core` rely on the shipped config in `config/`.
+- **Hard-coding allowed widths in HTL or model code** — widths are policy-driven and the servlet validates them. A request for a width not in the resource's policy-allowed widths is denied (404), regardless of selector match.
+
+## Source pointers
+
+- [`AdaptiveImageServlet`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java) — the servlet itself (no static `@Component`); rendition logic, asset/page branching, selector validation.
+- [`AdaptiveImageServletMappingConfigurationFactory`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationFactory.java) — OSGi factory PID with the `{RTs, selectors, extensions, defaultWidth}` tuple.
+- [`AdaptiveImageServletMappingConfigurationConsumer`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMappingConfigurationConsumer.java) — does the dynamic `bundleContext.registerService(...)` per config.
+- [`AdaptiveImageServletMetrics`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServletMetrics.java) — Sling-metrics counters/timers.
+- Out-of-box configurations: [`config/`](../../../config/) for runmode-specific factory instances.

--- a/docs/llm-wiki/concepts/component-policies.md
+++ b/docs/llm-wiki/concepts/component-policies.md
@@ -1,0 +1,35 @@
+# Component policies via Sling CA-config
+
+**Purpose** — explain how a component's "design / policy" values reach a Sling Model at request time, and how that interacts with editable templates and the `cq:Style` chain.
+
+## Invariants
+
+- Core Components do **not** read OSGi configs or hard-coded constants for authoring options. Allowed widths, allowed headings, allowed colour swatches, link targets, etc. come from a `Style` (the policy bound to the component on a template) injected via `@ScriptVariable`. Compare this with the `LinkManagerImpl` `currentStyle` field — see [`LinkManagerImpl`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkManagerImpl.java).
+- A policy is bound by **resource type**. A policy authored at `core/wcm/components/page/v2/page` does not affect a page whose template uses `core/wcm/components/page/v3/page`. Bumping a component to `vN+1` requires either a new policy or updating the template's `cq:policyMapping` — see [`Sling Model versioning`](sling-model-versioning.md).
+- Sling CA-config resources (`/conf/<…>/sling:configs/<config-class-fqn>`) are the storage layer for typed configs like `DataLayerConfig`. They are looked up via `ConfigurationResourceResolver`/`ConfigurationManager` from a `Resource`, which honours the `sling:configRef` chain — see [`CaConfigReferenceProvider`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider.java).
+- [`CaConfigReferenceProvider`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider.java) registers as a WCM `ReferenceProvider`, which means CA-config resources used by a page are picked up by AEM's reference/replication machinery (page activation, MSM rollout). Configs that should travel with a page **must** be discoverable through the resource resolver chain (`sling:configs` child of a `sling:configRef` ancestor), not stored elsewhere.
+- The bundled `commons.datalayer.v1` and similar clientlib categories are policy-controlled via `DataLayerConfig` rather than per-component dialogs. Toggling them from the dialog is **not** an option — components read the CA-config exclusively.
+- `ContainerPostProcessor` (in the same package) handles default child-resource population on policy or template changes; do not write component logic that assumes children are immutable across a re-policy.
+
+## Resolution pipeline
+
+1. A request hits a page. Sling resolves the template policy mapping for each component resource and exposes it as `currentStyle` (an instance of `com.day.cq.wcm.api.designer.Style`).
+2. The component's Sling Model receives `currentStyle` via `@ScriptVariable(injectionStrategy = OPTIONAL)`. Optional because some renders (preview, headless) may run without a template.
+3. For typed CA-configs (e.g. `DataLayerConfig`), the model adapts a `Resource` (typically the page's `jcr:content`) to the config interface via `ConfigurationBuilder.as(Class)`. Lookup walks the resource's ancestors for `sling:configRef` and resolves the matching `sling:configs` child.
+4. AEM activation / replication asks every registered `ReferenceProvider` for references rooted at a page. `CaConfigReferenceProvider` returns the `sling:configs` resources discovered for that page so they are replicated alongside content.
+5. Policy and CA-config values are read **per request** — they are not cached at component instantiation. Changing a policy and re-rendering the page will reflect the new value without restart.
+
+## Anti-patterns
+
+- **Reading from a hardcoded path like `/etc/designs/...` or `/conf/global/...`** — bypasses the CA-config resolver chain, doesn't follow `sling:configRef`, and silently breaks for sites in a different config hierarchy. Always go through `ConfigurationBuilder.as(Class)`.
+- **Putting authoring options in OSGi configuration** — OSGi configs are global. Authors expect per-template / per-site overrides. Anything author-tunable belongs in a CA-config or a `cq:Style` policy.
+- **Assuming a policy is shared between `vN` and `vN+1`** — a policy bound to one resource type does not apply to another. When introducing a new component version, either alias the resource type chain or migrate authored policies.
+- **Skipping `CaConfigReferenceProvider`-style registration when adding a new CA-config that should travel with content** — without it, page activation will not include the configuration and replicated/published pages will silently fall back to defaults.
+
+## Source pointers
+
+- [`DataLayerConfig`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/DataLayerConfig.java) — example typed CA-config interface.
+- [`CaConfigReferenceProvider`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/CaConfigReferenceProvider.java) — wires CA-config resources into AEM's reference graph for replication.
+- [`ContainerPostProcessor`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/ContainerPostProcessor.java) — runs on container resource changes; relevant for policy-driven default children.
+- [`CONFIGS.md`](../../../CONFIGS.md) — inventory of every OSGi config and CA-config the bundle ships.
+- Style/policy injection example: [`LinkManagerImpl`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkManagerImpl.java) `@ScriptVariable currentStyle`.

--- a/docs/llm-wiki/concepts/data-layer.md
+++ b/docs/llm-wiki/concepts/data-layer.md
@@ -1,0 +1,35 @@
+# Data Layer integration
+
+**Purpose** — explain how Core Components produce the JSON object consumed by the Adobe Client Data Layer (`adobeDataLayer`), the kill-switch contract, and the per-component contribution model.
+
+## Invariants
+
+- The Data Layer is **off by default**. It is enabled per page via Sling context-aware configuration `DataLayerConfig.enabled=true`. The default in [`DataLayerConfig`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/DataLayerConfig.java) is `false` — components must check this before emitting any `data-cmp-data-layer` payload.
+- The data-layer global object name defaults to `adobeDataLayer` (constant `DATALAYER_OBJECT_NAME_ADOBE` in [`DataLayerConfig`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/DataLayerConfig.java)). Consumers can override via `name`, but components must not hard-code `window.adobeDataLayer` — they read the configured name through the Page model.
+- Each component contributes a single root entry whose key is the **component ID** and whose value implements one of the `*Data` interfaces: [`ComponentData`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/ComponentData.java), [`ContainerData`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/ContainerData.java), [`ImageData`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/ImageData.java), [`PageData`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/PageData.java), [`ContentFragmentData`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/ContentFragmentData.java), [`AssetData`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/AssetData.java), [`EmbeddableData`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/EmbeddableData.java). New component types must add a new interface, not overload an existing one.
+- The data-layer JSON for a component is serialised via the `models/datalayer/jackson` mixins. Adding a getter to a `*Data` interface that is not annotated `@JsonInclude(NON_NULL)` will leak `null` into the published JSON and may break consumer dashboards.
+- `DataLayerConfig.skipClientlibInclude` controls whether the `core.wcm.components.commons.datalayer.v1` clientlib is auto-injected by the Page component. When `true`, the customer is responsible for loading the client data layer themselves. The Page model must not bypass this flag.
+- The Data Layer kill-switch is the CA-config (`DataLayerConfig`), not an OSGi config. There is no global toggle: enabling/disabling per-template-tree happens via `/conf/.../sling:configs/com.adobe.cq.wcm.core.components.internal.DataLayerConfig`.
+
+## Resolution pipeline
+
+1. The Page model resolves `DataLayerConfig` via Sling CA-config from the current resource. If `enabled=false`, no per-component data-layer attributes are rendered and the auto-include of the client clientlib is skipped.
+2. When enabled, each Core Component's HTL emits a `data-cmp-data-layer='{ "<id>": { … } }'` attribute on its root element. The JSON is produced by the model's `getData()` (returning a `*Data` interface) routed through Jackson via the mixins under `models/datalayer/jackson/`.
+3. The Page model emits a top-level `<script>` snippet that pushes `{event: 'cmp:show', component: <id>}` into the configured global array (default `adobeDataLayer`).
+4. Container components (Carousel, Tabs, Accordion, Container) implement [`ContainerData`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/ContainerData.java) which exposes `shownItems` so client-side state changes (slide change, tab switch) can dispatch `cmp:show`/`cmp:hide` events with the right child id.
+5. The browser-side data-layer client (loaded via the bundled clientlib unless `skipClientlibInclude=true`) reads the per-component DOM attributes and pushes them into the global array as components mount.
+
+## Anti-patterns
+
+- **Emitting data-layer attributes without checking `DataLayerConfig.enabled`** — leaks the `data-cmp-data-layer` attribute on every page even when authors think the feature is off. Any new component must read the Page model's `isDataLayerEnabled()` (or the underlying CA-config) before contributing.
+- **Hard-coding `window.adobeDataLayer.push(...)` in component JS** — bypasses the configurable name. Use the value exposed by the Page component (read from `DataLayerConfig.name`).
+- **Putting Data Layer logic inside HTL string-concatenation** — produces unencoded JSON that breaks for any title/description containing quotes. Always serialise via the `*Data` interface and the configured Jackson mapping.
+- **Reusing one `*Data` impl across multiple component types** — the JSON shape is part of the public contract; sharing an impl between `Image` and `Teaser` couples them. Each component owns its `*Data` impl in its `internal/models/vN/` package.
+
+## Source pointers
+
+- [`DataLayerConfig`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/DataLayerConfig.java) — CA-config, default `enabled=false`, default name `adobeDataLayer`, `skipClientlibInclude`.
+- [`models/datalayer/`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/) — public `*Data` interfaces.
+- [`models/datalayer/builder/`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/builder/) — fluent builders used by `*Impl` classes to assemble `*Data`.
+- [`models/datalayer/jackson/`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/jackson/) — Jackson mixins controlling JSON shape.
+- [`DATA_LAYER_INTEGRATION.md`](../../../DATA_LAYER_INTEGRATION.md) — public contract for downstream consumers.

--- a/docs/llm-wiki/concepts/forms-handling.md
+++ b/docs/llm-wiki/concepts/forms-handling.md
@@ -1,0 +1,36 @@
+# Forms handling pipeline
+
+**Purpose** — explain how a POST to a Core Form container is intercepted, validated, and dispatched to the configured form action handler, and the OSGi service-ranking constraints that make this work alongside Sling's default POST servlet.
+
+## Invariants
+
+- [`CoreFormHandlingServlet`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/CoreFormHandlingServlet.java) is registered as **both** `Servlet` and `Filter` (`service = {Servlet.class, Filter.class}`). It receives form POSTs as a Sling servlet (resource-type bound) and as a request filter (`sling.filter.scope=request`) so it can preprocess multipart bodies before Sling's POST processing runs.
+- The servlet binds to resource types `RT_CORE_FORM_CONTAINER_V1` and `RT_CORE_FORM_CONTAINER_V2` (constants in [`FormConstants`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/form/FormConstants.java)) with **selector `form` and extension `html` only**. A POST to the same resource without the `.form.html` selector/extension is **not** intercepted and falls through to Sling's default POST handler.
+- The component declares `service.ranking:Integer=610`, which places it above Sling's default POST servlet but below typical authoring/security filters. Lowering this ranking will cause the default POST servlet to win and form submissions will create JCR nodes instead of invoking action handlers — see [`CoreFormHandlingServlet`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/CoreFormHandlingServlet.java).
+- The servlet delegates the actual write to `FormsHandlingServletHelper` (Foundation forms) and uses `SaferSlingPostValidator` to deny disallowed property names. Customisations must go through Foundation form actions (`foundation/components/form/actions/*`) — the servlet does not invoke models directly.
+- `FormStructureHelperImpl` is a `FormStructureHelper` `@Component` that teaches Foundation Forms how to discover form fields inside a Core Form container. Without it, `FormsHandlingServletHelper` cannot enumerate the input fields and submission silently drops them — see [`FormStructureHelperImpl`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/form/FormStructureHelperImpl.java).
+- The configurationPid `com.adobe.cq.wcm.core.components.commons.forms.impl.CoreFormsHandlingServlet` is the public-facing PID for OSGi config (allowed properties, allowed action types). Renaming this PID is a breaking change for customer configs.
+
+## Resolution pipeline
+
+1. The browser submits to `…/jcr:content/form.form.html`. Sling resolves the resource (form container) and routes the POST.
+2. As a request filter, `CoreFormHandlingServlet` runs early in the chain — its `doFilter` lets `FormsHandlingServletHelper` parse the multipart/urlencoded body and surface form fields uniformly.
+3. As a servlet, it owns the POST for `(form container resource type, .form.html, POST)`. Sling's default POST servlet is overridden by the higher service ranking.
+4. `SaferSlingPostValidator` rejects any parameter name not in the allow-list (configured via OSGi). Disallowed parameters cause the request to abort with a 403/400.
+5. `FormsHandlingServletHelper` reads the configured `:formstart` resource pointer and resolves the **action** type (mailto, store-content, custom). It iterates fields exposed by `FormStructureHelperImpl`, applies their type-specific persistence/validation, and dispatches to the action.
+6. On success, the action returns a redirect/thank-you target which Foundation Forms turns into a Sling redirect response.
+
+## Anti-patterns
+
+- **Submitting to a Core Form container via plain `POST` without `.form.html`** — bypasses `CoreFormHandlingServlet` entirely. Sling's default POST servlet will create or modify nodes under the form resource path. This is a common authoring mistake when a custom client writes to `formresource` instead of `formresource.form.html`.
+- **Lowering `service.ranking` below the default POST servlet** — the default servlet will silently win. Form actions never run. Symptom: properties appear at the form container path but no email/redirect/post-action fires.
+- **Removing `FormStructureHelperImpl` or shadowing it without re-registering a `FormStructureHelper`** — Foundation Forms can't enumerate child fields and submitted values are silently dropped from the action invocation.
+- **Adding a new field type that produces a property name outside the allow-list** — `SaferSlingPostValidator` will reject the request. Either configure the allow-list (preferred) or use a Foundation-compatible field name.
+
+## Source pointers
+
+- [`CoreFormHandlingServlet`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/CoreFormHandlingServlet.java) — Servlet+Filter registration, ranking, selector/extension binding.
+- [`FormConstants`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/form/FormConstants.java) — `RT_CORE_FORM_CONTAINER_V1`/`V2` resource type constants.
+- [`FormHandlerImpl`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/form/FormHandlerImpl.java) — model-side helper for form processing.
+- [`FormStructureHelperImpl`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/form/FormStructureHelperImpl.java) — discovers fields inside a Core Form container.
+- [`FormActionTypeDataSourceServlet`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/FormActionTypeDataSourceServlet.java) and [`FormActionTypeSettingsDataSourceServlet`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/FormActionTypeSettingsDataSourceServlet.java) — populate the action-type dropdown in the form container dialog.

--- a/docs/llm-wiki/concepts/htl-components-and-amp.md
+++ b/docs/llm-wiki/concepts/htl-components-and-amp.md
@@ -1,0 +1,31 @@
+# HTL components and AMP overrides
+
+Core Components ship paired artifacts: a Sling Model in `bundles/core/` and an HTL component
+in `content/`. The `extensions/amp/` reactor module overlays selected HTL scripts to produce
+AMP-compatible markup while reusing the same Sling Models. This page is a navigation entry
+to find the right files for a given component.
+
+## Related
+
+- [Sling Model versioning and ImplementationPicker](sling-model-versioning.md)
+- [Link resolution pipeline](link-resolution.md)
+
+## Key entry points
+
+- [`content/src/content/jcr_root/apps/core/wcm/components/`](../../../content/src/content/jcr_root/apps/core/wcm/components/) — root for every shipped HTL component, organised as `<component>/<vN>/<component>/`.
+- `<component>/<vN>/<component>/<component>.html` — the HTL script that calls `data-sly-use.X="com.adobe.cq.wcm.core.components.models.X"` to bind the public Sling Model.
+- `<component>/<vN>/<component>/_cq_dialog/.content.xml` — Granite dialog definition.
+- `<component>/<vN>/<component>/_cq_editConfig.xml` — editor in-place behaviour, listeners, drop targets.
+- `<component>/<vN>/<component>/_cq_template/.content.xml` — initial child node tree placed when an instance is dropped on a page.
+- `<component>/<vN>/<component>/clientlibs/site/` and `clientlibs/editor/` — published / authoring JavaScript and CSS, packaged via `aem-clientlib-generator` (`npm run build` in `content/`).
+- [`extensions/amp/`](../../../extensions/amp/) — separate Maven reactor that overlays HTL scripts under `apps/core/wcm/components/<component>/<vN>/<component>` with AMP-specific markup. The Sling Model is **not** duplicated; AMP variants depend on the same `bundles/core/` JAR.
+- [`testing/it/it.ui.apps`](../../../testing/it/it.ui.apps/) and [`testing/it/it.ui.content`](../../../testing/it/it.ui.content/) — content packages installed alongside the bundle for HTTP/UI integration tests.
+
+## Gotchas
+
+- HTL files are checked in under `content/src/content/jcr_root/...` rather than `src/main/content/...`. The Maven `content-package-maven-plugin` build picks up that path; do not move scripts.
+- The `_cq_dialog`, `_cq_editConfig`, and `_cq_template` directories are **FileVault** representations — editing them by hand is supported, but never delete the leading dot in `.content.xml` and keep `jcr:primaryType` declarations intact.
+- AMP variants override the **HTML script only**. If a component renders custom JS via `data-sly-resource` to a separate node, the AMP overlay must include a script for that node too, otherwise the AMP page falls back to the base script and embeds disallowed JS.
+- Bumping a component to `vN+1` requires creating a parallel directory tree under `content/.../<component>/vN+1/` (HTL, dialog, editConfig, template, clientlibs) **and** the matching `internal/models/vN+1/` impl in `bundles/core/`. See [Sling Model versioning](sling-model-versioning.md) for what the picker requires.
+- Some clientlibs are **embedded** into others (e.g. the data-layer client lib into the page's site clientlib). Embedding is configured in the per-component `clientlib.config.json` consumed by `npm run build`; editing only the source JS without re-running `build` will not update the published clientlib.
+- The Karma/Jasmine JS unit-test fixtures live in `content/test/` and run via `npm run unit` from `content/`. They are independent of the JUnit suite under `bundles/core/`.

--- a/docs/llm-wiki/concepts/json-model-export.md
+++ b/docs/llm-wiki/concepts/json-model-export.md
@@ -1,0 +1,38 @@
+# JSON model export (Sling Model Exporter)
+
+**Purpose** — explain how Core Components produce the JSON shape consumed by the SPA Editor and headless clients via the `model.json` Sling Model Exporter.
+
+## Invariants
+
+- A component is exported as JSON when its public Sling Model is annotated `@Exporter(name = "jackson", extensions = "json")`. The export endpoint is `<page>.model.json` for the Page model and `<resource>.model.json` for individual components, served by the Sling Model Exporter — the bundle does not register a custom servlet for it.
+- Jackson behaviour for these models is customised by registered `ModuleProvider` services. [`PageModuleProvider`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/PageModuleProvider.java) is the global provider that wires in module-level configuration; [`DefaultMethodSkippingModuleProvider`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/DefaultMethodSkippingModuleProvider.java) excludes `default` interface methods from serialisation. Without the latter, default methods on public model interfaces would be serialised as JSON properties — breaking the documented JSON contract.
+- [`PageSerializer`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/PageSerializer.java) produces the SPA-Editor-compatible page tree (`:items`, `:itemsOrder`, `:type`). Children of a page are serialised in **`:itemsOrder` order**, not JCR child-node order; consumers parse `:itemsOrder` to render in the correct sequence.
+- [`LinkHtmlAttributesSerializer`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/LinkHtmlAttributesSerializer.java) controls the JSON shape of `Link.htmlAttributes`. The map is serialised flat (no nested `attrs:` envelope) — see [Link resolution pipeline](link-resolution.md) for how the underlying `Link` is built.
+- The `*Data` interfaces in [`models/datalayer/`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/) are serialised through dedicated mixins under [`models/datalayer/jackson/`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/jackson/). Adding a getter without a corresponding mixin entry leaks the value into the published JSON — see [Data Layer integration](data-layer.md).
+- The `model.json` shape is **public API**. A renamed JSON property is a breaking change for SPA Editor consumers and headless clients regardless of whether the underlying Java getter changed signature.
+
+## Resolution pipeline
+
+1. A request hits `<page>.model.json`. Sling Models Jackson Exporter resolves the page resource to the highest-versioned `Page` impl (via [`LatestVersionImplementationPicker`](sling-model-versioning.md)).
+2. The Jackson `ObjectMapper` for the export is built by the registered `ModuleProvider` services. `PageModuleProvider` and `DefaultMethodSkippingModuleProvider` contribute modules that:
+   - skip `default` interface methods (so they don't show up as JSON properties);
+   - apply mixins to data-layer types and links;
+   - add the SPA-Editor-specific serialisers.
+3. `PageSerializer` walks the page's container tree, serialising each child component via its own `@Exporter`-annotated model. The traversal honours `:itemsOrder` from the container model rather than JCR child-node order.
+4. Each child component's getter chain runs synchronously inside the same request, on the same `ResourceResolver`. There is no caching layer between Sling Models and Jackson — every `model.json` request re-runs the Sling Model lifecycle.
+5. The serialised tree is returned as `application/json`. Headless clients parse `:items` / `:itemsOrder` / `:type` to drive rendering or routing.
+
+## Anti-patterns
+
+- **Adding a public getter to a model interface to expose internal state** — the Jackson exporter serialises every public getter that isn't `default` or annotated `@JsonIgnore`. New getters become part of the public JSON contract instantly. If the value is not meant to be public, mark it `@JsonIgnore` or keep the method on the impl, not the interface.
+- **Returning a non-JSON-serialisable type from a getter** — `Resource`, `Node`, `ResourceResolver`, etc. will fail Jackson serialisation at request time and the whole `model.json` response will 500. Always return DTOs or primitives from exported getters.
+- **Reordering JCR child nodes to change render order** — has no effect on `model.json` because `PageSerializer` follows `:itemsOrder`. Changing render order requires updating the container's `:itemsOrder` payload (e.g. via the container's reorder logic), not JCR sibling order.
+- **Bypassing `DefaultMethodSkippingModuleProvider`** — registering a custom Jackson module that overrides the skip-default-methods behaviour will leak every default method on every Core model into JSON, including `Link`, `Component`, `Container` defaults that downstream consumers do not expect.
+
+## Source pointers
+
+- [`PageModuleProvider`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/PageModuleProvider.java) — registers Jackson module for page-level export.
+- [`PageSerializer`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/PageSerializer.java) — emits SPA-Editor `:items` / `:itemsOrder` / `:type` shape.
+- [`DefaultMethodSkippingModuleProvider`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/DefaultMethodSkippingModuleProvider.java) — strips `default` methods from serialisation.
+- [`LinkHtmlAttributesSerializer`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/LinkHtmlAttributesSerializer.java) — flattens `Link.htmlAttributes` for export.
+- [`models/datalayer/jackson/`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/datalayer/jackson/) — mixins controlling data-layer JSON.

--- a/docs/llm-wiki/concepts/link-resolution.md
+++ b/docs/llm-wiki/concepts/link-resolution.md
@@ -1,0 +1,40 @@
+# Link resolution pipeline
+
+**Purpose** — every URL rendered by a Core Component (button, teaser, navigation entry, content fragment field, image link…) flows through `LinkManager`/`LinkBuilder`. This page documents how a raw `linkURL` property becomes a final href, including shadowing, validation, and `PathProcessor` extension points.
+
+## Invariants
+
+- All Core Components must obtain links via [`LinkManager`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/link/LinkManager.java) (adapted from `SlingHttpServletRequest`) and never construct hrefs by string concatenation. `LinkManager` is the only path that runs the configured `PathProcessor` chain — see [`LinkManagerImpl`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkManagerImpl.java).
+- The set of allowed `target` attribute values is the unmodifiable set `{_blank, _parent, _top}`. `_self` is accepted in the dialog but produces **no** target attribute on render. Any other value is dropped — see `VALID_LINK_TARGETS` in [`LinkManagerImpl`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkManagerImpl.java).
+- "Shadowing" (a redirecting page silently rendered as its target) is **on by default**. To preserve the original page, the resource property `disableShadowing=true` must be set explicitly. The default constant is `PROP_DISABLE_SHADOWING_DEFAULT = false`. See [`LinkManagerImpl`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkManagerImpl.java).
+- `PathProcessor` is a public SPI — see [`services/link/PathProcessor`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/PathProcessor.java). Multiple processors are tried in OSGi service-ranking order; the first one whose `accepts(path, request)` returns `true` handles the link. The built-in [`DefaultPathProcessor`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java) accepts everything and runs last. Customers register processors at higher ranking to intercept specific path shapes (e.g. asset URLs, vanity prefixes).
+- `LinkBuilder` is mutable and request-scoped: it is instantiated per call to `LinkManager.get(...)` and not safe to share across threads or requests. Each `LinkBuilder.build()` produces a new immutable `Link`.
+
+## Resolution pipeline
+
+1. An HTL script or Sling Model calls `linkManager.get(resource)` (or `.get(page)` / `.get(asset)`). `LinkManager` is a request-scoped `@Model`.
+2. `LinkManager` reads `linkURL`, `linkTarget`, and `linkAccessibilityLabel`/`linkTitle` from the resource (via `@ScriptVariable properties` if injected through HTL).
+3. The resolved path is offered to the registered `PathProcessor` chain in service-ranking order. The first accepting processor:
+   - normalises/transforms the path,
+   - decides whether the link should be externalised, and
+   - may attach selectors/extension/fragment/query parts.
+4. If the resolved target is a `Page` and shadowing is enabled (default), the chain follows `cq:redirectTarget` until it lands on a non-redirecting page or the chain ends. Setting `disableShadowing=true` on the source resource short-circuits this step and keeps the original page.
+5. Target validation: if `linkTarget` is not in `VALID_LINK_TARGETS`, no `target` attribute is rendered. `_self` is also dropped (kept only as a dialog default).
+6. The `LinkBuilder` produces a `Link` whose `getURL()` is the final href and whose `getHtmlAttributes()` is the map serialised by [`LinkHtmlAttributesSerializer`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/LinkHtmlAttributesSerializer.java) when the model is exported to JSON.
+
+## Anti-patterns
+
+- **Building a link in HTL via `${'http://...' @ context='uri'}`** — bypasses `PathProcessor`, shadowing, and target validation. Always go through the model's `@getLink` (or equivalent) which delegates to `LinkManager`. Customer overlays that "fix" a link in HTL will silently regress shadowing.
+- **Setting an arbitrary `linkTarget`** — values outside `{_blank, _parent, _top, _self}` are dropped on output. Authors expecting `target="_new"` will see no target attribute in published HTML. Validate authoring dialogs against `VALID_LINK_TARGETS`.
+- **Caching a `LinkBuilder` across requests** — it carries request state. The OSGi `LinkManager` is request-scoped (`@Model(adaptables = SlingHttpServletRequest.class)`); never store its `LinkBuilder` in a static or service field.
+- **Registering a `PathProcessor` without a guard in `accepts`** — a processor that returns `true` unconditionally and is registered above `DefaultPathProcessor` will swallow every link in the system, including pages that should be shadow-resolved. Always scope `accepts` to a specific path prefix or resource type.
+
+## Source pointers
+
+- [`LinkManager`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/link/LinkManager.java) — public adaptable contract.
+- [`LinkBuilder`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/link/LinkBuilder.java) — fluent builder.
+- [`LinkManagerImpl`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkManagerImpl.java) — request-scoped `@Model`, defines validation constants and shadowing flag.
+- [`LinkBuilderImpl`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkBuilderImpl.java) — runs the `PathProcessor` chain.
+- [`DefaultPathProcessor`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/DefaultPathProcessor.java) — terminal/default processor.
+- [`PathProcessor` SPI](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/link/PathProcessor.java) — extension point.
+- [`LinkHtmlAttributesSerializer`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/LinkHtmlAttributesSerializer.java) — JSON shape of links.

--- a/docs/llm-wiki/concepts/sling-model-versioning.md
+++ b/docs/llm-wiki/concepts/sling-model-versioning.md
@@ -1,0 +1,37 @@
+# Sling Model versioning and ImplementationPicker
+
+**Purpose** — explain how the Core Components bundle resolves which `*Impl` class implements a public model interface (e.g. `Image`, `Page`, `Teaser`) at request time, given that several versioned implementations coexist in the same bundle.
+
+## Invariants
+
+- A public model interface lives in `com.adobe.cq.wcm.core.components.models` (e.g. [`Image`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java)). Every concrete implementation lives under `com.adobe.cq.wcm.core.components.internal.models.v<N>` and the version segment in the package path is the version segment used by `LatestVersionImplementationPicker`. Renaming the package breaks version selection — see [`LatestVersionImplementationPicker`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/LatestVersionImplementationPicker.java).
+- When the same public interface is `@Model(adapters = …)` from multiple `vN` impls, the **highest** numeric `vN` wins. The picker compares `INTERNAL_MODEL_PATTERN` matches and returns the higher integer — see [`LatestVersionImplementationPicker.pick`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/LatestVersionImplementationPicker.java).
+- The picker only fires for adapters whose package equals `com.adobe.cq.wcm.core.components.models`. Adapters in any other package fall through (`return null`) and Sling's default picker chain continues. Do not rely on this picker to disambiguate downstream/customer models.
+- Downstream Adobe internal models (anything under `com.adobe.cq.*` that is **not** in `com.adobe.cq.wcm.core.components.internal.models`) are filtered out before version comparison. A consumer cannot win the picker by adding an `@Model` in a sibling Adobe package.
+- The picker's `@ServiceRanking(1)` places it after `ResourceTypeBasedResourcePicker` (ranking 0/default). Resource-type-based picks always win over version-based picks. A `vN` impl bound to a more specific `resourceType` than `vN+1` will still be selected for that resource type.
+- Version bumps are an API event: a new `vN+1` impl must coexist with `vN` (users depend on it) and the matching HTL must live at `content/.../foo/vN+1/foo`. Removing or renaming a `vN` package is a breaking change even if no public interface changes.
+
+## Resolution pipeline
+
+1. Sling adapts a `Resource` (or `SlingHttpServletRequest`) to a public interface like `Image.class`.
+2. Sling Models gathers every `@Model(adapters = Image.class)` candidate visible to the bundle.
+3. The `ResourceTypeBasedResourcePicker` (registered by Sling Models, higher service ranking) tries to pick by `resourceType` match. If a single candidate matches the resource's `sling:resourceType` (or supertype chain), it wins and the chain stops.
+4. If no resource-type pick is decisive, `LatestVersionImplementationPicker` runs. It:
+   - filters to internal Core Components models or third-party (non-`com.adobe.cq.*`) models;
+   - parses `vN` out of each FQN with `INTERNAL_MODEL_PATTERN`;
+   - returns the candidate with the largest `N`. Ties or non-matches fall back to `implementationsTypes[0]`.
+5. The picked class is instantiated by Sling Models. From here, `@ScriptVariable`, `@Self`, `@OSGiService`, and `@PostConstruct` run inside that single picked impl — there is no further dispatch between versions.
+
+## Anti-patterns
+
+- **Cross-version inheritance for "code reuse"** — making `v2.FooImpl extends v1.FooImpl` couples the public surface of two versions. A bug fix in `v1` to satisfy the older HTL contract will leak into `v2` and vice versa. Prefer composition or a private helper in `internal/helper/`.
+- **Adding a `vN+1` impl without HTL** — the picker will start returning `vN+1` for every `Image.class` adaptation in the bundle, even where the JCR resource still references `core/wcm/components/image/v2/image`. Until the HTL exists, `data-sly-use.image="com.adobe.cq.wcm.core.components.models.Image"` will run code that doesn't match the markup contract. Always land impl + HTL together.
+- **Placing a `vN` impl in `com.adobe.cq.wcm.core.components.models`** — the picker treats only `internal.models.v<N>` as version-aware. An impl in the public package is filtered out and never wins a version comparison.
+- **Relying on `vN+1` to override a customer's downstream `@Model`** — a downstream model in a non-`com.adobe.cq` package can outrank Core Components by `service.ranking` or by binding to a more specific `resourceType`. Don't assume newest Core wins for customer-overlay components.
+
+## Source pointers
+
+- [`LatestVersionImplementationPicker`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/LatestVersionImplementationPicker.java) — the picker; `INTERNAL_MODEL_PATTERN` is the source of truth for the package convention.
+- [`models/`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/) — public, versionless model interfaces (the contract).
+- [`internal/models/v1`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/), [`v2`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/), [`v3`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/), [`v4`](../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v4/) — versioned implementations that the picker ranks.
+- [`VERSIONS.md`](../../../VERSIONS.md) — historical version-to-AEM matrix; update when bumping.

--- a/docs/llm-wiki/index.md
+++ b/docs/llm-wiki/index.md
@@ -1,0 +1,19 @@
+# Core Components — LLM Wiki
+
+This wiki documents subsystem-specific knowledge for the AEM WCM Core Components reactor.
+Project-wide context (build, reactor layout, repo conventions) lives in the root
+[`CLAUDE.md`](../../CLAUDE.md) — do not duplicate it here.
+
+Each concept page focuses on one subsystem with invariants, resolution pipelines, and
+source pointers. Read the relevant page before grepping the bundle.
+
+## Concepts
+
+- [Sling Model versioning and ImplementationPicker](concepts/sling-model-versioning.md) — how versioned `internal/models/vN/*Impl` classes are resolved at runtime.
+- [Link resolution pipeline](concepts/link-resolution.md) — how `LinkManager` / `LinkBuilder` produce URLs and apply path processors and shadowing.
+- [Adaptive Image servlet registration](concepts/adaptive-image-servlet.md) — how the image servlet is dynamically registered from OSGi factory configurations.
+- [Data Layer integration](concepts/data-layer.md) — runtime contract between component models and the Adobe Client Data Layer.
+- [Component policies via Sling CA-config](concepts/component-policies.md) — how content policies and CA-config reach component models.
+- [Forms handling pipeline](concepts/forms-handling.md) — how `CoreFormHandlingServlet` intercepts POSTs to core form containers.
+- [HTL components and AMP overrides](concepts/htl-components-and-amp.md) — how the `content/` package binds Sling models, and how AMP variants override scripts.
+- [JSON model export (Sling Model Exporter)](concepts/json-model-export.md) — Jackson serialization rules for headless/SPA consumption.


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Documentation Provided   | Yes (CLAUDE.md + llm-wiki)
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Added the llm-wiki and CLAUDE.md, to let Claude (and other LLMs) self-orient faster, reusing effort on a team level.

The wiki should also serve as project documentation for human use.

To have the llm-wiki auto-updated, please use ClawDEA 1.6.1 (https://plugins.jetbrains.com/plugin/31729-clawdea/edit/versions/stable/1056973) and in its settings, turn on "Auto-update wiki on drift". ClawDEA knows how to use and update the wiki; but it should also be very useful for any Claude-based tool, as the wiki is referenced from CLAUDE.md; other tools should also be able to auto-discover it from the docs folder.

The current covered concepts are a minimal startup set. As you develop using ClawDEA, it will auto-discover gaps and add to the wiki. It also watches for git activity to reflect the latest code changes into the wiki.
