### PR TITLE
fix(search): allow ES2015 in v2/v3 search clientlib compilation

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v2/search/clientlibs/site/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v2/search/clientlibs/site/.content.xml
@@ -2,4 +2,5 @@
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
-    categories="[core.wcm.components.search.v2]"/>
+    categories="[core.wcm.components.search.v2]"
+    jsProcessor="[default:none,min:gcc;languageIn=ECMASCRIPT_2015;languageOut=ECMASCRIPT_2015]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/clientlibs/site/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/clientlibs/site/.content.xml
@@ -2,4 +2,5 @@
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
-    categories="[core.wcm.components.search.v3]"/>
+    categories="[core.wcm.components.search.v3]"
+    jsProcessor="[default:none,min:gcc;languageIn=ECMASCRIPT_2015;languageOut=ECMASCRIPT_2015]"/>


### PR DESCRIPTION
The localizeMessage helper in the search v2/v3 site clientlibs uses ES6 syntax (default parameters, const, let), which the Google Closure Compiler rejects in its default ES5/strict mode during precompile-maven-plugin:compile-clientlibs, causing BUILD FAILURE.

Set jsProcessor to run GCC with languageIn/languageOut=ECMASCRIPT_2015 on both clientlibs, matching the existing image v2 site clientlib.