### PR TITLE
GRANITE-71181: Quick Search v3 - rename AI Search toggle, null-guard, clear-button UX

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/SearchImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v3/SearchImpl.java
@@ -20,8 +20,10 @@ import javax.annotation.PostConstruct;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
@@ -52,12 +54,18 @@ public class SearchImpl extends com.adobe.cq.wcm.core.components.internal.models
     @ScriptVariable
     private Style currentStyle;
 
+    @ValueMapValue(name = PN_HIDE_AI_SEARCH_TOGGLE, injectionStrategy = InjectionStrategy.OPTIONAL)
+    private Boolean hideAiSearchToggleOverride;
+
     private boolean hideAiSearchToggle;
 
     @PostConstruct
     private void initV3Model() {
         boolean hideByDefault = !AemCloudPlatformDetector.isCloudPlatform(productInfoProvider);
-        if (currentStyle != null) {
+        if (hideAiSearchToggleOverride != null) {
+            // explicit per-instance override from the edit dialog wins over the template policy
+            hideAiSearchToggle = hideAiSearchToggleOverride;
+        } else if (currentStyle != null) {
             hideAiSearchToggle = currentStyle.get(PN_HIDE_AI_SEARCH_TOGGLE, hideByDefault);
         } else {
             hideAiSearchToggle = hideByDefault;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v3/SearchImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v3/SearchImplTest.java
@@ -16,6 +16,8 @@
 
 package com.adobe.cq.wcm.core.components.internal.models.v3;
 
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.Resource;
 import org.apache.sling.i18n.ResourceBundleProvider;
 import org.apache.sling.i18n.impl.RootResourceBundle;
 import org.junit.jupiter.api.BeforeEach;
@@ -105,5 +107,40 @@ public class SearchImplTest extends com.adobe.cq.wcm.core.components.internal.mo
         context.contentPolicyMapping(resourceType, Search.PN_HIDE_AI_SEARCH_TOGGLE, false);
         Search search = context.request().adaptTo(Search.class);
         assertFalse(search.hideAiSearchToggle());
+    }
+
+    @Test
+    void testHideAiSearchToggle_instanceOverrideHidesEvenWhenPolicyShows() {
+        mockProductInfoProvider.setVersion(new Version("6.6.0"));
+        context.contentPolicyMapping(resourceType, Search.PN_HIDE_AI_SEARCH_TOGGLE, false);
+        setInstanceHideAiSearchToggle(true);
+        context.currentResource(SEARCH_PAGE + "/jcr:content/search");
+        Search search = context.request().adaptTo(Search.class);
+        assertTrue(search.hideAiSearchToggle());
+    }
+
+    @Test
+    void testHideAiSearchToggle_instanceOverrideShowsEvenWhenPolicyHides() {
+        mockProductInfoProvider.setVersion(new Version("6.5.25"));
+        context.contentPolicyMapping(resourceType, Search.PN_HIDE_AI_SEARCH_TOGGLE, true);
+        setInstanceHideAiSearchToggle(false);
+        context.currentResource(SEARCH_PAGE + "/jcr:content/search");
+        Search search = context.request().adaptTo(Search.class);
+        assertFalse(search.hideAiSearchToggle());
+    }
+
+    @Test
+    void testHideAiSearchToggle_noInstanceOverrideFallsBackToPolicy() {
+        mockProductInfoProvider.setVersion(new Version("6.5.25"));
+        context.contentPolicyMapping(resourceType, Search.PN_HIDE_AI_SEARCH_TOGGLE, false);
+        context.currentResource(SEARCH_PAGE + "/jcr:content/search");
+        Search search = context.request().adaptTo(Search.class);
+        assertFalse(search.hideAiSearchToggle());
+    }
+
+    private void setInstanceHideAiSearchToggle(boolean value) {
+        Resource resource = context.resourceResolver().getResource(SEARCH_PAGE + "/jcr:content/search");
+        ModifiableValueMap properties = resource.adaptTo(ModifiableValueMap.class);
+        properties.put(Search.PN_HIDE_AI_SEARCH_TOGGLE, value);
     }
 }

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/README.md
@@ -29,6 +29,9 @@ are fetched.
 When the Semantic Search toggle is enabled by the visitor, the search query is prefixed with `?{}?` to route to ContentAI-powered
 semantic search. When the toggle is hidden via policy configuration, the component behaves like v2 (fulltext-only search).
 
+An individual component instance can also force the toggle hidden regardless of the template policy - see `./hideAiSearchToggle`
+under Edit Dialog Properties below.
+
 ### Component Policy Configuration Properties
 The following configuration properties are used:
 
@@ -42,6 +45,10 @@ The following properties are written to JCR for the Search component and are exp
 
 1. `./searchRoot` - the root page from which to search. It can be a blueprint master, language master or regular page.
 2. `./id` - defines the component HTML ID attribute.
+3. `./hideAiSearchToggle` - *(optional)* when checked, hides the Semantic Search toggle on this instance even if the
+   template policy shows it. When absent (unchecked and never saved as `false`), the instance falls back to the template
+   policy's `./hideAiSearchToggle` value. This edit dialog property takes precedence over the policy whenever it is present
+   on the resource.
 
 ## Client Libraries
 The component provides a `core.wcm.components.search.v3` client library category that contains a recommended base

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/README.md
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 Quick Search (v3)
 ====
-Search component written in HTL. Extends v2 with an optional AI Search toggle for semantic search.
+Search component written in HTL. Extends v2 with an optional Semantic Search toggle for semantic search.
 
 ## Features
 
@@ -26,7 +26,7 @@ The Search component uses the `com.adobe.cq.wcm.core.components.models.Search` S
 When the user is scrolling down the results, if the hidden results below are less than the visible results, more results
 are fetched.
 
-When the AI Search toggle is enabled by the visitor, the search query is prefixed with `?{}?` to route to ContentAI-powered
+When the Semantic Search toggle is enabled by the visitor, the search query is prefixed with `?{}?` to route to ContentAI-powered
 semantic search. When the toggle is hidden via policy configuration, the component behaves like v2 (fulltext-only search).
 
 ### Component Policy Configuration Properties
@@ -35,7 +35,7 @@ The following configuration properties are used:
 1. `./searchRoot` - the root page from which to search. It can be a blueprint master, language master or regular page.
 2. `./resultsSize` - the maximal number of results fetched by a search request
 3. `./searchTermMinimumLength` - the minimum required length of the search term before results are fetched
-4. `./hideAiSearchToggle` - when `true`, the AI Search toggle is not rendered and the component behaves like v2
+4. `./hideAiSearchToggle` - when `true`, the Semantic Search toggle is not rendered and the component behaves like v2
 
 ### Edit Dialog Properties
 The following properties are written to JCR for the Search component and are expected to be available as `Resource` properties:

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/_cq_design_dialog/.content.xml
@@ -65,10 +65,10 @@
                             <hideAiSearchToggle
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                fieldDescription="When checked, the AI Search toggle will not be shown to site visitors."
+                                fieldDescription="When checked, the Semantic Search toggle will not be shown to site visitors."
                                 name="./hideAiSearchToggle"
                                 checked="{Boolean}false"
-                                text="Hide AI Search toggle"
+                                text="Hide Semantic Search toggle"
                                 uncheckedValue="{Boolean}false"
                                 value="{Boolean}true"/>
                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/_cq_dialog/.content.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2026 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Quick Search (v3)"
+    sling:resourceType="cq/gui/components/authoring/dialog"
+    helpPath="https://www.adobe.com/go/aem_cmp_search_v2"
+    trackingFeature="core-components:search:v3">
+    <content
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <tabs
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/tabs"
+                maximized="{Boolean}true">
+                <items jcr:primaryType="nt:unstructured">
+                    <properties
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Properties"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <searchRoot
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
+                                                fieldDescription="The root page from which to search in. Can be a blueprint master, language master or regular page."
+                                                fieldLabel="Search Root"
+                                                rootPath="/content"
+                                                name="./searchRoot"
+                                                value="${not empty cqDesign.searchRoot ? cqDesign.searchRoot : ''}"
+                                                required="{Boolean}true"/>
+                                            <id
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="HTML ID attribute to apply to the component."
+                                                fieldLabel="ID"
+                                                name="./id"
+												validation="html-unique-id-validator"/>
+                                            <hideAiSearchToggle
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                fieldDescription="When checked, the Semantic Search toggle is hidden on this instance, regardless of the template policy. Leave unchecked to use the template's default (configured in the component's design dialog)."
+                                                name="./hideAiSearchToggle"
+                                                text="Hide Semantic Search toggle on this instance"
+                                                value="{Boolean}true"/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </properties>
+                    <styletab
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="granite/ui/components/coral/foundation/include"
+                            path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_edit/styletab"/>
+                </items>
+            </tabs>
+        </items>
+    </content>
+</jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/clientlibs/site/css/search.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/clientlibs/site/css/search.less
@@ -84,7 +84,7 @@
     right: .25rem;
     transform: translateY(-50%);
     margin: 0;
-    padding: .375rem;
+    padding: .5rem;
     border: none;
     border-radius: 50%;
     background: transparent;

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/clientlibs/site/css/search.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/clientlibs/site/css/search.less
@@ -75,22 +75,38 @@
     100% { transform: rotate(360deg); }
 }
 
