### PR TITLE
fix: refresh editor page after hideAiSearchToggle policy change

### DIFF
--- a/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/search/v3/SearchIT.java
+++ b/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/search/v3/SearchIT.java
@@ -87,6 +87,8 @@ public class SearchIT extends com.adobe.cq.wcm.core.components.it.seljup.tests.s
             put("hideAiSearchToggle", "true");
         }});
 
+        editorPage.refresh();
+
         editorPage.enterPreviewMode();
         Commons.switchContext("ContentFrame");
         assertFalse(v3Search().isAiToggleVisible(), "AI Search toggle should be hidden when policy is enabled");


### PR DESCRIPTION
Reload the page editor after updating the Search v3 content policy so preview mode reflects hideAiSearchToggle=true and the flaky E2E assertion is stable.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
