### PR TITLE
Fix SITES-46718: CheckboxTextfieldTuple hide() NPE causes cq:styleId not written in Image component policies

### DIFF
--- a/content/karma.conf.js
+++ b/content/karma.conf.js
@@ -37,6 +37,7 @@ module.exports = function(config) {
             'src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/vcfRenderer.js',
             'src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/authoringutils/js/*.js',
             'src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/htmlidvalidator/js/*.js',
+            'src/content/jcr_root/apps/core/wcm/components/commons/v1/clientlibs/editor/checkboxTextfieldTuple/checkboxTextfieldTuple.js',
             'src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/clientlibs/editor/js/contentfragmentlist.js',
             'src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/dialog/js/editDialog.js',
             {

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/v1/clientlibs/editor/checkboxTextfieldTuple/checkboxTextfieldTuple.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/v1/clientlibs/editor/checkboxTextfieldTuple/checkboxTextfieldTuple.js
@@ -65,9 +65,11 @@
                         hide: function() {
                             self._checkboxFoundation.setDisabled(true);
                             $(self._checkbox).parent().hide();
-                            var previousValue = self._textfield.getAttribute(self.ATTR_PREVIOUS_VALUE);
-                            if (previousValue !== undefined && previousValue !== null) {
-                                self._setTextfieldValue(previousValue);
+                            if (self._textfield) {
+                                var previousValue = self._textfield.getAttribute(self.ATTR_PREVIOUS_VALUE);
+                                if (previousValue !== undefined && previousValue !== null) {
+                                    self._setTextfieldValue(previousValue);
+                                }
                             }
                         }
                     };

--- a/content/test/clientlibs/commons/checkboxTextfieldTupleTest.js
+++ b/content/test/clientlibs/commons/checkboxTextfieldTupleTest.js
@@ -63,7 +63,7 @@ describe("CheckboxTextfieldTuple suite", function() {
     });
 
     describe("checkbox foundation-toggleable adapter", function() {
-        it("hide() should not throw when textfield is absent (SITES-34101 regression)", function() {
+        it("hide() should not throw when textfield is absent (SITES-46718 regression)", function() {
             // Image v3 design dialog: titleValueFromDAM checkbox present, jcr:title input absent → _textfield = null
             const tuple = new CQ.CoreComponents.CheckboxTextfieldTuple.v1(
                 container,

--- a/content/test/clientlibs/commons/checkboxTextfieldTupleTest.js
+++ b/content/test/clientlibs/commons/checkboxTextfieldTupleTest.js
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright 2026 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+function makeCheckboxFoundationMock() {
+    return {
+        getValue: function() { return "false"; },
+        setValue: function() {},
+        isDisabled: function() { return false; },
+        setDisabled: function() {}
+    };
+}
+
+function makeTextfieldFoundationMock() {
+    return {
+        getValue: function() { return ""; },
+        setValue: jasmine.createSpy("textfield.setValue"),
+        isDisabled: function() { return false; },
+        setDisabled: function() {}
+    };
+}
+
+function getRegisteredCheckboxAdapter() {
+    return globalThis.foundationRegistry._adapters.find(function(a) {
+        return a.type === "foundation-toggleable" && a.selector.includes("titleValueFromDAM");
+    });
+}
+
+describe("CheckboxTextfieldTuple suite", function() {
+    let container;
+    let checkboxEl;
+    let checkboxFoundationMock;
+
+    beforeEach(function() {
+        container = document.createElement("div");
+        container.innerHTML =
+            "<div>" +
+            '<coral-checkbox name="./titleValueFromDAM" value="true">' +
+            '<input type="checkbox" handle="input" />' +
+            "</coral-checkbox>" +
+            "</div>";
+        document.body.appendChild(container);
+
+        checkboxEl = container.querySelector('coral-checkbox[name="./titleValueFromDAM"]');
+        checkboxFoundationMock = makeCheckboxFoundationMock();
+        checkboxEl.__foundationField = checkboxFoundationMock;
+    });
+
+    afterEach(function() {
+        container.remove();
+        globalThis.foundationRegistry._adapters.length = 0;
+    });
+
+    describe("checkbox foundation-toggleable adapter", function() {
+        it("hide() should not throw when textfield is absent (SITES-34101 regression)", function() {
+            // Image v3 design dialog: titleValueFromDAM checkbox present, jcr:title input absent → _textfield = null
+            const tuple = new CQ.CoreComponents.CheckboxTextfieldTuple.v1(
+                container,
+                'coral-checkbox[name="./titleValueFromDAM"]',
+                'input[name="./jcr:title"]'
+            );
+            expect(tuple._textfield).toBeNull();
+
+            const adapterConfig = getRegisteredCheckboxAdapter();
+            expect(adapterConfig).toBeDefined();
+            expect(function() { adapterConfig.adapter().hide(); }).not.toThrow();
+        });
+
+        it("hide() should restore previous textfield value when textfield is present", function() {
+            const titleInput = document.createElement("input");
+            titleInput.setAttribute("name", "./jcr:title");
+            titleInput.value = "Previous Title";  // constructor reads .value to initialise data-previous-value
+            container.querySelector("div").appendChild(titleInput);
+
+            const textfieldMock = makeTextfieldFoundationMock();
+            titleInput.__foundationField = textfieldMock;
+
+            const tuple = new CQ.CoreComponents.CheckboxTextfieldTuple.v1(
+                container,
+                'coral-checkbox[name="./titleValueFromDAM"]',
+                'input[name="./jcr:title"]'
+            );
+            expect(tuple._textfield).not.toBeNull();
+
+            getRegisteredCheckboxAdapter().adapter().hide();
+            expect(textfieldMock.setValue).toHaveBeenCalledWith("Previous Title");
+        });
+
+        it("show() should re-enable the checkbox", function() {
+            const titleInput = document.createElement("input");
+            titleInput.setAttribute("name", "./jcr:title");
+            container.querySelector("div").appendChild(titleInput);
+
+            const textfieldMock = makeTextfieldFoundationMock();
+            titleInput.__foundationField = textfieldMock;
+
+            const setDisabledSpy = jasmine.createSpy("checkbox.setDisabled");
+            checkboxFoundationMock.setDisabled = setDisabledSpy;
+
+            const tuple = new CQ.CoreComponents.CheckboxTextfieldTuple.v1(
+                container,
+                'coral-checkbox[name="./titleValueFromDAM"]',
+                'input[name="./jcr:title"]'
+            );
+            expect(tuple._textfield).not.toBeNull();
+
+            getRegisteredCheckboxAdapter().adapter().show();
+            expect(setDisabledSpy).toHaveBeenCalledWith(false);
+        });
+    });
+});

--- a/content/test/mocks.js
+++ b/content/test/mocks.js
@@ -126,6 +126,31 @@ class JQueryArray extends Array {
         }
         return this;
     }
+
+    adaptTo(type) {
+        if (type === 'foundation-field') {
+            return this[0]?.__foundationField ?? null;
+        }
+        if (type === 'foundation-registry') {
+            return globalThis.foundationRegistry;
+        }
+        if (type === 'foundation-toggleable') {
+            var adapters = globalThis.foundationRegistry?._adapters;
+            if (!adapters || !this[0]) return null;
+            for (var i = 0; i < adapters.length; i++) {
+                var cfg = adapters[i];
+                if (cfg.type === 'foundation-toggleable') {
+                    try {
+                        if (this[0].matches && this[0].matches(cfg.selector)) {
+                            return cfg.adapter();
+                        }
+                    } catch (e) { /* ignore invalid selectors */ }
+                }
+            }
+            return null;
+        }
+        return null;
+    }
 }
 
 function jQuery(obj) {
@@ -439,9 +464,13 @@ Granite = {
 // Mock foundation registry
 globalThis.foundationRegistry = {
     validators: [],
+    _adapters: [],
     register: function(type, config) {
         if (type === 'foundation.validation.validator') {
             this.validators.push(config);
+        }
+        if (type === 'foundation.adapters') {
+            this._adapters.push(config);
         }
     }
 };


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | SITES-46718
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

## Problem

Regression introduced in release 26353: when authors add a new Style to the Image component via Template Editor → Styles tab, the policy node is saved without a `cq:styleId` property. As a result the style appears in the UI but cannot be applied on content pages — the selection resets on dialog close.

### Immediate cause

`CheckboxTextfieldTuple`'s `foundation-toggleable` adapter called `self._textfield.getAttribute(...)` unconditionally in `hide()`. When `_textfield` is `null` — which happens in the Image v3 design dialog where the `titleValueFromDAM` checkbox is present but there is no `jcr:title` input — this threw a `TypeError`.

The uncaught exception propagated synchronously through jQuery's `$.fn.trigger('cui-contentloaded')`, preventing the subsequent `channel.trigger('dialog-ready')` from ever firing. Without `dialog-ready`, `design-dialog.js` never bound its multifield change handler, `setStyleId()` was never called, and `cq:styleId` was never written to JCR.

### Why it regressed in release 26353 (activated by PR #3026)

The latent NPE had existed since mid-2022, when a cleanup commit (`80cb3cd90`) removed the `handlePolicyDialog` guard from `image.js`. That guard — introduced together with the `extraClientlibs` dependency in the design dialog — branched on `[data-cmp-image-v3-dialog-policy-hook]` to skip the edit-dialog logic (including `captionTuple` construction and `updateImageThumbnail().then(...)`) when the design dialog opened. After the guard was removed, the edit-dialog JS ran unconditionally for both dialogs.

The bug remained dormant because `updateImageThumbnail()` previously issued a `$.ajax()` call with an invalid URL (both path attributes are absent in the design dialog, producing `"undefined.htmlundefined"`). That request failed with a 404, yielding a **rejected** jQuery deferred; jQuery's `.then(successHandler)` does not fire on rejection, so `captionTuple.hideCheckbox(true)` was never reached.

PR [#3026](https://github.com/adobe/aem-core-wcm-components/pull/3026) (SITES-41279) added path validation with an early return of `$.Deferred().resolve().promise()` — a valid security improvement for the edit dialog. In the design dialog the paths are always absent, so this early return now fires on every policy dialog open. A jQuery `.then()` on an **already-resolved** deferred executes its callback **synchronously**, putting `captionTuple.hideCheckbox(true)` inside the `cui-contentloaded` dispatch chain where the `TypeError` aborts event propagation before `dialog-ready` can fire.

## Fix

Added `if (self._textfield)` null guard in the `hide()` function of the checkbox's `foundation-toggleable` adapter, matching the pattern already present in `CheckboxTextfieldTuple.prototype.update()`.

## Tests

Added first-ever Karma/Jasmine unit tests for `CheckboxTextfieldTuple`:
- `hide()` must not throw when textfield is absent (SITES-46718 regression)
- `hide()` restores previous textfield value when textfield is present
- `show()` re-enables the checkbox

Also extended `test/mocks.js` with `adaptTo()` on `JQueryArray` and `foundation.adapters` registration support, enabling the class to be tested in the Karma harness.

## Before / After
Before the fix - `hide()` throws `TypeError` → `dialog-ready` blocked → `cq:styleId` empty
<img width="1400" height="900" alt="SITES-46718-before" src="https://github.com/user-attachments/assets/16a3f567-1abc-446d-9a52-92a23de7d4a9"/>
After fix - Null guard prevents crash → `dialog-ready` fires → `cq:styleId` written
<img width="1400" height="900" alt="SITES-46718-after" src="https://github.com/user-attachments/assets/1c20e320-4cf6-41ba-9ee0-a4c750c18deb"/>