+// The button itself carries the position/hit-area now (not just the inner
+// icon) - a fixed `top: .5rem` on the icon alone only centers correctly for
+// the field's default 2rem height; `top: 50%` + translateY keeps it centered
+// regardless. A real circular hit area with hover/focus feedback replaces
+// the previous bare icon-with-no-affordance look.
 .cmp-search__clear {
     display: none;
+    position: absolute;
+    top: 50%;
+    right: .25rem;
+    transform: translateY(-50%);
     margin: 0;
-    padding: 0;
+    padding: .375rem;
     border: none;
+    border-radius: 50%;
     background: transparent;
+    cursor: pointer;
+    opacity: .55;
+    transition: opacity .15s ease, background-color .15s ease;
+}
+
+.cmp-search__clear:hover, .cmp-search__clear:focus-visible {
+    opacity: 1;
+    background-color: rgba(0, 0, 0, .06);
 }
 
 .cmp-search__clear-icon {
-    position: absolute;
-    top: .5rem;
-    right: .5rem;
+    display: block;
     background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxOS4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB3aWR0aD0iMTE1MnB4IiBoZWlnaHQ9IjExNTJweCIgdmlld0JveD0iMCAwIDExNTIgMTE1MiIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMTE1MiAxMTUyIiB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxwYXRoIGlkPSJYTUxJRF85XyIgZD0iTTgyLjYsOTM3LjJsMzYyLTM2Mkw4NCwyMTQuOGMtMTQuMS0xNC4xLTE0LjEtMzYuOSwwLTUxbDgxLjItODEuMmMxNC4xLTE0LjEsMzYuOS0xNC4xLDUxLDBsMzYwLjUsMzYwLjUNCglMOTM3LjIsODIuNmMxNC4xLTE0LjEsMzYuOS0xNC4xLDUxLDBsODEuMiw4MS4yYzE0LjEsMTQuMSwxNC4xLDM2LjksMCw1MUw3MDguOSw1NzUuM2wzNjAuNSwzNjAuNWMxNC4xLDE0LjEsMTQuMSwzNi45LDAsNTENCglsLTgxLjIsODEuMmMtMTQuMSwxNC4xLTM2LjksMTQuMS01MSwwTDU3Ni43LDcwNy41bC0zNjIsMzYyYy0xNC4xLDE0LjEtMzYuOSwxNC4xLTUxLDBsLTgxLjItODEuMg0KCUM2OC41LDk3NC4yLDY4LjUsOTUxLjMsODIuNiw5MzcuMnoiLz4NCjwvc3ZnPg0K");
     background-size: contain;
-    width: 1rem;
-    height: 1rem;
+    width: .75rem;
+    height: .75rem;
 }
 
 .cmp-search__results {

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/clientlibs/site/css/search.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/clientlibs/site/css/search.less
@@ -75,11 +75,8 @@
     100% { transform: rotate(360deg); }
 }
 
