### PR TITLE
docs: add README and Component Library entries for search components

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Set of standardized Web Content Management (WCM) components for [Adobe Experienc
 
 ## Features
 
-* **Production-Ready:** 29 robust components that are well tested, widely used, and that perform well.
+* **Production-Ready:** 30 robust components that are well tested, widely used, and that perform well.
 * **Cloud-Ready:** Whether on [AEM as a Cloud Service](https://docs.adobe.com/content/help/en/experience-manager-cloud-service/landing/home.html), on [Adobe Managed Services](https://github.com/adobe/aem-project-archetype/tree/master/src/main/archetype/dispatcher.ams), or on-premise, they just work.
 * **Versatile:** The components represent generic concepts with which the authors can assemble nearly any layout.
 * **Configurable:** Template-level [content policies](https://docs.adobe.com/content/help/en/experience-manager-65/developing/platform/templates/page-templates-editable.html#content-policies) define which features the page authors are allowed to use or not.
@@ -43,8 +43,9 @@ Set of standardized Web Content Management (WCM) components for [Adobe Experienc
 2. [Navigation](content/src/content/jcr_root/apps/core/wcm/components/navigation/v2/navigation)
 3. [Language Navigation](content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v2/languagenavigation)
 4. [Breadcrumb](content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v3/breadcrumb)
-5. [Quick Search](content/src/content/jcr_root/apps/core/wcm/components/search/v1/search)
-6. [Table of Contents](content/src/content/jcr_root/apps/core/wcm/components/tableofcontents/v1/tableofcontents)
+5. [Quick Search](content/src/content/jcr_root/apps/core/wcm/components/search/v3/search)
+6. [ContentAI Supported Search](content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch)
+7. [Table of Contents](content/src/content/jcr_root/apps/core/wcm/components/tableofcontents/v1/tableofcontents)
 
 ### Page Authoring Components
 

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/contentaisearch/.content.xml
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/contentaisearch/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:description="ContentAI Supported Search Component for the Core Components Library"
+    jcr:primaryType="cq:Component"
+    jcr:title="ContentAI Supported Search"
+    sling:resourceSuperType="core/wcm/components/contentaisearch/v1/contentaisearch"
+    componentGroup="Core Components Examples"/>

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/search-v3/.content.xml
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/search-v3/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:description="Quick Search v3 Component for the Core Components Library"
+    jcr:primaryType="cq:Component"
+    jcr:title="Quick Search (v3)"
+    sling:resourceSuperType="core/wcm/components/search/v3/search"
+    componentGroup="Core Components Examples"/>

--- a/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/core-content/.content.xml
+++ b/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/core-content/.content.xml
@@ -22,6 +22,8 @@
     <pdf-viewer/>
     <progress-bar/>
     <search/>
+    <search-v3/>
+    <contentai-supported-search/>
     <separator/>
     <tabs/>
     <teaser/>

--- a/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/core-content/contentai-supported-search/.content.xml
+++ b/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/core-content/contentai-supported-search/.content.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:template="/conf/core-components-examples/settings/wcm/templates/content-page"
+        jcr:description="ContentAI Supported Search backed by Content AI search and generative search APIs"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="ContentAI Supported Search"
+        sling:resourceType="core-components-examples/components/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wcm/foundation/components/responsivegrid">
+            <responsivegrid
+                cq:styleIds="[1545309110033]"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="wcm/foundation/components/responsivegrid">
+                <text
+                    cq:styleIds="[1644862132301]"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/text"
+                    text="&lt;h1>ContentAI Supported Search&lt;sub>v1&lt;/sub>&lt;/h1>"
+                    textIsRich="true"/>
+                <text_806535487
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/text"
+                    text="&lt;p>Search component backed by the Content AI &lt;code>content-sources/search&lt;/code> and &lt;code>content-sources/gensearch&lt;/code> APIs. It merges results from configured public content sources and can optionally show a generative summary.&lt;/p>&lt;p>&lt;strong>Note:&lt;/strong> Live search and generative summary require a Content AI API configuration for the AEM environment. Without valid API credentials and content sources, examples may show empty results or errors.&lt;/p>"
+                    textIsRich="true"/>
+                <teaser
+                    cq:styleIds="[1550165685463]"
+                    jcr:description="&lt;p>GitHub&lt;/p>"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Technical Documentation"
+                    sling:resourceType="core-components-examples/components/teaser"
+                    actionsEnabled="false"
+                    descriptionFromPage="false"
+                    fileReference="/content/dam/core-components-examples/library/github-logo.svg"
+                    linkURL="https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/README.md"
+                    textIsRich="true"
+                    titleFromPage="false"/>
+                <title
+                    cq:styleIds="[1544759664489]"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Examples"
+                    sling:resourceType="core-components-examples/components/title"
+                    type="h2"/>
+                <title_439265523
+                    cq:styleIds="[1544759676459]"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Card layout"
+                    sling:resourceType="core-components-examples/components/title"
+                    type="h3"/>
+                <text_1083667127
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/text"
+                    text="&lt;p>Default card layout with generative summary toggle visible and enabled by default.&lt;/p>"
+                    textIsRich="true"/>
+                <demo
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/demo"
+                    fullWidth="{Boolean}true">
+                    <component
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/demo/component">
+                        <contentaisearch_card
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/contentaisearch"
+                            contentSourceType="ACQUISITION"
+                            contentSources="example-public-source"
+                            genSearchEnabledByDefault="{Boolean}true"
+                            genSearchToggleVisible="{Boolean}true"
+                            placeholder="Search content"
+                            resultsLayout="card"
+                            resultsSize="{Long}12"/>
+                    </component>
+                    <info
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/tabs">
+                        <properties
+                            cq:panelTitle="Properties"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/properties"
+                            reference="../../component"/>
+                        <markup
+                            cq:panelTitle="Markup"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/markup"
+                            reference="../../component"/>
+                        <json
+                            cq:panelTitle="JSON"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/json"
+                            reference="../../component"/>
+                    </info>
+                </demo>
+                <title_439265524
+                    cq:styleIds="[1544759676459]"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="List layout"
+                    sling:resourceType="core-components-examples/components/title"
+                    type="h3"/>
+                <text_1083667128
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/text"
+                    text="&lt;p>List layout with the generative summary toggle hidden from visitors.&lt;/p>"
+                    textIsRich="true"/>
+                <demo_2
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/demo"
+                    fullWidth="{Boolean}true">
+                    <component
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/demo/component">
+                        <contentaisearch_list
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/contentaisearch"
+                            contentSourceType="ACQUISITION"
+                            contentSources="example-public-source"
+                            genSearchEnabledByDefault="{Boolean}false"
+                            genSearchToggleVisible="{Boolean}false"
+                            placeholder="Search content"
+                            resultsLayout="list"
+                            resultsSize="{Long}12"/>
+                    </component>
+                    <info
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/tabs">
+                        <properties
+                            cq:panelTitle="Properties"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/properties"
+                            reference="../../component"/>
+                        <markup
+                            cq:panelTitle="Markup"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/markup"
+                            reference="../../component"/>
+                        <json
+                            cq:panelTitle="JSON"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/json"
+                            reference="../../component"/>
+                    </info>
+                </demo_2>
+            </responsivegrid>
+        </root>
+    </jcr:content>
+</jcr:root>

--- a/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/core-content/search-v3/.content.xml
+++ b/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/core-content/search-v3/.content.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:template="/conf/core-components-examples/settings/wcm/templates/content-page"
+        jcr:description="Quick Search v3 with optional AI Search toggle for semantic search"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="Search v3"
+        sling:resourceType="core-components-examples/components/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wcm/foundation/components/responsivegrid">
+            <responsivegrid
+                cq:styleIds="[1545309110033]"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="wcm/foundation/components/responsivegrid">
+                <text
+                    cq:styleIds="[1644862132301]"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/text"
+                    text="&lt;h1>Quick Search&lt;sub>v3&lt;/sub>&lt;/h1>"
+                    textIsRich="true"/>
+                <text_806535487
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/text"
+                    text="&lt;p>Quick Search v3 extends v2 with an optional visitor-facing AI Search toggle. When enabled, the search query is prefixed with &lt;code>?{}?&lt;/code> to route to ContentAI-powered semantic search.&lt;/p>"
+                    textIsRich="true"/>
+                <teaser
+                    cq:styleIds="[1550165685463]"
+                    jcr:description="&lt;p>GitHub&lt;/p>"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Technical Documentation"
+                    sling:resourceType="core-components-examples/components/teaser"
+                    actionsEnabled="false"
+                    descriptionFromPage="false"
+                    fileReference="/content/dam/core-components-examples/library/github-logo.svg"
+                    linkURL="https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/README.md"
+                    textIsRich="true"
+                    titleFromPage="false"/>
+                <teaser_1419027210
+                    cq:styleIds="[1550165685463]"
+                    jcr:description="&lt;p>Adobe Help Center&lt;/p>"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Using Core Components"
+                    sling:resourceType="core-components-examples/components/teaser"
+                    actionsEnabled="false"
+                    descriptionFromPage="false"
+                    fileReference="/content/dam/core-components-examples/library/adobe-logo.svg"
+                    linkURL="https://www.adobe.com/go/aem_cmp_search_v2"
+                    textIsRich="true"
+                    titleFromPage="false"/>
+                <title
+                    cq:styleIds="[1544759664489]"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Examples"
+                    sling:resourceType="core-components-examples/components/title"
+                    type="h2"/>
+                <title_439265523
+                    cq:styleIds="[1544759676459]"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Basic configuration"
+                    sling:resourceType="core-components-examples/components/title"
+                    type="h3"/>
+                <text_1083667127
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/text"
+                    text="&lt;p>Quick Search v3 with a configured Search Root. With the AI Search toggle off, behavior matches v2 fulltext search.&lt;/p>"
+                    textIsRich="true"/>
+                <demo
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/demo"
+                    fullWidth="{Boolean}true">
+                    <component
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/demo/component">
+                        <search_v3_basic
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/search-v3"
+                            searchRoot="/content/core-components-examples/library"/>
+                    </component>
+                    <info
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/tabs">
+                        <properties
+                            cq:panelTitle="Properties"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/properties"
+                            reference="../../component"/>
+                        <markup
+                            cq:panelTitle="Markup"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/markup"
+                            reference="../../component"/>
+                        <json
+                            cq:panelTitle="JSON"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/json"
+                            reference="../../component"/>
+                    </info>
+                </demo>
+                <title_439265524
+                    cq:styleIds="[1544759676459]"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="AI Search toggle"
+                    sling:resourceType="core-components-examples/components/title"
+                    type="h3"/>
+                <text_1083667128
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/text"
+                    text="&lt;p>When the visitor enables the AI Search toggle, the component prepends &lt;code>?{}?&lt;/code> to the &lt;code>fulltext&lt;/code> query parameter. Use the browser network tab to inspect the search request when testing semantic search.&lt;/p>"
+                    textIsRich="true"/>
+                <demo_2
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/demo"
+                    fullWidth="{Boolean}true">
+                    <component
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/demo/component">
+                        <search_v3_ai_toggle
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/search-v3"
+                            searchRoot="/content/core-components-examples/library"/>
+                    </component>
+                    <info
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core-components-examples/components/tabs">
+                        <properties
+                            cq:panelTitle="Properties"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/properties"
+                            reference="../../component"/>
+                        <markup
+                            cq:panelTitle="Markup"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/markup"
+                            reference="../../component"/>
+                        <json
+                            cq:panelTitle="JSON"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="core-components-examples/components/demo/json"
+                            reference="../../component"/>
+                    </info>
+                </demo_2>
+                <title_439265525
+                    cq:styleIds="[1544759676459]"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Hide AI Search toggle (design policy)"
+                    sling:resourceType="core-components-examples/components/title"
+                    type="h3"/>
+                <text_1083667129
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core-components-examples/components/text"
+                    text="&lt;p>Template authors can hide the visitor-facing toggle via the v3 design dialog property &lt;code>hideAiSearchToggle&lt;/code>. When enabled, the component behaves like v2 and only performs fulltext search. On AEM 6.5, the toggle is hidden by default.&lt;/p>"
+                    textIsRich="true"/>
+            </responsivegrid>
+        </root>
+    </jcr:content>
+</jcr:root>


### PR DESCRIPTION
Document Quick Search v3 and ContentAI Supported Search in the root README and add Component Library example pages with proxy components.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
