### PR TITLE
GRANITE-70028: ContentAI Supported Search - stale-response fixes, Markdown rendering, results cap

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ContentAISupportedSearchImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ContentAISupportedSearchImpl.java
@@ -41,7 +41,6 @@ import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.internal.AemCloudPlatformDetector;
 import com.adobe.cq.wcm.core.components.models.ContentAISupportedSearch;
-import com.adobe.cq.wcm.core.components.services.contentai.ContentAIClient;
 import com.adobe.cq.wcm.core.components.util.AbstractComponentImpl;
 import com.adobe.granite.license.ProductInfoProvider;
 import com.day.cq.i18n.I18n;
@@ -69,7 +68,7 @@ public class ContentAISupportedSearchImpl extends AbstractComponentImpl implemen
     private String contentSource;
 
     @ValueMapValue(name = PN_CONTENT_SOURCE_TYPE)
-    @Default(values = ContentAIClient.DEFAULT_CONTENT_SOURCE_TYPE)
+    @Default(values = ContentAISupportedSearch.DEFAULT_CONTENT_SOURCE_TYPE)
     private String contentSourceType;
 
     @ValueMapValue(name = PN_CONTENT_SOURCES, injectionStrategy = InjectionStrategy.OPTIONAL)
@@ -135,7 +134,7 @@ public class ContentAISupportedSearchImpl extends AbstractComponentImpl implemen
     @NotNull
     @Override
     public String getContentSourceType() {
-        return StringUtils.defaultIfBlank(contentSourceType, ContentAIClient.DEFAULT_CONTENT_SOURCE_TYPE);
+        return StringUtils.defaultIfBlank(contentSourceType, ContentAISupportedSearch.DEFAULT_CONTENT_SOURCE_TYPE);
     }
 
     @NotNull

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentAIClientImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentAIClientImpl.java
@@ -35,6 +35,7 @@ import org.apache.http.util.EntityUtils;
 import org.apache.sling.settings.SlingSettingsService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.metatype.annotations.Designate;