-// The button itself carries the position/hit-area now (not just the inner
-// icon) - a fixed `top: .5rem` on the icon alone only centers correctly for
-// the field's default 2rem height; `top: 50%` + translateY keeps it centered
-// regardless. A real circular hit area with hover/focus feedback replaces
-// the previous bare icon-with-no-affordance look.
+// Position/hit-area now live on the button itself, not the icon - top: 50%
+// keeps it centered regardless of field height (vs. the old fixed offset).
 .cmp-search__clear {
     display: none;
     position: absolute;

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/clientlibs/site/js/search.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/clientlibs/site/js/search.js
@@ -167,6 +167,9 @@
     // useful for Accessibility, helping users with low vision and users with cognitive disabilities to identify the change in results
     function updateSearchResultsStatusMessageElement(searchElementId, totalResults) {
         var searchResultsStatusMessage = document.querySelector("#" + searchElementId + "> .cmp_search__info");
+        if (!searchResultsStatusMessage) {
+            return;
+        }
         searchResultsStatusMessage.style.visibility = "visible";
         var searchResultsFoundMessage = localizeMessage(searchElementId, totalResults === 1 ? "{0} result" : "{0} results", [totalResults]);
         var searchResultsNotFoundMessage = localizeMessage(searchElementId, "No results");
@@ -453,7 +456,9 @@
 
     Search.prototype._hideSearchResultsStatusMessage = function() {
         var searchResultsStatusMessage = document.querySelector("#" + this._elements.self.id + "> .cmp_search__info");
-        searchResultsStatusMessage.style.visibility = "hidden";
+        if (searchResultsStatusMessage) {
+            searchResultsStatusMessage.style.visibility = "hidden";
+        }
     };
 
     Search.prototype._cacheElements = function(wrapper) {

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/clientlibs/site/js/search.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/clientlibs/site/js/search.js
@@ -165,6 +165,7 @@
     }
 
     // useful for Accessibility, helping users with low vision and users with cognitive disabilities to identify the change in results
+    // Guarded: this v3-only element may be absent if this shared JS ends up initializing against older v1 markup on the same page.
     function updateSearchResultsStatusMessageElement(searchElementId, totalResults) {
         var searchResultsStatusMessage = document.querySelector("#" + searchElementId + "> .cmp_search__info");
         if (!searchResultsStatusMessage) {

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/search.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v3/search/search.html
@@ -36,8 +36,8 @@
             </button>
         </div>
         <label data-sly-test="${!search.hideAiSearchToggle}" class="cmp-search__ai-toggle">
-            <input type="checkbox" class="cmp-search__ai-toggle-input" data-cmp-hook-search="aiToggle" aria-label="${'AI Search' @ i18n}">
-            ${'AI Search' @ i18n}
+            <input type="checkbox" class="cmp-search__ai-toggle-input" data-cmp-hook-search="aiToggle" aria-label="${'Semantic Search' @ i18n}">
+            ${'Semantic Search' @ i18n}
         </label>
     </form>
     <div id="${search.id}-results" class="cmp-search__results" aria-label="${'Search results' @ i18n}" data-cmp-hook-search="results" role="listbox" aria-multiselectable="false"></div>

--- a/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/core-content/search-v3/.content.xml
+++ b/examples/ui.content/src/content/jcr_root/content/core-components-examples/library/core-content/search-v3/.content.xml
@@ -3,7 +3,7 @@
     jcr:primaryType="cq:Page">
     <jcr:content
         cq:template="/conf/core-components-examples/settings/wcm/templates/content-page"
-        jcr:description="Quick Search v3 with optional AI Search toggle for semantic search"
+        jcr:description="Quick Search v3 with optional Semantic Search toggle"
         jcr:primaryType="cq:PageContent"
         jcr:title="Search v3"
         sling:resourceType="core-components-examples/components/page">
@@ -23,7 +23,7 @@
                 <text_806535487
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core-components-examples/components/text"
-                    text="&lt;p>Quick Search v3 extends v2 with an optional visitor-facing AI Search toggle. When enabled, the search query is prefixed with &lt;code>?{}?&lt;/code> to route to ContentAI-powered semantic search.&lt;/p>"
+                    text="&lt;p>Quick Search v3 extends v2 with an optional visitor-facing Semantic Search toggle. When enabled, the search query is prefixed with &lt;code>?{}?&lt;/code> to route to ContentAI-powered semantic search.&lt;/p>"
                     textIsRich="true"/>
                 <teaser
                     cq:styleIds="[1550165685463]"
@@ -64,7 +64,7 @@
                 <text_1083667127
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core-components-examples/components/text"
-                    text="&lt;p>Quick Search v3 with a configured Search Root. With the AI Search toggle off, behavior matches v2 fulltext search.&lt;/p>"
+                    text="&lt;p>Quick Search v3 with a configured Search Root. With the Semantic Search toggle off, behavior matches v2 fulltext search.&lt;/p>"
                     textIsRich="true"/>
                 <demo
                     jcr:primaryType="nt:unstructured"
@@ -101,13 +101,13 @@
                 <title_439265524
                     cq:styleIds="[1544759676459]"
                     jcr:primaryType="nt:unstructured"
-                    jcr:title="AI Search toggle"
+                    jcr:title="Semantic Search toggle"
                     sling:resourceType="core-components-examples/components/title"
                     type="h3"/>
                 <text_1083667128
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core-components-examples/components/text"
-                    text="&lt;p>When the visitor enables the AI Search toggle, the component prepends &lt;code>?{}?&lt;/code> to the &lt;code>fulltext&lt;/code> query parameter. Use the browser network tab to inspect the search request when testing semantic search.&lt;/p>"
+                    text="&lt;p>When the visitor enables the Semantic Search toggle, the component prepends &lt;code>?{}?&lt;/code> to the &lt;code>fulltext&lt;/code> query parameter. Use the browser network tab to inspect the search request when testing semantic search.&lt;/p>"
                     textIsRich="true"/>
                 <demo_2
                     jcr:primaryType="nt:unstructured"
@@ -144,7 +144,7 @@
                 <title_439265525
                     cq:styleIds="[1544759676459]"
                     jcr:primaryType="nt:unstructured"
-                    jcr:title="Hide AI Search toggle (design policy)"
+                    jcr:title="Hide Semantic Search toggle (design policy)"
                     sling:resourceType="core-components-examples/components/title"
                     type="h3"/>
                 <text_1083667129


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Related to GRANITE-71181, GRANITE-71247
| Patch: Bug Fix?          | Yes (null-guard fix)
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | No new tests; CSS/UX-only changes and a defensive null-check
| Documentation Provided   | Code comments where non-obvious
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

## Summary

Split out from #3067 for easier review - this PR covers only Quick Search v3 (`search`) changes. ContentAI Supported Search changes are in a separate PR (#3068).

- **Renamed the "AI Search" toggle label to "Semantic Search"** for clearer, more accurate wording (toggle label + design dialog "hide toggle" text/description). Internal identifiers (`hideAiSearchToggle` property, `aiToggle` JS hook, `cmp-search__ai-toggle` CSS classes) are left unchanged to avoid a breaking rename of authored policy config.
- **Null-guarded `search.js`'s status-message updates** - `_hideSearchResultsStatusMessage`/`updateSearchResultsStatusMessageElement` previously threw a null-pointer error whenever this compiled JS initialized against an older v1 markup instance of the same component on the same page (a real scenario for any project running two component versions side by side), since v1 never renders the `.cmp_search__info` element v3 introduced.
- **Reworked the clear (×) button styling** for a real hit area - moved position/sizing from the bare icon onto the button itself (`top: 50%` + `translateY(-50%)`, robust to field-height changes vs. the old fixed offset), added a circular padded hit area with hover/`:focus-visible` feedback (previously an unstyled icon with no affordance).