### PR TITLE
Fix typo in Breadcrumbs v3 disableShadowing checked value

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v3/breadcrumb/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v3/breadcrumb/_cq_design_dialog/.content.xml
@@ -69,7 +69,7 @@
                                 text="Disable shadowing"
                                 name="./disableShadowing"
                                 value="{Boolean}true"
-                                checked="{Boolean}false}"
+                                checked="{Boolean}false"
                                 uncheckedValue="{Boolean}false"/>
                         </items>
                     </properties>


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #3042
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | N/A (dialog XML typo only)
| Documentation Provided   | N/A
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

In the Breadcrumbs v3 design dialog, disableShadowing had checked="{Boolean}false}" with an extra closing brace. Updated it to checked="{Boolean}false".