### PR TITLE
fix(deps): update jsoup to 1.23.1 to address GHSA-pmhh-3w7g-xqp8

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -406,7 +406,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.15.3</version>
+            <version>1.23.1</version>
         </dependency>
 
         <dependency>

--- a/bundles/core/src/test/resources/tableofcontents/exporter-duplicate-ids-content.html
+++ b/bundles/core/src/test/resources/tableofcontents/exporter-duplicate-ids-content.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8">
   <title>TOC Duplicate IDs Test</title>
  </head>
- <body><!-- TOCs -->
+ <body>
+  <!-- TOCs -->
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#bla">Bla</a>
@@ -18,7 +19,8 @@
        </ul></li>
      </ul></li>
    </ul>
-  </div> <!-- Page Content -->
+  </div>
+  <!-- Page Content -->
   <div>
    <h1 id="bla">Bla</h1>
    <h2 id="bla-1">Bla</h2>

--- a/bundles/core/src/test/resources/tableofcontents/exporter-include-ignore-content.html
+++ b/bundles/core/src/test/resources/tableofcontents/exporter-include-ignore-content.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8">
   <title>TOC Include Ignore Behavior Test</title>
  </head>
- <body><!-- TOCs -->
+ <body>
+  <!-- TOCs -->
   <div class="cmp-toc__content" id="sample-toc-id">
    <ol>
     <li><a href="#page-title">Page title</a>
@@ -80,7 +81,8 @@
       <li><a href="#sidebar-title">Sidebar title</a></li>
      </ol></li>
    </ol>
-  </div> <!-- Page Content -->
+  </div>
+  <!-- Page Content -->
   <h1 class="cmp-title" id="page-title">Page title</h1>
   <div class="main">
    <div class="cmp-title">

--- a/bundles/core/src/test/resources/tableofcontents/exporter-nesting-content.html
+++ b/bundles/core/src/test/resources/tableofcontents/exporter-nesting-content.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8">
   <title>TOC Nesting Behaviour Test</title>
  </head>
- <body><!-- TOCs -->
+ <body>
+  <!-- TOCs -->
   <div class="cmp-toc__content">
    <ul>
     <li><a href="#bla">Bla</a>
@@ -91,7 +92,8 @@
       <li><a href="#ble">Ble</a></li>
      </ul></li>
    </ul>
-  </div> <!-- Page Content -->
+  </div>
+  <!-- Page Content -->
   <div class="example-1">
    <h1 id="bla">Bla</h1>
    <h2 id="bli">Bli</h2>

--- a/bundles/core/src/test/resources/tableofcontents/exporter-no-heading-content.html
+++ b/bundles/core/src/test/resources/tableofcontents/exporter-no-heading-content.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8">
   <title>TOC No Heading Test</title>
  </head>
- <body><!-- TOCs -->
+ <body>
+  <!-- TOCs -->
   <div class="cmp-toc__content"></div>
   <p>Sample Text</p>
  </body>

--- a/bundles/core/src/test/resources/tableofcontents/exporter-template-placeholder-content.html
+++ b/bundles/core/src/test/resources/tableofcontents/exporter-template-placeholder-content.html
@@ -20,8 +20,7 @@
       </ul></li>
     </ul>
    </div>
-   <div>
-   </div>
+   <div></div>
   </div>
   <div>
    <div class="cmp-toc__content"></div>


### PR DESCRIPTION
Fixes an XSS vulnerability where jsoup's Cleaner could mis-sanitize malformed tag names in custom Safelists that permit raw-text elements. Updates the pretty-printed TOC filter test fixtures to match jsoup's newer HTML comment formatting; no functional change.


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes GHSA-pmhh-3w7g-xqp8`
| Patch: Bug Fix?          |
| Tests Added + Pass?      | Small change made to whitespace in some existing tests to match new jsoup output, shouldn't be significant blast radius
| Any Dependency Changes?  | updated jsoup to 1.23.1
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
This updates the jsoup dependency to 1.23.1 to fix GHSA-pmhh-3w7g-xqp8, a vulnerability in the upstream project. This version of jsoup appears to introduce some small whitespace changes to the way HTML is written back out, so the tests were adjusted accordingly.