### PR TITLE
Fix VCF template list empty due to base64 modelId padding

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/dialog/js/editDialog.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/dialog/js/editDialog.js
@@ -490,12 +490,14 @@
      * to a binary string before being passed to btoa().
      *
      * @param {String} str - the string to encode
-     * @returns {String} base64 encoding of the UTF-8 bytes of {@code str}
+     * @returns {String} unpadded base64 encoding of the UTF-8 bytes of {@code str}, as
+     * expected by the Content Fragment Visualization API's model ID format
      */
     function base64EncodeUtf8(str) {
-        return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, hex) {
+        var base64 = btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, hex) {
             return String.fromCharCode(parseInt(hex, 16));
         }));
+        return base64.replace(/=+$/, "");
     }
 
     /**

--- a/content/test/clientlibs/contentfragment/editDialogTest.js
+++ b/content/test/clientlibs/contentfragment/editDialogTest.js
@@ -158,6 +158,32 @@ describe("Test editDialog VCF template retention for", function() {
         }, done);
     });
 
+    it("model ID sent to templates API has base64 padding stripped", function(done) {
+        let requestedUrl = null;
+
+        jQuery._getJSONHandler = function(url, resolve) {
+            if (url.includes("jcr:content/data")) {
+                resolve({ "cq:model": MODEL_PATH });
+            } else if (url.includes(COMPONENT_PATH)) {
+                resolve({ fragmentPath: FRAGMENT_PATH, displayMode: "vcf" });
+            }
+        };
+
+        jQuery._ajaxHandler = function(ajaxOptions, resolve) {
+            requestedUrl = ajaxOptions.url;
+            resolve(TEMPLATES_RESPONSE);
+        };
+
+        channel.trigger({ type: "foundation-contentloaded", target: fixture.el });
+
+        setTimeout(function() {
+            // MODEL_PATH's standard base64 encoding ends in "=" padding; the API expects it stripped.
+            expect(requestedUrl).toContain("L2NvbmYvdGVzdC9zZXR0aW5ncy9kYW0vY2ZtL21vZGVscy9wZXJzb24/");
+            expect(requestedUrl).not.toContain("%3D");
+            done();
+        }, 100);
+    });
+
     it("templates are not loaded when no fragment is selected", function(done) {
         fixture.el.querySelector("[name='./fragmentPath']").value = "";
         let ajaxCalled = false;


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

## Summary

The "Visual Content Fragment Template" dropdown in the Content Fragment editor dialog was showing up empty for some models, even when the model had templates registered on the Content Fragment Visualization (CFVS) backend.

Root cause: `resolveModelId()` in `editDialog.js` base64-encodes the fragment's Content Fragment Model path (`cq:model`) to build the `modelId` sent to `GET /adobe/contentFragments/models/{modelId}/templates`. `base64EncodeUtf8()` used `btoa()` directly, which includes standard `=` padding whenever the encoded input isn't a multiple of 3 bytes. That padding gets URL-encoded to `%3D%3D` in the request path. The CFVS backend doesn't resolve model IDs in that padded form, and instead of erroring it returns a valid but empty `{"items":[],"cursor":null}` response — making it look like the model has no templates.

Confirmed via two live requests for the same model, differing only in padding:
- Padded modelId → `200 {"items":[],"cursor":null}`
- Unpadded modelId → `200 {"items":[{"id":"...","name":"test",...}]}`

Since only model paths whose length isn't a multiple of 3 bytes produce padding, this bug affected some models but not others, making it look intermittent.

## Fix

Strip trailing `=` padding from the base64-encoded model ID in `base64EncodeUtf8()` before it's used to build the templates API URL.

## Test plan

- [x] Added a Karma/Jasmine test asserting the templates API request URL contains the unpadded model ID and never contains `%3D`
- [x] Full existing Karma suite passes (483/483)