### PR TITLE
fix(contentaisearch): make modelFactory protected for OSGi field injection

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/AbstractContentAISearchServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/AbstractContentAISearchServlet.java
@@ -57,7 +57,7 @@ abstract class AbstractContentAISearchServlet extends SlingSafeMethodsServlet {
     protected transient ContentAIClient contentAIClient;
 
     @Reference
-    private transient ModelFactory modelFactory;
+    protected transient ModelFactory modelFactory;
 
     @Override
     protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws IOException {


### PR DESCRIPTION
## Summary
- Change `modelFactory` from `private` to `protected` in `AbstractContentAISearchServlet`
- Fixes OSGi Declarative Services field injection for `ContentAIGenSearchServlet` and `ContentAISearchResultsServlet` subclass components
- Prevents startup ERROR logs (`findField: Suitable but non-accessible field modelFactory`) that cause quickstart `LogFileIT#testErrors` to fail on `core.wcm.components.core:2.32.2`

## Context
`contentAIClient` was already `protected`; `modelFactory` was `private`, which blocks DS field injection when references are inherited onto subclass SCR components via `_dsannotations-options>inherit`.

## Test plan
- [ ] Build `bundles/core` and verify generated SCR XML still includes `modelFactory` references on both servlet components
- [ ] Deploy bundle to local AEM SDK and confirm no OSGi field-injection ERROR lines in `error.log` at startup
- [ ] Re-run quickstart `LogFileIT#testErrors` (or `it-sdk-master-pr` stage) with updated bundle version

Made with [Cursor](https://cursor.com)