@@ -77,14 +78,47 @@ public class ContentAIClientImpl implements ContentAIClient {
     @Reference
     private SlingSettingsService slingSettings;
 
-    private ContentAIConfig config;
+    // volatile: @Modified can run concurrently with in-flight requests on
+    // other threads: swapping both fields together under a single volatile
+    // write (config last) means a request either sees the old config with
+    // the old client, or the new config with the new client, never a mix.
+    private volatile ContentAIConfig config;
+    private volatile CloseableHttpClient httpClient;
 
     private final ObjectMapper mapper = new ObjectMapper();
 
     @Activate
     @Modified
     protected void activate(ContentAIConfig config) {
+        CloseableHttpClient previousClient = this.httpClient;
+        this.httpClient = buildHttpClient(config);
+        // config is written last (see the volatile note above)
         this.config = config;
+        // Accepted tradeoff: if @Modified fires while another thread is mid-execute() on previousClient (read via
+        // this.httpClient at the top of executeGet/executeRequest before this swap), closing it here can abort that
+        // in-flight call - it surfaces as one failed request (IOException -> ContentAIClientException), not data
+        // corruption, and OSGi reconfiguration is rare enough in practice that this is preferable to the added
+        // complexity of reference-counting or a drain delay before closing.
+        if (previousClient != null) {
+            closeQuietly(previousClient);
+        }
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        closeQuietly(this.httpClient);
+        this.httpClient = null;
+    }
+
+    private void closeQuietly(CloseableHttpClient client) {
+        if (client == null) {
+            return;
+        }
+        try {
+            client.close();
+        } catch (IOException e) {
+            LOGGER.warn("Failed to close Content AI HTTP client", e);
+        }
     }
 
     @Override
@@ -164,43 +198,41 @@ public class ContentAIClientImpl implements ContentAIClient {
     }
 
     private JsonNode executeGet(String path) throws ContentAIClientException {
+        // Snapshot once: config is volatile and @Modified can swap it concurrently with this request. Reading
+        // config.apiKey() and (inside resolveBaseUrl) config.baseUrlOverride() as two separate field reads could
+        // otherwise combine an old API key with a new base URL, or vice versa, if a reconfiguration lands in between.
+        ContentAIConfig config = this.config;
         String apiKey = config.apiKey();
         if (StringUtils.isBlank(apiKey)) {
             throw new ContentAIClientException("Content AI API key (X-Api-Key) is not configured", 0);
         }
-        String url = resolveBaseUrl() + path;
-        RequestConfig requestConfig = RequestConfig.custom()
-            .setConnectTimeout(config.connectionTimeout())
-            .setSocketTimeout(config.socketTimeout())
-            .build();
-        try (CloseableHttpClient httpClient = getHttpClient(requestConfig)) {
+        String url = resolveBaseUrl(config) + path;
+        try {
             HttpGet get = new HttpGet(url);
             get.setHeader("Accept", "application/json");
             get.setHeader("X-Api-Key", apiKey);
-            return executeAndParse(httpClient, get, path);
+            return executeAndParse(this.httpClient, get, path);
         } catch (IOException e) {
             throw new ContentAIClientException("Failed to call Content AI at " + path, e);
         }
     }
 
     private JsonNode executeRequest(String path, ObjectNode body) throws ContentAIClientException {
+        // See executeGet's comment on why config is snapshotted once per request.
+        ContentAIConfig config = this.config;
         String apiKey = config.apiKey();
         if (StringUtils.isBlank(apiKey)) {
             throw new ContentAIClientException("Content AI API key (X-Api-Key) is not configured", 0);
         }
-        String url = resolveBaseUrl() + path;
-        RequestConfig requestConfig = RequestConfig.custom()
-            .setConnectTimeout(config.connectionTimeout())
-            .setSocketTimeout(config.socketTimeout())
-            .build();
-        try (CloseableHttpClient httpClient = getHttpClient(requestConfig)) {
+        String url = resolveBaseUrl(config) + path;
+        try {
             HttpPost post = new HttpPost(url);
             post.setHeader("Content-Type", "application/json");
             // Anonymous, public-index access uses X-Api-Key (a Developer Console client ID), never a bearer token.
             post.setHeader("X-Api-Key", apiKey);
             post.setEntity(new StringEntity(mapper.writeValueAsString(body), StandardCharsets.UTF_8));
 
-            return executeAndParse(httpClient, post, path);
+            return executeAndParse(this.httpClient, post, path);
         } catch (IOException e) {
             throw new ContentAIClientException("Failed to call Content AI at " + path, e);
         }
@@ -211,10 +243,12 @@ public class ContentAIClientImpl implements ContentAIClient {
      * targets its own environment's bucket rather than a hand-configured value. Falls back to the dev-only
      * {@code baseUrlOverride} config when the CS environment variables are absent (local/non-CS development).
      *
+     * @param config the config snapshot to resolve against (see callers' notes on why this isn't read from the
+     *               instance field directly)
      * @return the base URL (without a trailing slash), up to and including the Content AI path
      * @throws ContentAIClientException if no override is set and the environment variables are not present
      */
-    protected String resolveBaseUrl() throws ContentAIClientException {
+    protected String resolveBaseUrl(ContentAIConfig config) throws ContentAIClientException {
         String override = config.baseUrlOverride();
         if (StringUtils.isNotBlank(override)) {
             return stripTrailingSlash(override.trim());
@@ -300,7 +334,18 @@ public class ContentAIClientImpl implements ContentAIClient {
         }
     }
 
-    protected CloseableHttpClient getHttpClient(RequestConfig requestConfig) {
+    /**
+     * Builds the long-lived, shared HTTP client used for every Content AI call - built once per activation
+     * (config change) rather than per request, so requests reuse pooled connections instead of paying a fresh
+     * TCP/TLS handshake every time.
+     *
+     * @param config the configuration this client's connect/socket timeouts are derived from
+     */
+    protected CloseableHttpClient buildHttpClient(ContentAIConfig config) {
+        RequestConfig requestConfig = RequestConfig.custom()
+            .setConnectTimeout(config.connectionTimeout())
+            .setSocketTimeout(config.socketTimeout())
+            .build();
         if (httpClientBuilderFactory != null) {
             return httpClientBuilderFactory.newBuilder().setDefaultRequestConfig(requestConfig).build();
         }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentAIClientImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentAIClientImpl.java
@@ -78,8 +78,10 @@ public class ContentAIClientImpl implements ContentAIClient {
     @Reference
     private SlingSettingsService slingSettings;
 
-    // volatile: @Modified can run concurrently with in-flight requests; config
-    // is written last so a request never sees a mix of old/new config+client.
+    // volatile: @Modified can run concurrently with in-flight requests. config is snapshotted once per request
+    // (see executeGet/executeRequest), so a request's apiKey/baseUrl reads can't straddle a reconfiguration.
+    // httpClient is read unsnapshotted, so a request may still pair an old config with a just-swapped httpClient -
+    // harmless, since httpClient only affects transport/pooling, not the URL/headers already built from that config.
     private volatile ContentAIConfig config;
     private volatile CloseableHttpClient httpClient;
 
@@ -199,11 +201,12 @@ public class ContentAIClientImpl implements ContentAIClient {
             throw new ContentAIClientException("Content AI API key (X-Api-Key) is not configured", 0);
         }
         String url = resolveBaseUrl(config) + path;
+        CloseableHttpClient httpClient = requireHttpClient();
         try {
             HttpGet get = new HttpGet(url);
             get.setHeader("Accept", "application/json");
             get.setHeader("X-Api-Key", apiKey);
-            return executeAndParse(this.httpClient, get, path);
+            return executeAndParse(httpClient, get, path);
         } catch (IOException e) {
             throw new ContentAIClientException("Failed to call Content AI at " + path, e);
         }
@@ -217,6 +220,7 @@ public class ContentAIClientImpl implements ContentAIClient {
             throw new ContentAIClientException("Content AI API key (X-Api-Key) is not configured", 0);
         }
         String url = resolveBaseUrl(config) + path;
+        CloseableHttpClient httpClient = requireHttpClient();
         try {
             HttpPost post = new HttpPost(url);
             post.setHeader("Content-Type", "application/json");
@@ -224,10 +228,20 @@ public class ContentAIClientImpl implements ContentAIClient {
             post.setHeader("X-Api-Key", apiKey);
             post.setEntity(new StringEntity(mapper.writeValueAsString(body), StandardCharsets.UTF_8));
 
-            return executeAndParse(this.httpClient, post, path);
+            return executeAndParse(httpClient, post, path);
         } catch (IOException e) {
             throw new ContentAIClientException("Failed to call Content AI at " + path, e);
         }
+    }
+
+    // Snapshotted once, same reasoning as config - also turns the narrow post-@Deactivate window (httpClient set to
+    // null) into a clean ContentAIClientException instead of an unchecked NullPointerException.
+    private CloseableHttpClient requireHttpClient() throws ContentAIClientException {
+        CloseableHttpClient current = this.httpClient;
+        if (current == null) {
+            throw new ContentAIClientException("Content AI HTTP client is not available (component deactivated)", 0);
+        }
+        return current;
     }
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentAIClientImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentAIClientImpl.java
@@ -78,10 +78,8 @@ public class ContentAIClientImpl implements ContentAIClient {
     @Reference
     private SlingSettingsService slingSettings;
 
-    // volatile: @Modified can run concurrently with in-flight requests on
-    // other threads: swapping both fields together under a single volatile
-    // write (config last) means a request either sees the old config with
-    // the old client, or the new config with the new client, never a mix.
+    // volatile: @Modified can run concurrently with in-flight requests; config
+    // is written last so a request never sees a mix of old/new config+client.
     private volatile ContentAIConfig config;
     private volatile CloseableHttpClient httpClient;
 
@@ -92,13 +90,9 @@ public class ContentAIClientImpl implements ContentAIClient {
     protected void activate(ContentAIConfig config) {
         CloseableHttpClient previousClient = this.httpClient;
         this.httpClient = buildHttpClient(config);
-        // config is written last (see the volatile note above)
-        this.config = config;
-        // Accepted tradeoff: if @Modified fires while another thread is mid-execute() on previousClient (read via
-        // this.httpClient at the top of executeGet/executeRequest before this swap), closing it here can abort that
-        // in-flight call - it surfaces as one failed request (IOException -> ContentAIClientException), not data
-        // corruption, and OSGi reconfiguration is rare enough in practice that this is preferable to the added
-        // complexity of reference-counting or a drain delay before closing.
+        this.config = config; // written last, see the volatile note above
+        // Accepted tradeoff: closing previousClient here can abort a request still mid-flight on it (surfaces as
+        // one failed request, not corruption) - reconfiguration is rare enough that this beats reference-counting.
         if (previousClient != null) {
             closeQuietly(previousClient);
         }
@@ -198,9 +192,7 @@ public class ContentAIClientImpl implements ContentAIClient {
     }
 
     private JsonNode executeGet(String path) throws ContentAIClientException {
-        // Snapshot once: config is volatile and @Modified can swap it concurrently with this request. Reading
-        // config.apiKey() and (inside resolveBaseUrl) config.baseUrlOverride() as two separate field reads could
-        // otherwise combine an old API key with a new base URL, or vice versa, if a reconfiguration lands in between.
+        // Snapshot once - config is volatile, so two separate field reads could combine an old API key with a new base URL.
         ContentAIConfig config = this.config;
         String apiKey = config.apiKey();
         if (StringUtils.isBlank(apiKey)) {
@@ -335,9 +327,8 @@ public class ContentAIClientImpl implements ContentAIClient {
     }
 
     /**
-     * Builds the long-lived, shared HTTP client used for every Content AI call - built once per activation
-     * (config change) rather than per request, so requests reuse pooled connections instead of paying a fresh
-     * TCP/TLS handshake every time.
+     * Builds the shared HTTP client, once per activation rather than per request, so requests reuse pooled
+     * connections instead of paying a fresh TCP/TLS handshake every time.
      *
      * @param config the configuration this client's connect/socket timeouts are derived from
      */

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentSourceSearchMerger.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentSourceSearchMerger.java
@@ -82,6 +82,10 @@ public final class ContentSourceSearchMerger {
     }
 
     /**
+     * Note: each source's own cursor advances independent of how many of its items actually survive the
+     * merge+cap - a source whose items are outranked and dropped this page has no way to resurface them via
+     * Load More, since that source's cursor already points past them.
+     *
      * @param partials        per-source search responses from the current request
      * @param sourceCursors   cursors for the next page per source (sources with more results)
      * @param limit           maximum number of merged results to return

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentSourceSearchMerger.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentSourceSearchMerger.java
@@ -42,13 +42,16 @@ public final class ContentSourceSearchMerger {
      */
     @NotNull
     public static ContentSourceSearchResult merge(@NotNull List<ContentSourceSearchResult> partials, int limit) {
+        // Summed across sources, not the max of any one - each partial's totalResults is that source's own
+        // independent match count, so the combined universe of matches is their sum (minus whatever de-duplication
+        // happens below), not bounded by whichever single source happened to report the most.
         long reportedTotal = 0;
         Map<String, ContentSourceSearchResult.Item> byId = new LinkedHashMap<>();
         for (ContentSourceSearchResult partial : partials) {
             if (partial == null) {
                 continue;
             }
-            reportedTotal = Math.max(reportedTotal, partial.getTotalResults());
+            reportedTotal += partial.getTotalResults();
             if (partial.getResults() == null) {
                 continue;
             }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentSourceSearchMerger.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentSourceSearchMerger.java
@@ -42,9 +42,7 @@ public final class ContentSourceSearchMerger {
      */
     @NotNull
     public static ContentSourceSearchResult merge(@NotNull List<ContentSourceSearchResult> partials, int limit) {
-        // Summed across sources, not the max of any one - each partial's totalResults is that source's own
-        // independent match count, so the combined universe of matches is their sum (minus whatever de-duplication
-        // happens below), not bounded by whichever single source happened to report the most.
+        // Summed, not maxed - each partial's totalResults is that source's own independent match count.
         long reportedTotal = 0;
         Map<String, ContentSourceSearchResult.Item> byId = new LinkedHashMap<>();
         for (ContentSourceSearchResult partial : partials) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAIGenSearchServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAIGenSearchServlet.java
@@ -17,11 +17,13 @@ package com.adobe.cq.wcm.core.components.internal.servlets.contentaisearch;
 
 import javax.servlet.Servlet;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
 
 import com.adobe.cq.wcm.core.components.models.ContentAISupportedSearch;
 import com.adobe.cq.wcm.core.components.services.contentai.ContentAIClientException;
+import com.adobe.cq.wcm.core.components.services.contentai.ContentSourceQueryResult;
 
 /**
  * Servlet exposing the ContentAI Supported Search component's generative-summary endpoint,
@@ -44,6 +46,12 @@ public class ContentAIGenSearchServlet extends AbstractContentAISearchServlet {
     @Override
     protected Object executeQuery(@NotNull ContentAISupportedSearch model, @NotNull String query)
         throws ContentAIClientException {
+        if (StringUtils.isBlank(model.getPrimaryContentSource())) {
+            // Mirrors ContentAISearchResultsServlet's own empty-sources check
+            // instead of calling out to Content AI with a blank content
+            // source name, which only fails once it gets there.
+            return new ContentSourceQueryResult();
+        }
         return contentAIClient.genSearch(model.getPrimaryContentSource(), model.getContentSourceType(), query);
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAISearchResultsServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAISearchResultsServlet.java
@@ -86,7 +86,7 @@ public class ContentAISearchResultsServlet extends AbstractContentAISearchServle
             }
         }
 
-        return ContentSourceSearchMerger.mergeToResponse(partials, nextCursors, 0);
+        return ContentSourceSearchMerger.mergeToResponse(partials, nextCursors, model.getResultsSize());
     }
 
     @NotNull

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentSourcesDataSourceServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentSourcesDataSourceServlet.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.wcm.core.components.internal.services.contentai.ContentSourceLabelFormatter;
 import com.adobe.cq.wcm.core.components.internal.servlets.TextValueDataResourceSource;
+import com.adobe.cq.wcm.core.components.models.ContentAISupportedSearch;
 import com.adobe.cq.wcm.core.components.services.contentai.ContentAIClient;
 import com.adobe.cq.wcm.core.components.services.contentai.ContentAIClientException;
 import com.adobe.cq.wcm.core.components.services.contentai.ContentSourceListItem;
@@ -139,7 +140,7 @@ public class ContentSourcesDataSourceServlet extends SlingSafeMethodsServlet {
             }
         }
 
-        return ContentAIClient.DEFAULT_CONTENT_SOURCE_TYPE;
+        return ContentAISupportedSearch.DEFAULT_CONTENT_SOURCE_TYPE;
     }
 
     private boolean isResolvableContentSourceType(@Nullable String value) {

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ContentAISupportedSearch.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ContentAISupportedSearch.java
@@ -21,8 +21,6 @@ import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import com.adobe.cq.wcm.core.components.services.contentai.ContentAIClient;
-
 /**
  * Defines the {@code ContentAISupportedSearch} Sling Model used for the
  * {@code /apps/core/wcm/components/contentaisearch} component.
@@ -50,6 +48,9 @@ public interface ContentAISupportedSearch extends Component {
     String RESULTS_LAYOUT_CARD = "card";
     String RESULTS_LAYOUT_LIST = "list";
 
+    /** Default Content AI content source type used when none is configured. */
+    String DEFAULT_CONTENT_SOURCE_TYPE = "ACQUISITION";
+
     /**
      * @return the primary Content AI content source name (first configured source).
      * @since com.adobe.cq.wcm.core.components.models 12.32.0
@@ -65,7 +66,7 @@ public interface ContentAISupportedSearch extends Component {
      */
     @NotNull
     default String getContentSourceType() {
-        return ContentAIClient.DEFAULT_CONTENT_SOURCE_TYPE;
+        return DEFAULT_CONTENT_SOURCE_TYPE;
     }
 
     /**

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.31.0")
+@Version("12.32.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentAIClientImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentAIClientImplTest.java
@@ -367,6 +367,38 @@ class ContentAIClientImplTest {
     }
 
     @Test
+    void deactivateClosesHttpClientAndClearsField() throws Exception {
+        client.deactivate();
+
+        verify(mockHttpClient).close();
+        assertNull(FieldUtils.getField(ContentAIClientImpl.class, "httpClient", true).get(client));
+    }
+
+    @Test
+    void deactivateSwallowsCloseException() throws Exception {
+        org.mockito.Mockito.doThrow(new IOException("close failed")).when(mockHttpClient).close();
+
+        client.deactivate();
+    }
+
+    @Test
+    void reactivateClosesThePreviousHttpClient() throws Exception {
+        // client's httpClient field currently holds mockHttpClient (via attachTransport in setUp).
+        client.activate(config(TEST_API_KEY, TEST_BASE_URL));
+
+        verify(mockHttpClient).close();
+    }
+
+    @Test
+    void reactivateSwallowsPreviousClientCloseException() throws Exception {
+        org.mockito.Mockito.doThrow(new IOException("close failed")).when(mockHttpClient).close();
+
+        client.activate(config(TEST_API_KEY, TEST_BASE_URL));
+
+        verify(mockHttpClient).close();
+    }
+
+    @Test
     void deriveBucketIgnoresMalformedServiceValue() throws Exception {
         Map<String, String> env = new HashMap<>();
         env.put("AEM_SERVICE", "not-a-bucket");

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentAIClientImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentAIClientImplTest.java
@@ -30,15 +30,12 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
-import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicStatusLine;
-import org.apache.http.osgi.services.HttpClientBuilderFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
@@ -112,13 +109,10 @@ class ContentAIClientImplTest {
     }
 
     private void attachTransport(ContentAIClientImpl target) {
-        HttpClientBuilderFactory mockBuilderFactory = mock(HttpClientBuilderFactory.class);
-        setField(ContentAIClientImpl.class, "httpClientBuilderFactory", target, mockBuilderFactory);
-
-        HttpClientBuilder mockBuilder = mock(HttpClientBuilder.class);
-        when(mockBuilderFactory.newBuilder()).thenReturn(mockBuilder);
-        when(mockBuilder.setDefaultRequestConfig(any(RequestConfig.class))).thenReturn(mockBuilder);
-        when(mockBuilder.build()).thenReturn(mockHttpClient);
+        // The client is now built once in activate() rather than per request, so injecting a mock
+        // HttpClientBuilderFactory after activate() has already run would be too late - set the already-built
+        // (real) client field directly instead.
+        setField(ContentAIClientImpl.class, "httpClient", target, mockHttpClient);
     }
 
     private void respondWith(int statusCode, String jsonBody) throws IOException {
@@ -367,10 +361,9 @@ class ContentAIClientImplTest {
     @Test
     void usesDefaultHttpClientWhenBuilderFactoryMissing() {
         ContentAIClientImpl noFactory = new ContentAIClientImpl();
-        noFactory.activate(config(TEST_API_KEY, TEST_BASE_URL));
         setField(ContentAIClientImpl.class, "httpClientBuilderFactory", noFactory, null);
 
-        assertNotNull(noFactory.getHttpClient(RequestConfig.custom().build()));
+        assertNotNull(noFactory.buildHttpClient(config(TEST_API_KEY, TEST_BASE_URL)));
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentSourceSearchMergerTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentSourceSearchMergerTest.java
@@ -74,6 +74,21 @@ class ContentSourceSearchMergerTest {
     }
 
     @Test
+    void merge_capsResultsAcrossMultipleSourcesExceedingResultsSize() {
+        // Two sources each independently contributing more than the configured limit -
+        // the regression this exists to catch is returning up to N x limit instead of limit.
+        ContentSourceSearchResult first = result(item("a1", 0.95), item("a2", 0.85), item("a3", 0.75));
+        ContentSourceSearchResult second = result(item("b1", 0.9), item("b2", 0.8), item("b3", 0.7));
+
+        ContentSourceSearchResult merged = ContentSourceSearchMerger.merge(Arrays.asList(first, second), 3);
+
+        assertEquals(3, merged.getResults().size());
+        assertEquals("a1", merged.getResults().get(0).getId());
+        assertEquals("b1", merged.getResults().get(1).getId());
+        assertEquals("a2", merged.getResults().get(2).getId());
+    }
+
+    @Test
     void merge_skipsNullPartialsItemsAndBlankIds() {
         ContentSourceSearchResult valid = result(item("doc_1", 0.5));
         ContentSourceSearchResult nullResults = new ContentSourceSearchResult();

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentSourceSearchMergerTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/contentai/ContentSourceSearchMergerTest.java
@@ -38,12 +38,26 @@ class ContentSourceSearchMergerTest {
 
         ContentSourceSearchResult merged = ContentSourceSearchMerger.merge(Arrays.asList(first, second), 10);
 
-        assertEquals(3, merged.getTotalResults());
+        // Each partial independently reports totalResults=2 (from the result() helper below) - summed, not maxed,
+        // across the two sources: 2 + 2 = 4, even though de-duplication leaves only 3 unique items.
+        assertEquals(4, merged.getTotalResults());
         assertEquals(3, merged.getResults().size());
         assertEquals("doc_2", merged.getResults().get(0).getId());
         assertEquals("doc_1", merged.getResults().get(1).getId());
         assertEquals(0.8, merged.getResults().get(1).getScore(), 0.001);
         assertNull(merged.getCursor());
+    }
+
+    @Test
+    void merge_totalResultsSumsAcrossSourcesNotMax() {
+        ContentSourceSearchResult first = result(item("doc_1", 0.5));
+        first.setTotalResults(50);
+        ContentSourceSearchResult second = result(item("doc_2", 0.5));
+        second.setTotalResults(30);
+
+        ContentSourceSearchResult merged = ContentSourceSearchMerger.merge(Arrays.asList(first, second), 10);
+
+        assertEquals(80, merged.getTotalResults());
     }
 
     @Test

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAIGenSearchServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAIGenSearchServletTest.java
@@ -30,8 +30,11 @@ import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(AemContextExtension.class)
@@ -100,5 +103,19 @@ class ContentAIGenSearchServletTest {
         underTest.doGet(context.request(), context.response());
 
         assertEquals(400, context.response().getStatus());
+    }
+
+    @Test
+    void doGetReturnsEmptyResultWhenNoContentSourceConfigured() throws Exception {
+        context.create().resource(CONTENT_ROOT + "/jcr:content/par/empty-gensearch",
+            "sling:resourceType", "core/wcm/components/contentaisearch/v1/contentaisearch");
+        context.currentResource(CONTENT_ROOT + "/jcr:content/par/empty-gensearch");
+        context.request().setQueryString("q=electric+cars");
+
+        underTest.doGet(context.request(), context.response());
+
+        assertEquals(200, context.response().getStatus());
+        assertTrue(context.response().getOutputAsString().contains("\"hits\":[]"));
+        verify(mockClient, never()).genSearch(anyString(), anyString(), anyString());
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAISearchResultsServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAISearchResultsServletTest.java
@@ -154,6 +154,41 @@ class ContentAISearchResultsServletTest {
     }
 
     @Test
+    void doGetCapsResultsAcrossMultipleConfiguredSources() throws Exception {
+        String multiSourceRoot = "/content-multisource";
+        context.load().json(TEST_BASE + "/test-content-multisource.json", multiSourceRoot);
+
+        ContentSourceSearchResult sourceAResult = new ContentSourceSearchResult();
+        sourceAResult.setResults(java.util.Arrays.asList(
+            itemWithScore("a1", 0.95), itemWithScore("a2", 0.85), itemWithScore("a3", 0.75)));
+        ContentSourceSearchResult sourceBResult = new ContentSourceSearchResult();
+        sourceBResult.setResults(java.util.Arrays.asList(
+            itemWithScore("b1", 0.9), itemWithScore("b2", 0.8), itemWithScore("b3", 0.7)));
+
+        when(mockClient.search(eq("source-a"), eq("ACQUISITION"), eq("adventure"), eq(3), isNull()))
+            .thenReturn(sourceAResult);
+        when(mockClient.search(eq("source-b"), eq("ACQUISITION"), eq("adventure"), eq(3), isNull()))
+            .thenReturn(sourceBResult);
+
+        context.currentResource(multiSourceRoot + "/jcr:content/par/contentaisearch");
+        context.request().setQueryString("q=adventure");
+
+        underTest.doGet(context.request(), context.response());
+
+        assertEquals(200, context.response().getStatus());
+        String output = context.response().getOutputAsString();
+        int resultCount = StringUtils.countMatches(output, "\"id\":");
+        assertEquals(3, resultCount, "Merged results across 2 sources of 3 each must be capped to resultsSize (3), not returned as up to 6");
+    }
+
+    private static ContentSourceSearchResult.Item itemWithScore(String id, double score) {
+        ContentSourceSearchResult.Item item = new ContentSourceSearchResult.Item();
+        item.setId(id);
+        item.setScore(score);
+        return item;
+    }
+
+    @Test
     void doGetReturns502WhenContentAiFails() throws Exception {
         when(mockClient.search(anyString(), anyString(), anyString(), anyInt(), isNull()))
             .thenThrow(new ContentAIClientException("failed", 502));

--- a/bundles/core/src/test/resources/contentaisearchservlet/test-content-multisource.json
+++ b/bundles/core/src/test/resources/contentaisearchservlet/test-content-multisource.json
@@ -1,0 +1,18 @@
+{
+  "jcr:primaryType": "cq:Page",
+  "jcr:content": {
+    "jcr:primaryType": "cq:PageContent",
+    "sling:resourceType": "core/wcm/components/page/v3/page",
+    "par": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "wcm/foundation/components/parsys",
+      "contentaisearch": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "core/wcm/components/contentaisearch/v1/contentaisearch",
+        "id": "contentaisearch-1",
+        "contentSources": ["source-a", "source-b"],
+        "resultsSize": 3
+      }
+    }
+  }
+}

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/README.md
@@ -40,6 +40,31 @@ The following properties are written to JCR for the ContentAI Supported Search c
 10. `./disclaimerText` - optional disclaimer below the generative summary
 11. `./id` - defines the component HTML ID attribute
 
+## Configuration - Content AI API Access
+The component calls the Content AI `content-sources/search` and `content-sources/gensearch` APIs through the `ContentAIClient` OSGi service, which is configured via the `Core Components Content AI Client` OSGi configuration (PID `com.adobe.cq.wcm.core.components.internal.services.contentai.ContentAIClientImpl`):
+
+| Property | Required | Description |
+|---|---|---|
+| `apiKey` | Yes | Adobe Developer Console client ID (X-Api-Key) used for anonymous, public-index Content AI access. |
+| `defaultContentSource` | No | Default public content source name used when a component instance does not specify one. |
+| `connectionTimeout` | No | Connection timeout (ms) to Content AI. Defaults to `2000`. |
+| `socketTimeout` | No | Socket read timeout (ms). Defaults to `10000`. |
+| `baseUrlOverride` | No | Full Content AI base URL override, for local/non-Cloud-Service development only. |
+
+Without a valid `apiKey`, the component renders its results section but search/gensearch requests fail gracefully (see `ContentAIClientException`); no key is bundled with, or defaulted by, this component.
+
+### Setting `apiKey` on AEM as a Cloud Service
+1. Obtain an X-Api-Key by requesting Content AI API access for your AEM CS Program/Environment (via the Content AI onboarding process) and creating a Server-to-Server credential in Adobe Developer Console. Copy its "API Key (Client ID)".
+2. In your own Cloud Manager Git repository, add an OSGi configuration targeting the PID above, for example at:
+   `ui.config/src/main/content/jcr_root/apps/<your-app>/osgiconfig/config.author/com.adobe.cq.wcm.core.components.internal.services.contentai.ContentAIClientImpl.cfg.json`
+   ```json
+   {
+     "apiKey": "$[secret:CONTENT_AI_API_KEY]"
+   }
+   ```
+3. Set `CONTENT_AI_API_KEY` as a secret environment variable for your environment in Cloud Manager, using the key copied in step 1.
+4. On the next deploy (or OSGi config reload), Cloud Manager's environment variable interpolation resolves the placeholder and the component starts sending `X-Api-Key` automatically. No AEM code changes are required.
+
 ## Client Libraries
 The component provides a `core.wcm.components.contentaisearch.v1` client library category that contains recommended base CSS styling and JavaScript. It should be added to a relevant site client library using the `embed` property.
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/_cq_dialog/.content.xml
@@ -76,7 +76,7 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                         fieldLabel="Content Sources"
-                                        fieldDescription="Public Content AI content sources to search. Must contain only published/public content — Content AI does not evaluate AEM ACLs."
+                                        fieldDescription="Public Content AI content sources to search. Must contain only published/public content — Content AI does not evaluate AEM ACLs. Requires an OSGi-configured Content AI API key — see the component README."
                                         name="./contentSources"
                                         multiple="{Boolean}true"
                                         required="{Boolean}true"

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/clientlibs/site/css/contentaisearch.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/clientlibs/site/css/contentaisearch.less
@@ -157,6 +157,12 @@
         }
     }
 
+    // toggleShow() sets display:none/block directly via JS, so there's no
+    // intermediate state for a CSS *transition* to interpolate between - a
+    // *transition* would just cut instantly. A CSS *animation* sidesteps
+    // this: browsers automatically restart it whenever an element re-enters
+    // the render tree (display goes from none back to block), with no JS
+    // changes needed.
     &__summary-loading {
         margin: 1.25em 0;
 
@@ -190,6 +196,10 @@
 
     &__summary {
         margin: 1.25em 0;
+    }
+
+    &__summary:not([hidden]), &__summary-loading:not([hidden]) {
+        animation: cmp-contentaisearch__fade-in 400ms ease-out;
     }
 
     &__summary-card {
@@ -244,7 +254,41 @@
     &__summary-text {
         margin: 0 0 1em;
         line-height: 1.6;
-        white-space: pre-wrap;
+
+        // Deliberately no :last-child margin-bottom:0 override. The summary
+        // is revealed word by word (see _renderSummary), so whichever
+        // paragraph/list is currently being typed out IS the last child at
+        // that moment - giving it a different margin than "finished" ones
+        // would mean every block's bottom margin jumps from 0 to .75em the
+        // instant a new one starts after it, a spacing shift that grows
+        // throughout the reveal and is most noticeable right as it settles.
+        // Every block now carries the same margin throughout, mid-reveal or
+        // finished, at the cost of one harmless trailing margin at the end.
+        // The AI summary's Markdown is rendered into plain p/ul/li/strong/a
+        // tags (see _renderMarkdownSummary/_renderMarkdownInline) with no
+        // classes of their own, since the content is dynamically generated
+        // from arbitrary response text rather than authored markup.
+        p { /* stylelint-disable-line selector-max-type */
+            margin: 0 0 .75em;
+        }
+
+        ul { /* stylelint-disable-line selector-max-type */
+            margin: 0 0 .75em;
+            padding-left: 1.25em;
+        }
+
+        li { /* stylelint-disable-line selector-max-type */
+            margin: 0 0 .35em;
+        }
+
+        strong { /* stylelint-disable-line selector-max-type */
+            font-weight: 700;
+        }
+
+        a { /* stylelint-disable-line selector-max-type */
+            color: @summary-accent;
+            text-decoration: underline;
+        }
     }
 
     &__sources-section {
@@ -359,6 +403,16 @@
         list-style: none;
         margin: 0;
         padding: 0;
+    }
+
+    // The results list replaces all of its content in one synchronous write
+    // (_renderResults), so there's no display:none/block toggle to key an
+    // animation off of the way the summary card's show/hide has - the class
+    // is instead removed and re-added by JS on every render (with a forced
+    // reflow in between) to restart this animation each time, including a
+    // Load More append.
+    &__results--refresh {
+        animation: cmp-contentaisearch__fade-in 320ms ease-out;
     }
 
     &--card &__results {
@@ -488,4 +542,16 @@
 @keyframes cmp-contentaisearch__loading-indicator-spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
+}
+
+@keyframes cmp-contentaisearch__fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(-6px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/clientlibs/site/css/contentaisearch.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/clientlibs/site/css/contentaisearch.less
@@ -157,12 +157,6 @@
         }
     }
 
-    // toggleShow() sets display:none/block directly via JS, so there's no
-    // intermediate state for a CSS *transition* to interpolate between - a
-    // *transition* would just cut instantly. A CSS *animation* sidesteps
-    // this: browsers automatically restart it whenever an element re-enters
-    // the render tree (display goes from none back to block), with no JS
-    // changes needed.
     &__summary-loading {
         margin: 1.25em 0;
 
@@ -198,6 +192,8 @@
         margin: 1.25em 0;
     }
 
+    // An animation (not a transition) so it auto-restarts when display goes
+    // from none back to block, since toggleShow() has no intermediate state.
     &__summary:not([hidden]), &__summary-loading:not([hidden]) {
         animation: cmp-contentaisearch__fade-in 400ms ease-out;
     }
@@ -255,19 +251,9 @@
         margin: 0 0 1em;
         line-height: 1.6;
 
-        // Deliberately no :last-child margin-bottom:0 override. The summary
-        // is revealed word by word (see _renderSummary), so whichever
-        // paragraph/list is currently being typed out IS the last child at
-        // that moment - giving it a different margin than "finished" ones
-        // would mean every block's bottom margin jumps from 0 to .75em the
-        // instant a new one starts after it, a spacing shift that grows
-        // throughout the reveal and is most noticeable right as it settles.
-        // Every block now carries the same margin throughout, mid-reveal or
-        // finished, at the cost of one harmless trailing margin at the end.
-        // The AI summary's Markdown is rendered into plain p/ul/li/strong/a
-        // tags (see _renderMarkdownSummary/_renderMarkdownInline) with no
-        // classes of their own, since the content is dynamically generated
-        // from arbitrary response text rather than authored markup.
+        // No :last-child override - the word-by-word reveal makes the last
+        // child change mid-render, which would otherwise shift spacing.
+        // Bare tags (not classes) since this is rendered from response text.
         p { /* stylelint-disable-line selector-max-type */
             margin: 0 0 .75em;
         }
@@ -405,12 +391,8 @@
         padding: 0;
     }
 
-    // The results list replaces all of its content in one synchronous write
-    // (_renderResults), so there's no display:none/block toggle to key an
-    // animation off of the way the summary card's show/hide has - the class
-    // is instead removed and re-added by JS on every render (with a forced
-    // reflow in between) to restart this animation each time, including a
-    // Load More append.
+    // Class is removed/re-added by JS on every render (see _renderResults)
+    // to restart this animation, since the list has no display toggle to key off of.
     &__results--refresh {
         animation: cmp-contentaisearch__fade-in 320ms ease-out;
     }

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/clientlibs/site/js/contentaisearch.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/clientlibs/site/js/contentaisearch.js
@@ -18,8 +18,8 @@
 
     var NS = "cmp";
     var IS = "contentaisearch";
-    var DELAY = 300;
     var LOADING_DISPLAY_DELAY = 300;
+    var REVEAL_WORD_INTERVAL_MS = 12;
 
     var selectors = {
         self: "[data-" + NS + '-is="' + IS + '"]',
@@ -56,11 +56,21 @@
         this._genSearchEnabled = this._resolveInitialGenSearchEnabled();
         this._resultsLayout = this._element.getAttribute("data-cmp-results-layout") === "list" ? "list" : "card";
         this._i18n = this._parseI18n();
-        this._timeout = null;
+        this._revealTimer = null;
         this._currentQuery = "";
         this._allResults = [];
         this._hasMore = false;
         this._sourceCursors = {};
+        // Monotonic per-endpoint request counters, plus which query (if any)
+        // is currently in flight for that endpoint. Replaces comparing
+        // against _currentQuery alone: two requests for the identical query
+        // text (e.g. pressing Enter twice) are otherwise indistinguishable
+        // from each other by a string comparison, so neither looks "stale"
+        // to the other no matter which one resolves last.
+        this._resultsRequestId = 0;
+        this._genSearchRequestId = 0;
+        this._pendingResultsQuery = null;
+        this._pendingGenSearchQuery = null;
 
         this._applyLayoutClass();
         this._syncLayoutButtons();
@@ -87,9 +97,7 @@
             this._elements.loadMore.addEventListener("click", this._onLoadMore.bind(this));
         }
         if (this._elements.form) {
-            this._elements.form.addEventListener("submit", function(event) {
-                event.preventDefault();
-            });
+            this._elements.form.addEventListener("submit", this._onFormSubmit.bind(this));
         }
     }
 
@@ -171,13 +179,22 @@
         this._renderResults();
     };
 
+    // Search runs only on an explicit trigger - form submit (Enter, or a
+    // mobile keyboard's "Go"/"Search" action, both of which fire the form's
+    // submit event same as a real submit button would) or the AI-answer
+    // toggle changing - never on typing itself. A debounced search-as-you-
+    // type fires a fresh, often-incomplete query on every brief pause,
+    // which both re-renders the results/summary repeatedly while the user
+    // is still typing (a visible flicker) and shows the loading indicators
+    // for every one of those in-between queries, giving the impression a
+    // search is running when the user hasn't asked for one yet.
     ContentAISearch.prototype._onInput = function() {
-        var self = this;
         this._syncClearButton();
-        clearTimeout(this._timeout);
-        this._timeout = setTimeout(function() {
-            self._runQuery();
-        }, DELAY);
+    };
+
+    ContentAISearch.prototype._onFormSubmit = function(event) {
+        event.preventDefault();
+        this._runQuery();
     };
 
     ContentAISearch.prototype._syncClearButton = function() {
@@ -195,14 +212,39 @@
         this._clearResults();
     };
 
+    // Only ever touches the gensearch/summary state - toggling the
+    // AI-answer switch has nothing to do with the plain results list, so
+    // unlike the old behavior (which always re-ran _runQuery, re-firing a
+    // full .search.json call along with it) this no longer re-fetches
+    // results that haven't changed.
     ContentAISearch.prototype._onToggleChange = function() {
         this._genSearchEnabled = this._elements.toggle.checked;
         if (!this._genSearchEnabled) {
+            // Invalidate any gensearch request still in flight so a
+            // late-arriving answer can't reopen the summary the user just
+            // explicitly turned off.
+            this._genSearchRequestId++;
+            this._pendingGenSearchQuery = null;
+            if (this._revealTimer) {
+                clearTimeout(this._revealTimer);
+                this._revealTimer = null;
+            }
             toggleShow(this._elements.summary, false);
             toggleShow(this._elements.error, false);
             this._setSummaryLoading(false);
+            return;
         }
-        this._runQuery();
+        var query = this._elements.input.value;
+        if (!query || query !== this._currentQuery) {
+            // Nothing has been submitted yet, or the field has unsubmitted
+            // edits - wait for an explicit submit rather than searching just
+            // because the toggle moved.
+            return;
+        }
+        if (this._pendingGenSearchQuery === query) {
+            return;
+        }
+        this._runGenSearch(query);
     };
 
     ContentAISearch.prototype._onLoadMore = function() {
@@ -210,16 +252,32 @@
     };
 
     ContentAISearch.prototype._onRetry = function() {
-        this._runGenSearch(this._elements.input.value);
+        var query = this._elements.input.value;
+        if (this._pendingGenSearchQuery === query) {
+            // Already retrying this exact query - ignore a repeated click
+            // instead of firing a second, redundant request.
+            return;
+        }
+        this._runGenSearch(query);
     };
 
     ContentAISearch.prototype._runQuery = function() {
         var query = this._elements.input.value;
-        this._currentQuery = query;
         if (!query) {
+            this._currentQuery = query;
             this._clearResults();
             return;
         }
+        if (query === this._currentQuery &&
+            (this._pendingResultsQuery === query || this._pendingGenSearchQuery === query)) {
+            // The identical query is already in flight (e.g. Enter pressed
+            // twice, or mashed while waiting) - ignore the duplicate submit
+            // rather than firing a second round-trip. The in-flight request
+            // still resolves normally; submitting again once it's done
+            // fires a fresh one as usual.
+            return;
+        }
+        this._currentQuery = query;
         this._runResultsSearch(query);
         if (this._genSearchEnabled) {
             this._runGenSearch(query);
@@ -234,6 +292,19 @@
         this._allResults = [];
         this._hasMore = false;
         this._sourceCursors = {};
+        // Invalidate anything still in flight - its response, if any,
+        // resolves against a request ID nothing compares equal to anymore.
+        this._resultsRequestId++;
+        this._genSearchRequestId++;
+        this._pendingResultsQuery = null;
+        this._pendingGenSearchQuery = null;
+        if (this._revealTimer) {
+            clearTimeout(this._revealTimer);
+            this._revealTimer = null;
+        }
+        if (this._elements.sources) {
+            this._elements.sources.style.visibility = "";
+        }
         if (this._elements.results) {
             this._elements.results.innerHTML = "";
         }
@@ -277,14 +348,26 @@
     ContentAISearch.prototype._runResultsSearch = function(query) {
         var self = this;
         var searchStart = Date.now();
+        // Shared with _runLoadMore - a fresh search and a load-more append
+        // both write to _allResults/_hasMore/_sourceCursors, so whichever of
+        // the two is issued more recently needs to invalidate the other one's
+        // still-in-flight response, not just responses to a different query.
+        var requestId = ++this._resultsRequestId;
+        this._pendingResultsQuery = query;
         this._setFieldLoading(true);
         var url = this._resourcePath + ".search.json?q=" + encodeURIComponent(query);
         this._fetchJson(url)
             .then(function(data) {
+                if (requestId !== self._resultsRequestId) {
+                    return;
+                }
                 self._storeResults(data);
                 self._renderResults();
             })
             .catch(function() {
+                if (requestId !== self._resultsRequestId) {
+                    return;
+                }
                 self._allResults = [];
                 self._hasMore = false;
                 self._sourceCursors = {};
@@ -295,6 +378,10 @@
                 toggleShow(self._elements.loadMore, false);
             })
             .then(function() {
+                if (requestId !== self._resultsRequestId) {
+                    return;
+                }
+                self._pendingResultsQuery = null;
                 var elapsed = Date.now() - searchStart;
                 var delay = Math.max(0, LOADING_DISPLAY_DELAY - elapsed);
                 setTimeout(function() {
@@ -334,17 +421,34 @@
             return;
         }
         var self = this;
+        var query = this._currentQuery;
+        // Shares _resultsRequestId with _runResultsSearch - if a fresh
+        // search is issued while this append is still in flight (or vice
+        // versa), whichever fired later wins and the other's response is
+        // ignored, instead of racing to write _allResults/_sourceCursors.
+        var requestId = ++this._resultsRequestId;
         if (this._elements.loadMore) {
             this._elements.loadMore.disabled = true;
         }
-        var url = this._resourcePath + ".search.json?q=" + encodeURIComponent(this._currentQuery) +
+        var url = this._resourcePath + ".search.json?q=" + encodeURIComponent(query) +
             "&cursors=" + encodeURIComponent(JSON.stringify(this._sourceCursors));
         this._fetchJson(url)
             .then(function(data) {
+                if (requestId !== self._resultsRequestId) {
+                    return;
+                }
                 self._storeResults(data, true);
                 self._renderResults();
             })
+            .catch(function() {
+                // A failed page fetch shouldn't leave "Load More" stuck
+                // disabled forever - keep the results that are already
+                // shown and let the user try again.
+            })
             .then(function() {
+                if (requestId !== self._resultsRequestId) {
+                    return;
+                }
                 if (self._elements.loadMore) {
                     self._elements.loadMore.disabled = false;
                 }
@@ -354,6 +458,8 @@
     ContentAISearch.prototype._runGenSearch = function(query) {
         var self = this;
         var genSearchStart = Date.now();
+        var requestId = ++this._genSearchRequestId;
+        this._pendingGenSearchQuery = query;
         toggleShow(this._elements.error, false);
         toggleShow(this._elements.summary, false);
         this._setSummaryLoading(true);
@@ -362,12 +468,26 @@
         }
         this._fetchJson(this._resourcePath + ".gensearch.json?q=" + encodeURIComponent(query))
             .then(function(data) {
+                if (requestId !== self._genSearchRequestId) {
+                    return;
+                }
                 self._hideSummaryLoading(genSearchStart, function() {
-                    self._renderSummary(data);
+                    if (requestId !== self._genSearchRequestId) {
+                        return;
+                    }
+                    self._pendingGenSearchQuery = null;
+                    self._renderSummary(data, requestId);
                 });
             })
             .catch(function() {
+                if (requestId !== self._genSearchRequestId) {
+                    return;
+                }
                 self._hideSummaryLoading(genSearchStart, function() {
+                    if (requestId !== self._genSearchRequestId) {
+                        return;
+                    }
+                    self._pendingGenSearchQuery = null;
                     self._handleGenSearchError();
                 });
             });
@@ -404,6 +524,16 @@
         return (item && item.data && item.data.metadata) || {};
     };
 
+    // Content AI's own acquisition indexing convention stores the crawled page's
+    // address as "source" (metadata.source, duplicated at data.source) - "url" is
+    // only ever present for content sources that map a differently-named field.
+    // Every resolver below checks metadata.url first for that case, then falls
+    // back to the acquisition convention.
+    function resolveMetadataUrl(metadata, fallbackUrl) {
+        var m = metadata || {};
+        return m.url || m.source || fallbackUrl || "";
+    }
+
     ContentAISearch.prototype._resolveItemLabel = function(item) {
         if (!item) {
             return "";
@@ -428,8 +558,9 @@
                 return headingMatch[1].trim();
             }
         }
-        if (metadata.url) {
-            return this._labelFromUrl(metadata.url);
+        var url = resolveMetadataUrl(metadata, data.source);
+        if (url) {
+            return this._labelFromUrl(url);
         }
         return item.id || "";
     };
@@ -466,18 +597,33 @@
         if (metadata.title) {
             return metadata.title;
         }
-        if (metadata.url) {
-            return this._labelFromUrl(metadata.url);
+        var url = resolveMetadataUrl(metadata, hit.source);
+        if (url) {
+            return this._labelFromUrl(url);
         }
         return hit.id || "";
     };
 
+    // Only ever used as a last-resort fallback, once metadata.title/data.title/
+    // data.name have all already come up empty - so there's no risk of this
+    // clobbering an authored title, just turning a bare URL into something
+    // readable: strip a trailing page extension, turn dashes/underscores into
+    // spaces, and title-case the result (e.g. "ski-touring-mont-blanc.html"
+    // becomes "Ski Touring Mont Blanc" instead of "ski touring mont blanc.html").
     ContentAISearch.prototype._labelFromUrl = function(url) {
         try {
             var parsed = new URL(url, window.location.origin);
             var segments = parsed.pathname.split("/").filter(Boolean);
             if (segments.length) {
-                return decodeURIComponent(segments[segments.length - 1]).replace(/[-_]/g, " ");
+                var slug = decodeURIComponent(segments[segments.length - 1])
+                    .replace(/\.(html?|php|aspx?)$/i, "")
+                    .replace(/[-_]+/g, " ")
+                    .trim();
+                if (slug) {
+                    return slug.replace(/\S+/g, function(word) {
+                        return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+                    });
+                }
             }
         } catch (e) {
             // fall through
@@ -487,7 +633,7 @@
 
     ContentAISearch.prototype._populateItemNode = function(root, item) {
         var metadata = this._getItemMetadata(item);
-        var url = metadata.url;
+        var url = resolveMetadataUrl(metadata, item && item.data && item.data.source);
         var title = this._resolveItemLabel(item);
         var description = this._resolveItemDescription(item);
         var image = this._resolveItemImage(item);
@@ -560,7 +706,7 @@
             return html;
         }
         hits.forEach(function(hit) {
-            var url = hit.metadata && hit.metadata.url;
+            var url = resolveMetadataUrl(hit.metadata, hit.source);
             var label = self._resolveHitLabel(hit);
             var el = document.createElement("div");
             el.innerHTML = self._elements.sourceTemplate.innerHTML;
@@ -590,16 +736,132 @@
         }
 
         this._elements.results.innerHTML = this._generateResultItems(this._allResults);
+        // The whole list is replaced in one synchronous write, so there's no
+        // display:none/block toggle for a CSS *animation* to key off of the
+        // way the summary card's show/hide has - remove-then-re-add the
+        // class instead (with a forced reflow in between) so the animation
+        // restarts on every render, including a Load More append.
+        this._elements.results.classList.remove("cmp-contentaisearch__results--refresh");
+        void this._elements.results.offsetWidth;
+        this._elements.results.classList.add("cmp-contentaisearch__results--refresh");
 
         toggleShow(this._elements.resultsSection, true);
         toggleShow(this._elements.loadMore, this._hasMore);
     };
 
-    ContentAISearch.prototype._renderSummary = function(data) {
-        this._elements.summaryText.textContent = data.result || "";
+    // Reveals the answer word by word rather than painting it in one go. The
+    // full answer is already in hand (this runs once the blocking gensearch
+    // response has arrived) - a genuine reduction in time-to-first-word
+    // would need the API's SSE streaming endpoint relayed through a servlet
+    // fan-out across every configured content source, a larger change; this
+    // is the interim, purely cosmetic improvement. Every tick re-renders
+    // through _renderMarkdownSummary (never a raw, unstyled Text node), so
+    // paragraph/list spacing is already in place from the first word instead
+    // of appearing all at once on the last one.
+    //
+    // A newer query starting its own _renderSummary call cancels this one's
+    // timer (below), but that alone isn't enough: a still-ticking reveal for
+    // an older query can otherwise run to completion - and sit there fully
+    // rendered - before a slower-arriving newer response replaces it, the
+    // same stale-response race _runResultsSearch/_runGenSearch already guard
+    // against at the network level. Each tick re-checks requestId against
+    // _genSearchRequestId (not query text - two requests for the identical
+    // query, e.g. a double Enter, are otherwise indistinguishable) so a
+    // reveal superseded by a newer request stops silently instead of
+    // finishing or restarting.
+    ContentAISearch.prototype._renderSummary = function(data, requestId) {
+        var self = this;
+        var fullText = data.result || "";
         var hits = data.hits || [];
-        this._elements.sources.innerHTML = this._generateSourceItems(hits);
+        var tokens = fullText.split(/(\s+)/);
+        var idx = 0;
+
+        if (this._revealTimer) {
+            clearTimeout(this._revealTimer);
+            this._revealTimer = null;
+        }
+
+        if (this._elements.sources) {
+            // Sources are generated up front (same as the summary text
+            // itself) but held back until the reveal finishes, rather than
+            // showing them - momentarily out of sync - before the answer
+            // they support has even finished appearing.
+            this._elements.sources.innerHTML = this._generateSourceItems(hits);
+            this._elements.sources.style.visibility = "hidden";
+        }
         toggleShow(this._elements.summary, true);
+
+        function tick() {
+            if (requestId !== self._genSearchRequestId) {
+                self._revealTimer = null;
+                return;
+            }
+            idx++;
+            self._elements.summaryText.innerHTML = self._renderMarkdownSummary(tokens.slice(0, idx).join(""));
+            if (idx < tokens.length) {
+                self._revealTimer = setTimeout(tick, REVEAL_WORD_INTERVAL_MS);
+            } else {
+                self._revealTimer = null;
+                if (self._elements.sources) {
+                    self._elements.sources.style.visibility = "";
+                }
+            }
+        }
+
+        tick();
+    };
+
+    function escapeHtml(str) {
+        return String(str)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
+    }
+
+    // Content AI returns the generative answer as Markdown (bold, links, bullet lists).
+    // Renders a minimal, safe subset of it: text is HTML-escaped first, then only
+    // **bold**, [text](url) links (http/https only, re-validated via _isSafeUrl),
+    // and "- " bullet lists are turned into markup; anything else stays plain text.
+    ContentAISearch.prototype._renderMarkdownInline = function(text) {
+        var self = this;
+        var html = escapeHtml(text);
+        html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+        html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, function(match, label, url) {
+            return self._isSafeUrl(url) ? '<a href="' + url + '">' + label + "</a>" : label;
+        });
+        return html;
+    };
+
+    ContentAISearch.prototype._renderMarkdownSummary = function(text) {
+        var lines = String(text || "").split(/\r?\n/);
+        var html = "";
+        var listOpen = false;
+        var i;
+        var trimmed;
+        for (i = 0; i < lines.length; i++) {
+            trimmed = lines[i].replace(/^\s+/, "");
+            if (/^[-*]\s+/.test(trimmed)) {
+                if (!listOpen) {
+                    html += "<ul>";
+                    listOpen = true;
+                }
+                html += "<li>" + this._renderMarkdownInline(trimmed.replace(/^[-*]\s+/, "")) + "</li>";
+            } else {
+                if (listOpen) {
+                    html += "</ul>";
+                    listOpen = false;
+                }
+                if (trimmed.length > 0) {
+                    html += "<p>" + this._renderMarkdownInline(trimmed) + "</p>";
+                }
+            }
+        }
+        if (listOpen) {
+            html += "</ul>";
+        }
+        return html;
     };
 
     function stripAsciiControlsAndWhitespaceForSchemeCheck(str) {

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/clientlibs/site/js/contentaisearch.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/clientlibs/site/js/contentaisearch.js
@@ -414,9 +414,8 @@
                 // Keep existing results shown; don't leave Load More disabled forever.
             })
             .then(function() {
-                if (requestId !== self._resultsRequestId) {
-                    return;
-                }
+                // Always re-enable, even if a newer request superseded this one - otherwise
+                // a fresh search that re-shows Load More would leave it stuck disabled.
                 if (self._elements.loadMore) {
                     self._elements.loadMore.disabled = false;
                 }

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/clientlibs/site/js/contentaisearch.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v1/contentaisearch/clientlibs/site/js/contentaisearch.js
@@ -61,12 +61,8 @@
         this._allResults = [];
         this._hasMore = false;
         this._sourceCursors = {};
-        // Monotonic per-endpoint request counters, plus which query (if any)
-        // is currently in flight for that endpoint. Replaces comparing
-        // against _currentQuery alone: two requests for the identical query
-        // text (e.g. pressing Enter twice) are otherwise indistinguishable
-        // from each other by a string comparison, so neither looks "stale"
-        // to the other no matter which one resolves last.
+        // Monotonic request IDs, since comparing query text alone can't tell
+        // apart two requests for the identical query (e.g. double Enter).
         this._resultsRequestId = 0;
         this._genSearchRequestId = 0;
         this._pendingResultsQuery = null;
@@ -179,15 +175,9 @@
         this._renderResults();
     };
 
-    // Search runs only on an explicit trigger - form submit (Enter, or a
-    // mobile keyboard's "Go"/"Search" action, both of which fire the form's
-    // submit event same as a real submit button would) or the AI-answer
-    // toggle changing - never on typing itself. A debounced search-as-you-
-    // type fires a fresh, often-incomplete query on every brief pause,
-    // which both re-renders the results/summary repeatedly while the user
-    // is still typing (a visible flicker) and shows the loading indicators
-    // for every one of those in-between queries, giving the impression a
-    // search is running when the user hasn't asked for one yet.
+    // Search runs only on explicit submit (Enter/toggle change), never on
+    // typing itself - avoids the flicker/loading-spinner noise of firing a
+    // fresh, incomplete query on every debounced keystroke pause.
     ContentAISearch.prototype._onInput = function() {
         this._syncClearButton();
     };
@@ -212,17 +202,13 @@
         this._clearResults();
     };
 
-    // Only ever touches the gensearch/summary state - toggling the
-    // AI-answer switch has nothing to do with the plain results list, so
-    // unlike the old behavior (which always re-ran _runQuery, re-firing a
-    // full .search.json call along with it) this no longer re-fetches
-    // results that haven't changed.
+    // Only touches gensearch/summary state - the results list doesn't
+    // depend on this toggle and shouldn't re-fetch when it changes.
     ContentAISearch.prototype._onToggleChange = function() {
         this._genSearchEnabled = this._elements.toggle.checked;
         if (!this._genSearchEnabled) {
-            // Invalidate any gensearch request still in flight so a
-            // late-arriving answer can't reopen the summary the user just
-            // explicitly turned off.
+            // Invalidate any in-flight gensearch request so a late answer
+            // can't reopen the summary the user just turned off.
             this._genSearchRequestId++;
             this._pendingGenSearchQuery = null;
             if (this._revealTimer) {
@@ -236,9 +222,7 @@
         }
         var query = this._elements.input.value;
         if (!query || query !== this._currentQuery) {
-            // Nothing has been submitted yet, or the field has unsubmitted
-            // edits - wait for an explicit submit rather than searching just
-            // because the toggle moved.
+            // No submitted query, or unsubmitted edits - wait for a real submit.
             return;
         }
         if (this._pendingGenSearchQuery === query) {
@@ -254,9 +238,7 @@
     ContentAISearch.prototype._onRetry = function() {
         var query = this._elements.input.value;
         if (this._pendingGenSearchQuery === query) {
-            // Already retrying this exact query - ignore a repeated click
-            // instead of firing a second, redundant request.
-            return;
+            return; // already retrying this exact query
         }
         this._runGenSearch(query);
     };
@@ -270,12 +252,7 @@
         }
         if (query === this._currentQuery &&
             (this._pendingResultsQuery === query || this._pendingGenSearchQuery === query)) {
-            // The identical query is already in flight (e.g. Enter pressed
-            // twice, or mashed while waiting) - ignore the duplicate submit
-            // rather than firing a second round-trip. The in-flight request
-            // still resolves normally; submitting again once it's done
-            // fires a fresh one as usual.
-            return;
+            return; // identical query already in flight (e.g. double Enter)
         }
         this._currentQuery = query;
         this._runResultsSearch(query);
@@ -292,8 +269,7 @@
         this._allResults = [];
         this._hasMore = false;
         this._sourceCursors = {};
-        // Invalidate anything still in flight - its response, if any,
-        // resolves against a request ID nothing compares equal to anymore.
+        // Bump request IDs so anything still in flight resolves as stale.
         this._resultsRequestId++;
         this._genSearchRequestId++;
         this._pendingResultsQuery = null;
@@ -348,10 +324,8 @@
     ContentAISearch.prototype._runResultsSearch = function(query) {
         var self = this;
         var searchStart = Date.now();
-        // Shared with _runLoadMore - a fresh search and a load-more append
-        // both write to _allResults/_hasMore/_sourceCursors, so whichever of
-        // the two is issued more recently needs to invalidate the other one's
-        // still-in-flight response, not just responses to a different query.
+        // Shared counter with _runLoadMore - both write _allResults, so
+        // whichever fires later must invalidate the other's response.
         var requestId = ++this._resultsRequestId;
         this._pendingResultsQuery = query;
         this._setFieldLoading(true);
@@ -422,10 +396,6 @@
         }
         var self = this;
         var query = this._currentQuery;
-        // Shares _resultsRequestId with _runResultsSearch - if a fresh
-        // search is issued while this append is still in flight (or vice
-        // versa), whichever fired later wins and the other's response is
-        // ignored, instead of racing to write _allResults/_sourceCursors.
         var requestId = ++this._resultsRequestId;
         if (this._elements.loadMore) {
             this._elements.loadMore.disabled = true;
@@ -441,9 +411,7 @@
                 self._renderResults();
             })
             .catch(function() {
-                // A failed page fetch shouldn't leave "Load More" stuck
-                // disabled forever - keep the results that are already
-                // shown and let the user try again.
+                // Keep existing results shown; don't leave Load More disabled forever.
             })
             .then(function() {
                 if (requestId !== self._resultsRequestId) {
@@ -524,11 +492,8 @@
         return (item && item.data && item.data.metadata) || {};
     };
 
-    // Content AI's own acquisition indexing convention stores the crawled page's
-    // address as "source" (metadata.source, duplicated at data.source) - "url" is
-    // only ever present for content sources that map a differently-named field.
-    // Every resolver below checks metadata.url first for that case, then falls
-    // back to the acquisition convention.
+    // Content AI's acquisition indexing stores the crawled page address as
+    // "source" (metadata.source/data.source), not "url" - fall back to it.
     function resolveMetadataUrl(metadata, fallbackUrl) {
         var m = metadata || {};
         return m.url || m.source || fallbackUrl || "";
@@ -604,12 +569,8 @@
         return hit.id || "";
     };
 
-    // Only ever used as a last-resort fallback, once metadata.title/data.title/
-    // data.name have all already come up empty - so there's no risk of this
-    // clobbering an authored title, just turning a bare URL into something
-    // readable: strip a trailing page extension, turn dashes/underscores into
-    // spaces, and title-case the result (e.g. "ski-touring-mont-blanc.html"
-    // becomes "Ski Touring Mont Blanc" instead of "ski touring mont blanc.html").
+    // Last-resort fallback once title/name are empty: turns a bare URL into
+    // something readable (e.g. "ski-touring-mont-blanc.html" -> "Ski Touring Mont Blanc").
     ContentAISearch.prototype._labelFromUrl = function(url) {
         try {
             var parsed = new URL(url, window.location.origin);
@@ -736,11 +697,8 @@
         }
 
         this._elements.results.innerHTML = this._generateResultItems(this._allResults);
-        // The whole list is replaced in one synchronous write, so there's no
-        // display:none/block toggle for a CSS *animation* to key off of the
-        // way the summary card's show/hide has - remove-then-re-add the
-        // class instead (with a forced reflow in between) so the animation
-        // restarts on every render, including a Load More append.
+        // Force a reflow so re-adding the class restarts the fade-in animation
+        // on every render (the list has no display toggle to key an animation off of).
         this._elements.results.classList.remove("cmp-contentaisearch__results--refresh");
         void this._elements.results.offsetWidth;
         this._elements.results.classList.add("cmp-contentaisearch__results--refresh");
@@ -749,26 +707,10 @@
         toggleShow(this._elements.loadMore, this._hasMore);
     };
 
-    // Reveals the answer word by word rather than painting it in one go. The
-    // full answer is already in hand (this runs once the blocking gensearch
-    // response has arrived) - a genuine reduction in time-to-first-word
-    // would need the API's SSE streaming endpoint relayed through a servlet
-    // fan-out across every configured content source, a larger change; this
-    // is the interim, purely cosmetic improvement. Every tick re-renders
-    // through _renderMarkdownSummary (never a raw, unstyled Text node), so
-    // paragraph/list spacing is already in place from the first word instead
-    // of appearing all at once on the last one.
-    //
-    // A newer query starting its own _renderSummary call cancels this one's
-    // timer (below), but that alone isn't enough: a still-ticking reveal for
-    // an older query can otherwise run to completion - and sit there fully
-    // rendered - before a slower-arriving newer response replaces it, the
-    // same stale-response race _runResultsSearch/_runGenSearch already guard
-    // against at the network level. Each tick re-checks requestId against
-    // _genSearchRequestId (not query text - two requests for the identical
-    // query, e.g. a double Enter, are otherwise indistinguishable) so a
-    // reveal superseded by a newer request stops silently instead of
-    // finishing or restarting.
+    // Reveals the already-fetched answer word by word (cosmetic only - a real
+    // streaming reduction in time-to-first-word would need the API's SSE
+    // endpoint). Each tick re-checks requestId against _genSearchRequestId so
+    // a reveal superseded by a newer query stops instead of finishing/restarting.
     ContentAISearch.prototype._renderSummary = function(data, requestId) {
         var self = this;
         var fullText = data.result || "";
@@ -782,10 +724,7 @@
         }
 
         if (this._elements.sources) {
-            // Sources are generated up front (same as the summary text
-            // itself) but held back until the reveal finishes, rather than
-            // showing them - momentarily out of sync - before the answer
-            // they support has even finished appearing.
+            // Held back until the reveal finishes, so sources don't show before the answer they support.
             this._elements.sources.innerHTML = this._generateSourceItems(hits);
             this._elements.sources.style.visibility = "hidden";
         }
@@ -820,10 +759,9 @@
             .replace(/'/g, "&#39;");
     }
 
-    // Content AI returns the generative answer as Markdown (bold, links, bullet lists).
-    // Renders a minimal, safe subset of it: text is HTML-escaped first, then only
-    // **bold**, [text](url) links (http/https only, re-validated via _isSafeUrl),
-    // and "- " bullet lists are turned into markup; anything else stays plain text.
+    // Renders a minimal, safe subset of the generative answer's Markdown: text
+    // is HTML-escaped first, then only **bold** and http(s) [text](url) links
+    // (validated via _isSafeUrl) are turned into markup.
     ContentAISearch.prototype._renderMarkdownInline = function(text) {
         var self = this;
         var html = escapeHtml(text);


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Related to GRANITE-70028
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Existing tests updated where applicable
| Documentation Provided   | Code comments where non-obvious; component README updated
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

## Summary

Split out from #3067 for easier review - this PR covers only the ContentAI Supported Search (`contentaisearch`) component changes. Quick Search v3 changes are in a separate PR.

- **Removed search-as-you-type debounce; search now only fires on explicit submit** (Enter / mobile "Go", or the AI-answer toggle changing) - previously a fresh, often-incomplete query fired on every ~300ms typing pause, causing visible flicker and repeated network calls.
- **Fixed a stale-response race** across results search, gensearch, and load-more - a slower, older response arriving after a newer one could overwrite it with stale data.
- **Clear button now invalidates in-flight requests** instead of letting a late response silently repopulate results after the user cleared the field.
- **Fixed result/source links** - falls back to `metadata.source`/`data.source` when `metadata.url` is absent, matching Content AI's acquisition-indexing convention.
- **Render the AI-generated summary's Markdown** (bold, links, bullet lists) instead of showing raw `**`/`[text](url)` syntax as literal text, with a word-by-word reveal.
- **Results now respect the configured `resultsSize`** as a true cap on the final merged results across all configured content sources (previously could return up to N × resultsSize for N sources) - also fixed `totalResults` to sum across sources instead of taking the max.
- **Deduped in-flight requests, fixed a Load More error state, and reuse a single HTTP client** instead of creating one per request.
- Made `modelFactory` `protected` for correct OSGi field injection; documented the Content AI API key OSGi configuration.
- **Decoupled `ContentAISupportedSearch`'s default content source type from `ContentAIClient`** - moved `DEFAULT_CONTENT_SOURCE_TYPE` onto the `ContentAISupportedSearch` model interface itself, so the component's model layer no longer depends on a service-layer class it otherwise has no relationship to (`ContentAIClient` keeps its own copy for its own independent default overloads). Bumped the `models` package's minor version accordingly, per the OSGi bnd-baseline check.