### PR TITLE
SITES-47738: FT for displaying vcf

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/_cq_dialog/.content.xml
@@ -65,12 +65,8 @@
                                                 value="vcf">
                                                 <granite:rendercondition
                                                     jcr:primaryType="nt:unstructured"
-                                                    sling:resourceType="granite/ui/components/coral/foundation/renderconditions/not">
-                                                    <rendercondition
-                                                        jcr:primaryType="nt:unstructured"
-                                                        sling:resourceType="granite/ui/components/coral/foundation/renderconditions/feature"
-                                                        feature="core.wcm.components.contentfragment.vcf"/>
-                                                </granite:rendercondition>
+                                                    sling:resourceType="granite/ui/components/renderconditions/featuretoggle"
+                                                    toggleName="FT_SITES-47738"/>
                                             </vcf>
                                         </items>
                                     </displayMode>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/_cq_dialog/.content.xml
@@ -62,7 +62,16 @@
                                             <vcf
                                                 jcr:primaryType="nt:unstructured"
                                                 text="Visual Content Fragment"
-                                                value="vcf"/>
+                                                value="vcf">
+                                                <granite:rendercondition
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/renderconditions/not">
+                                                    <rendercondition
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/renderconditions/feature"
+                                                        feature="core.wcm.components.contentfragment.vcf"/>
+                                                </granite:rendercondition>
+                                            </vcf>
                                         </items>
                                     </displayMode>
                                     <elementNames


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-47738 
| Patch: Bug Fix?          | No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

Problem: we added a new functionality for Visual Content Fragments but a customer said that they don't want Visual Content Fragments to become another supported authoring path.

Solution: wrap a Feature Flag around this functionality: FT_SITES-47738
