### PR TITLE
GRANITE-71475: ContentAI Supported Search v2 - tabbed Search Results / AI Mode

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ContentAISupportedSearchV2Impl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ContentAISupportedSearchV2Impl.java
@@ -18,11 +18,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v2;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
@@ -44,10 +40,6 @@ import com.adobe.cq.wcm.core.components.models.ContentAISupportedSearch;
 import com.adobe.cq.wcm.core.components.models.ContentAISupportedSearchV2;
 import com.adobe.cq.wcm.core.components.util.AbstractComponentImpl;
 import com.adobe.granite.license.ProductInfoProvider;
-import com.day.cq.i18n.I18n;
-import com.day.cq.wcm.api.Page;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Model(adaptables = SlingHttpServletRequest.class,
     adapters = {ContentAISupportedSearchV2.class, ContentAISupportedSearch.class, ComponentExporter.class},
@@ -104,8 +96,6 @@ public class ContentAISupportedSearchV2Impl extends AbstractComponentImpl implem
     private List<String> resolvedContentSources = Collections.emptyList();
     private String resolvedPrimaryContentSource = "";
     private boolean aiSearchModeEnabled;
-
-    private final Map<String, String> i18nMessagesMap = new HashMap<>();
 
     @PostConstruct
     private void initModel() {
@@ -183,34 +173,6 @@ public class ContentAISupportedSearchV2Impl extends AbstractComponentImpl implem
     @Override
     public String getExportedType() {
         return RESOURCE_TYPE;
-    }
-
-    @JsonIgnore
-    @NotNull
-    @Override
-    public String getI18nMessages() {
-        Page page = getCurrentPage();
-        Locale pageLocale = page != null ? page.getLanguage(false) : request.getLocale();
-        ResourceBundle resourceBundle = request.getResourceBundle(pageLocale);
-        I18n i18n = new I18n(resourceBundle);
-        i18nMessagesMap.put("Search", i18n.get("Search"));
-        i18nMessagesMap.put("Clear", i18n.get("Clear"));
-        i18nMessagesMap.put("AI-generated responses may be inaccurate. Verify important information.",
-            i18n.get("AI-generated responses may be inaccurate. Verify important information."));
-        i18nMessagesMap.put("Generative answer", i18n.get("Generative answer"));
-        i18nMessagesMap.put("Generating answer...", i18n.get("Generating answer..."));
-        i18nMessagesMap.put("Powered by Content AI", i18n.get("Powered by Content AI"));
-        i18nMessagesMap.put("Sources", i18n.get("Sources"));
-        i18nMessagesMap.put("Search results", i18n.get("Search results"));
-        i18nMessagesMap.put("Cards", i18n.get("Cards"));
-        i18nMessagesMap.put("List", i18n.get("List"));
-        i18nMessagesMap.put("Results layout", i18n.get("Results layout"));
-        i18nMessagesMap.put("Load more results", i18n.get("Load more results"));
-        try {
-            return new ObjectMapper().writeValueAsString(i18nMessagesMap);
-        } catch (Exception e) {
-            return "{}";
-        }
     }
 
     @NotNull

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ContentAISupportedSearchV2Impl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ContentAISupportedSearchV2Impl.java
@@ -1,0 +1,241 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2026 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.models.annotations.Default;
+import org.apache.sling.models.annotations.Exporter;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+import org.jetbrains.annotations.NotNull;
+
+import com.adobe.cq.export.json.ComponentExporter;
+import com.adobe.cq.export.json.ExporterConstants;
+import com.adobe.cq.wcm.core.components.internal.AemCloudPlatformDetector;
+import com.adobe.cq.wcm.core.components.models.ContentAISupportedSearch;
+import com.adobe.cq.wcm.core.components.models.ContentAISupportedSearchV2;
+import com.adobe.cq.wcm.core.components.util.AbstractComponentImpl;
+import com.adobe.granite.license.ProductInfoProvider;
+import com.day.cq.i18n.I18n;
+import com.day.cq.wcm.api.Page;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Model(adaptables = SlingHttpServletRequest.class,
+    adapters = {ContentAISupportedSearchV2.class, ContentAISupportedSearch.class, ComponentExporter.class},
+    resourceType = ContentAISupportedSearchV2Impl.RESOURCE_TYPE)
+@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+public class ContentAISupportedSearchV2Impl extends AbstractComponentImpl implements ContentAISupportedSearchV2 {
+
+    protected static final String RESOURCE_TYPE = "core/wcm/components/contentaisearch/v2/contentaisearch";
+
+    public static final int PROP_RESULTS_SIZE_DEFAULT = 12;
+    public static final String PROP_RESULTS_LAYOUT_DEFAULT = ContentAISupportedSearch.RESULTS_LAYOUT_CARD;
+
+    @OSGiService(injectionStrategy = InjectionStrategy.OPTIONAL)
+    private ProductInfoProvider productInfoProvider;
+
+    @ValueMapValue
+    @Default(values = "")
+    private String contentSource;
+
+    @ValueMapValue(name = PN_CONTENT_SOURCE_TYPE)
+    @Default(values = ContentAISupportedSearch.DEFAULT_CONTENT_SOURCE_TYPE)
+    private String contentSourceType;
+
+    @ValueMapValue(name = PN_CONTENT_SOURCES, injectionStrategy = InjectionStrategy.OPTIONAL)
+    private String[] contentSources;
+
+    @ValueMapValue(name = PN_PRIMARY_CONTENT_SOURCE, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Default(values = "")
+    private String primaryContentSource;
+
+    @ValueMapValue
+    @Default(intValues = PROP_RESULTS_SIZE_DEFAULT)
+    private int resultsSize;
+
+    @ValueMapValue(name = PN_RESULTS_LAYOUT)
+    @Default(values = PROP_RESULTS_LAYOUT_DEFAULT)
+    private String resultsLayout;
+
+    @ValueMapValue(name = PN_AI_SEARCH_MODE_ENABLED, injectionStrategy = InjectionStrategy.OPTIONAL)
+    private Boolean aiSearchModeEnabledProperty;
+
+    @ValueMapValue(name = PN_GENSEARCH_ERROR_RETRY_VISIBLE)
+    @Default(booleanValues = true)
+    private boolean genSearchErrorRetryVisible;
+
+    @ValueMapValue
+    @Default(values = "")
+    private String placeholder;
+
+    @ValueMapValue
+    @Default(values = "")
+    private String disclaimerText;
+
+    private List<String> resolvedContentSources = Collections.emptyList();
+    private String resolvedPrimaryContentSource = "";
+    private boolean aiSearchModeEnabled;
+
+    private final Map<String, String> i18nMessagesMap = new HashMap<>();
+
+    @PostConstruct
+    private void initModel() {
+        resolvedContentSources = resolveContentSources();
+        resolvedPrimaryContentSource = resolvePrimaryContentSource(resolvedContentSources);
+        aiSearchModeEnabled = resolveAiSearchModeEnabled();
+    }
+
+    private boolean resolveAiSearchModeEnabled() {
+        if (!AemCloudPlatformDetector.isCloudPlatform(productInfoProvider)) {
+            return false;
+        }
+        return aiSearchModeEnabledProperty == null || aiSearchModeEnabledProperty.booleanValue();
+    }
+
+    @NotNull
+    @Override
+    public String getContentSource() {
+        return resolvedPrimaryContentSource;
+    }
+
+    @NotNull
+    @Override
+    public String getContentSourceType() {
+        return StringUtils.defaultIfBlank(contentSourceType, ContentAISupportedSearch.DEFAULT_CONTENT_SOURCE_TYPE);
+    }
+
+    @NotNull
+    @Override
+    public List<String> getContentSources() {
+        return resolvedContentSources;
+    }
+
+    @NotNull
+    @Override
+    public String getPrimaryContentSource() {
+        return resolvedPrimaryContentSource;
+    }
+
+    @Override
+    public int getResultsSize() {
+        return resultsSize;
+    }
+
+    @NotNull
+    @Override
+    public String getResultsLayout() {
+        if (ContentAISupportedSearch.RESULTS_LAYOUT_LIST.equals(resultsLayout)) {
+            return ContentAISupportedSearch.RESULTS_LAYOUT_LIST;
+        }
+        return ContentAISupportedSearch.RESULTS_LAYOUT_CARD;
+    }
+
+    @Override
+    public boolean isAiSearchModeEnabled() {
+        return aiSearchModeEnabled;
+    }
+
+    @Override
+    public boolean isGenSearchErrorRetryVisible() {
+        return genSearchErrorRetryVisible;
+    }
+
+    @Override
+    public String getPlaceholder() {
+        return StringUtils.isBlank(placeholder) ? null : placeholder;
+    }
+
+    @Override
+    public String getDisclaimerText() {
+        return StringUtils.isBlank(disclaimerText) ? null : disclaimerText;
+    }
+
+    @NotNull
+    @Override
+    public String getExportedType() {
+        return RESOURCE_TYPE;
+    }
+
+    @JsonIgnore
+    @NotNull
+    @Override
+    public String getI18nMessages() {
+        Page page = getCurrentPage();
+        Locale pageLocale = page != null ? page.getLanguage(false) : request.getLocale();
+        ResourceBundle resourceBundle = request.getResourceBundle(pageLocale);
+        I18n i18n = new I18n(resourceBundle);
+        i18nMessagesMap.put("Search", i18n.get("Search"));
+        i18nMessagesMap.put("Clear", i18n.get("Clear"));
+        i18nMessagesMap.put("AI-generated responses may be inaccurate. Verify important information.",
+            i18n.get("AI-generated responses may be inaccurate. Verify important information."));
+        i18nMessagesMap.put("Generative answer", i18n.get("Generative answer"));
+        i18nMessagesMap.put("Generating answer...", i18n.get("Generating answer..."));
+        i18nMessagesMap.put("Powered by Content AI", i18n.get("Powered by Content AI"));
+        i18nMessagesMap.put("Sources", i18n.get("Sources"));
+        i18nMessagesMap.put("Search results", i18n.get("Search results"));
+        i18nMessagesMap.put("Cards", i18n.get("Cards"));
+        i18nMessagesMap.put("List", i18n.get("List"));
+        i18nMessagesMap.put("Results layout", i18n.get("Results layout"));
+        i18nMessagesMap.put("Load more results", i18n.get("Load more results"));
+        try {
+            return new ObjectMapper().writeValueAsString(i18nMessagesMap);
+        } catch (Exception e) {
+            return "{}";
+        }
+    }
+
+    @NotNull
+    private List<String> resolveContentSources() {
+        List<String> sources = new ArrayList<>();
+        if (contentSources != null) {
+            sources.addAll(Arrays.stream(contentSources)
+                .filter(StringUtils::isNotBlank)
+                .map(String::trim)
+                .collect(Collectors.toList()));
+        }
+        if (sources.isEmpty() && StringUtils.isNotBlank(contentSource)) {
+            sources.add(contentSource.trim());
+        }
+        return Collections.unmodifiableList(sources);
+    }
+
+    @NotNull
+    private String resolvePrimaryContentSource(@NotNull List<String> sources) {
+        if (StringUtils.isNotBlank(primaryContentSource)) {
+            return primaryContentSource.trim();
+        }
+        if (!sources.isEmpty()) {
+            return sources.get(0);
+        }
+        return "";
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/AbstractContentAISearchServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/AbstractContentAISearchServlet.java
@@ -46,6 +46,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 abstract class AbstractContentAISearchServlet extends SlingSafeMethodsServlet {
 
     protected static final String RESOURCE_TYPE = "core/wcm/components/contentaisearch/v1/contentaisearch";
+    protected static final String RESOURCE_TYPE_V2 = "core/wcm/components/contentaisearch/v2/contentaisearch";
     protected static final String EXTENSION = "json";
     private static final String PARAM_QUERY = "q";
     private static final int MAX_QUERY_LENGTH = 512;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAIGenSearchServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAIGenSearchServlet.java
@@ -34,6 +34,7 @@ import com.adobe.cq.wcm.core.components.services.contentai.ContentSourceQueryRes
     property = {
         "sling.servlet.methods=GET",
         "sling.servlet.resourceTypes=" + AbstractContentAISearchServlet.RESOURCE_TYPE,
+        "sling.servlet.resourceTypes=" + AbstractContentAISearchServlet.RESOURCE_TYPE_V2,
         "sling.servlet.selectors=" + ContentAIGenSearchServlet.SELECTOR,
         "sling.servlet.extensions=" + AbstractContentAISearchServlet.EXTENSION
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAISearchResultsServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAISearchResultsServlet.java
@@ -47,6 +47,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
     property = {
         "sling.servlet.methods=GET",
         "sling.servlet.resourceTypes=" + AbstractContentAISearchServlet.RESOURCE_TYPE,
+        "sling.servlet.resourceTypes=" + AbstractContentAISearchServlet.RESOURCE_TYPE_V2,
         "sling.servlet.selectors=" + ContentAISearchResultsServlet.SELECTOR,
         "sling.servlet.extensions=" + AbstractContentAISearchServlet.EXTENSION
     }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ContentAISupportedSearchV2.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ContentAISupportedSearchV2.java
@@ -1,0 +1,55 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2026 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.models;
+
+/**
+ * Defines the {@code ContentAISupportedSearchV2} Sling Model used for the
+ * {@code /apps/core/wcm/components/contentaisearch/v2} component.
+ *
+ * <p>Extends {@link ContentAISupportedSearch} rather than sharing it directly: v2 replaces the
+ * visitor-facing generative-summary <em>checkbox toggle</em> with two mutually-exclusive tabs
+ * (Search Results / AI Mode), which removes {@code genSearchEnabledByDefault} entirely and
+ * repurposes {@code genSearchToggleVisible}/{@code genSearchErrorFallback} into differently-shaped
+ * properties below — a bigger contract change than this project's more common v1/v2
+ * shared-interface-with-additive-default-methods pattern is meant for.</p>
+ *
+ * @since com.adobe.cq.wcm.core.components.models 12.33.0
+ */
+public interface ContentAISupportedSearchV2 extends ContentAISupportedSearch {
+
+    String PN_AI_SEARCH_MODE_ENABLED = "aiSearchModeEnabled";
+    String PN_GENSEARCH_ERROR_RETRY_VISIBLE = "genSearchErrorRetryVisible";
+
+    /**
+     * @return whether the "AI Mode" tab is rendered at all. When {@code false}, the component
+     *         shows only a plain Search Results view with no tab bar and never calls the
+     *         generative-search endpoint. Only available on AEM as a Cloud Service; always
+     *         {@code false} on classic AEM regardless of author configuration (same platform
+     *         gating as v1's {@code genSearchToggleVisible}).
+     */
+    default boolean isAiSearchModeEnabled() {
+        return true;
+    }
+
+    /**
+     * @return whether a retry button is shown alongside the AI Mode tab's error message when
+     *         generative search fails. The error message itself is always shown on failure;
+     *         this only controls the retry button.
+     */
+    default boolean isGenSearchErrorRetryVisible() {
+        return true;
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ContentAISupportedSearchV2ImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ContentAISupportedSearchV2ImplTest.java
@@ -1,3 +1,18 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2026 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v2;
 
 import java.util.Arrays;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ContentAISupportedSearchV2ImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ContentAISupportedSearchV2ImplTest.java
@@ -129,4 +129,62 @@ class ContentAISupportedSearchV2ImplTest {
 
         assertFalse(model.isGenSearchErrorRetryVisible());
     }
+
+    @Test
+    void resultsLayoutDefaultsToCard() {
+        createResource(new HashMap<>());
+        context.currentResource(COMPONENT_PATH);
+
+        ContentAISupportedSearchV2 model = context.request().adaptTo(ContentAISupportedSearchV2.class);
+
+        assertEquals(ContentAISupportedSearchV2.RESULTS_LAYOUT_CARD, model.getResultsLayout());
+    }
+
+    @Test
+    void resultsLayoutListWhenAuthored() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("resultsLayout", "list");
+        createResource(props);
+        context.currentResource(COMPONENT_PATH);
+
+        ContentAISupportedSearchV2 model = context.request().adaptTo(ContentAISupportedSearchV2.class);
+
+        assertEquals(ContentAISupportedSearchV2.RESULTS_LAYOUT_LIST, model.getResultsLayout());
+    }
+
+    @Test
+    void exportedTypeIsV2ResourceType() {
+        createResource(new HashMap<>());
+        context.currentResource(COMPONENT_PATH);
+
+        ContentAISupportedSearchV2 model = context.request().adaptTo(ContentAISupportedSearchV2.class);
+
+        assertEquals(ContentAISupportedSearchV2Impl.RESOURCE_TYPE, model.getExportedType());
+    }
+
+    @Test
+    void resolvesLegacySingleContentSourceProperty() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("contentSource", "wknd");
+        createResource(props);
+        context.currentResource(COMPONENT_PATH);
+
+        ContentAISupportedSearchV2 model = context.request().adaptTo(ContentAISupportedSearchV2.class);
+
+        assertEquals(Arrays.asList("wknd"), model.getContentSources());
+        assertEquals("wknd", model.getPrimaryContentSource());
+    }
+
+    @Test
+    void primaryContentSourceOverridesFirstOfContentSources() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("contentSources", new String[] {"wknd", "wknd-blog"});
+        props.put("primaryContentSource", "wknd-blog");
+        createResource(props);
+        context.currentResource(COMPONENT_PATH);
+
+        ContentAISupportedSearchV2 model = context.request().adaptTo(ContentAISupportedSearchV2.class);
+
+        assertEquals("wknd-blog", model.getPrimaryContentSource());
+    }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ContentAISupportedSearchV2ImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v2/ContentAISupportedSearchV2ImplTest.java
@@ -1,0 +1,117 @@
+package com.adobe.cq.wcm.core.components.internal.models.v2;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.sling.i18n.ResourceBundleProvider;
+import org.apache.sling.i18n.impl.RootResourceBundle;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.osgi.framework.Version;
+
+import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
+import com.adobe.cq.wcm.core.components.models.ContentAISupportedSearchV2;
+import com.adobe.cq.wcm.core.components.testing.MockProductInfoProvider;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(AemContextExtension.class)
+class ContentAISupportedSearchV2ImplTest {
+
+    private static final String CONTENT_ROOT = "/content";
+    private static final String COMPONENT_PATH = CONTENT_ROOT + "/contentaisearch-v2";
+
+    private final AemContext context = CoreComponentTestContext.newAemContext();
+    private static final MockProductInfoProvider mockProductInfoProvider = new MockProductInfoProvider();
+
+    @BeforeEach
+    void setUp() {
+        mockProductInfoProvider.setVersion(new Version("6.6.0")); // cloud, per AemCloudPlatformDetector.MIN_CLOUD_CLASSIC_VERSION
+        context.registerInjectActivateService(mockProductInfoProvider);
+        ResourceBundleProvider resourceBundleProvider = Mockito.mock(ResourceBundleProvider.class);
+        Mockito.when(resourceBundleProvider.getResourceBundle(Mockito.any())).thenReturn(new RootResourceBundle());
+        Mockito.when(resourceBundleProvider.getResourceBundle(Mockito.any(), Mockito.any())).thenReturn(new RootResourceBundle());
+        context.registerService(ResourceBundleProvider.class, resourceBundleProvider);
+    }
+
+    private void createResource(Map<String, Object> extraProps) {
+        Map<String, Object> props = new HashMap<>(extraProps);
+        props.put("sling:resourceType", ContentAISupportedSearchV2Impl.RESOURCE_TYPE);
+        context.create().resource(COMPONENT_PATH, props);
+    }
+
+    @Test
+    void resolvesContentSourcesAndPrimarySource() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("contentSources", new String[] {"wknd", "wknd-blog"});
+        createResource(props);
+        context.currentResource(COMPONENT_PATH);
+
+        ContentAISupportedSearchV2 model = context.request().adaptTo(ContentAISupportedSearchV2.class);
+
+        assertEquals(Arrays.asList("wknd", "wknd-blog"), model.getContentSources());
+        assertEquals("wknd", model.getPrimaryContentSource());
+    }
+
+    @Test
+    void aiSearchModeEnabledDefaultsToTrueOnCloud() {
+        createResource(new HashMap<>());
+        context.currentResource(COMPONENT_PATH);
+
+        ContentAISupportedSearchV2 model = context.request().adaptTo(ContentAISupportedSearchV2.class);
+
+        assertTrue(model.isAiSearchModeEnabled());
+    }
+
+    @Test
+    void aiSearchModeEnabledFalseOnNonCloud() {
+        mockProductInfoProvider.setVersion(new Version("6.5.25")); // below MIN_CLOUD_CLASSIC_VERSION
+        createResource(new HashMap<>());
+        context.currentResource(COMPONENT_PATH);
+
+        ContentAISupportedSearchV2 model = context.request().adaptTo(ContentAISupportedSearchV2.class);
+
+        assertFalse(model.isAiSearchModeEnabled());
+    }
+
+    @Test
+    void aiSearchModeEnabledFalseWhenAuthoredFalse() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("aiSearchModeEnabled", false);
+        createResource(props);
+        context.currentResource(COMPONENT_PATH);
+
+        ContentAISupportedSearchV2 model = context.request().adaptTo(ContentAISupportedSearchV2.class);
+
+        assertFalse(model.isAiSearchModeEnabled());
+    }
+
+    @Test
+    void genSearchErrorRetryVisibleDefaultsToTrue() {
+        createResource(new HashMap<>());
+        context.currentResource(COMPONENT_PATH);
+
+        ContentAISupportedSearchV2 model = context.request().adaptTo(ContentAISupportedSearchV2.class);
+
+        assertTrue(model.isGenSearchErrorRetryVisible());
+    }
+
+    @Test
+    void genSearchErrorRetryVisibleFalseWhenAuthoredFalse() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("genSearchErrorRetryVisible", false);
+        createResource(props);
+        context.currentResource(COMPONENT_PATH);
+
+        ContentAISupportedSearchV2 model = context.request().adaptTo(ContentAISupportedSearchV2.class);
+
+        assertFalse(model.isGenSearchErrorRetryVisible());
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAISearchResultsServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/contentaisearch/ContentAISearchResultsServletTest.java
@@ -216,6 +216,29 @@ class ContentAISearchResultsServletTest {
     }
 
     @Test
+    void doGetWorksForV2ResourceType() throws Exception {
+        ContentSourceSearchResult expected = new ContentSourceSearchResult();
+        ContentSourceSearchResult.Item item = new ContentSourceSearchResult.Item();
+        item.setId("doc_1");
+        item.setScore(0.75);
+        expected.setResults(Collections.singletonList(item));
+        when(mockClient.search(eq("wknd"), eq("ACQUISITION"), eq("electric cars"), eq(10), isNull())).thenReturn(expected);
+
+        context.create().resource("/content/jcr:content/par/contentaisearch-v2",
+            "sling:resourceType", "core/wcm/components/contentaisearch/v2/contentaisearch",
+            "contentSources", new String[] {"wknd"},
+            "resultsSize", 10);
+        context.currentResource("/content/jcr:content/par/contentaisearch-v2");
+        context.request().setQueryString("q=electric+cars");
+
+        underTest.doGet(context.request(), context.response());
+
+        assertEquals(200, context.response().getStatus());
+        String output = context.response().getOutputAsString();
+        assertTrue(output.contains("\"id\":\"doc_1\""));
+    }
+
+    @Test
     void parseSourceCursors_returnsEmptyMapForBlankInput() {
         assertTrue(ContentAISearchResultsServlet.parseSourceCursors(null).isEmpty());
         assertTrue(ContentAISearchResultsServlet.parseSourceCursors("").isEmpty());

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="ContentAI Supported Search"
+    jcr:description="Search component with a Content AI generative answer shown in a separate AI Mode tab, and a results list"
+    cq:icon="search"
+    componentGroup=".core-wcm"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/README.md
@@ -59,7 +59,6 @@ BLOCK cmp-contentaisearch
     ELEMENT cmp-contentaisearch__input
     ELEMENT cmp-contentaisearch__input-label
     ELEMENT cmp-contentaisearch__icon
-    ELEMENT cmp-contentaisearch__loading-indicator
     ELEMENT cmp-contentaisearch__clear
     ELEMENT cmp-contentaisearch__clear-icon
     ELEMENT cmp-contentaisearch__tabs
@@ -106,17 +105,15 @@ BLOCK cmp-contentaisearch
 Apply a `data-cmp-is="contentaisearch"` attribute to the wrapper block to enable initialization of the JavaScript component.
 
 1. `data-cmp-content-source` - populated with `primaryContentSource`, specifies the Content AI source for generative search
-2. `data-cmp-ai-search-mode-enabled` - populated with `aiSearchModeEnabled`
+2. `data-cmp-ai-search-mode-enabled` - populated with `aiSearchModeEnabled`; a Sightly boolean-typed attribute, so it's rendered bare (present) when true and omitted entirely when false - the client JS reads it with `hasAttribute`, not a string comparison
 3. `data-cmp-gensearch-error-retry-visible` - populated with `genSearchErrorRetryVisible`, present on the root element for reference/parity only — the client JS never reads it; retry-button visibility is enforced server-side by the HTL (`data-sly-test="${search.genSearchErrorRetryVisible}"` on the retry button itself), which simply omits the button from the DOM when false
 4. `data-cmp-results-layout` - populated with `resultsLayout` (`card` or `list`)
 5. `data-cmp-resource-path` - the component resource path used to build `.search.json` and `.gensearch.json` URLs
-6. `data-i18n-messages` - localized strings for client-side rendering
 
 ```
 data-cmp-hook-contentaisearch="form"
 data-cmp-hook-contentaisearch="input"
 data-cmp-hook-contentaisearch="icon"
-data-cmp-hook-contentaisearch="loadingIndicator"
 data-cmp-hook-contentaisearch="clear"
 data-cmp-hook-contentaisearch="tabs"
 data-cmp-hook-contentaisearch="tabSearchResults"

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/README.md
@@ -25,14 +25,14 @@ The component uses the `com.adobe.cq.wcm.core.components.models.ContentAISupport
 ### Behavior
 On submit, the component always fetches `.search.json`. When AI Search Mode is enabled (see below), it also fetches `.gensearch.json` in parallel — regardless of which tab is currently active, so switching tabs is instant rather than triggering a new fetch. When AI Search Mode is disabled, `.gensearch.json` is never called at all.
 
-The active tab persists across page loads via a single, site-wide cookie (`cmp-contentaisearch-tab`, values `search-results`/`ai-mode`), applied by a small synchronous script inline in the component's own markup — not a server-side cookie read — so pages using this component remain fully cacheable.
+The active tab persists across page loads via a single, site-wide cookie (`cmp-contentaisearch-tab`, values `search-results`/`ai-mode`, set with `path=/; max-age=<1 year>; SameSite=Lax; Secure`), applied by a small synchronous script inline in the component's own markup — not a server-side cookie read — so pages using this component remain fully cacheable.
 
 ### Edit Dialog Properties
 The following properties are written to JCR for the component:
 
 1. `./contentSourceType` - the Content AI content source type (default `ACQUISITION`)
 2. `./contentSources` - the selected Content AI content source names
-3. `./primaryContentSource` - optional override for generative search source
+3. `./primaryContentSource` - optional override for generative search source (resource property; not exposed as a dialog field — set via the underlying resource, not authored through the dialog UI)
 4. `./resultsSize` - default number of results to fetch
 5. `./resultsLayout` - `card` or `list`
 6. `./placeholder` - placeholder text for the search input
@@ -107,7 +107,7 @@ Apply a `data-cmp-is="contentaisearch"` attribute to the wrapper block to enable
 
 1. `data-cmp-content-source` - populated with `primaryContentSource`, specifies the Content AI source for generative search
 2. `data-cmp-ai-search-mode-enabled` - populated with `aiSearchModeEnabled`
-3. `data-cmp-gensearch-error-retry-visible` - populated with `genSearchErrorRetryVisible`
+3. `data-cmp-gensearch-error-retry-visible` - populated with `genSearchErrorRetryVisible`, present on the root element for reference/parity only — the client JS never reads it; retry-button visibility is enforced server-side by the HTL (`data-sly-test="${search.genSearchErrorRetryVisible}"` on the retry button itself), which simply omits the button from the DOM when false
 4. `data-cmp-results-layout` - populated with `resultsLayout` (`card` or `list`)
 5. `data-cmp-resource-path` - the component resource path used to build `.search.json` and `.gensearch.json` URLs
 6. `data-i18n-messages` - localized strings for client-side rendering

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/README.md
@@ -1,0 +1,134 @@
+<!--
+Copyright 2026 Adobe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+ContentAI Supported Search (v2)
+====
+Search component backed by the Content AI `content-sources/search` and `content-sources/gensearch` APIs, presenting the generative answer and the results list as two mutually-exclusive tabs — Search Results and AI Mode — instead of v1's stacked checkbox-toggle layout.
+
+## Features
+
+### Use Object
+The component uses the `com.adobe.cq.wcm.core.components.models.ContentAISupportedSearchV2` Sling model as its Use-object (extends v1's `ContentAISupportedSearch`).
+
+### Behavior
+On submit, the component always fetches `.search.json`. When AI Search Mode is enabled (see below), it also fetches `.gensearch.json` in parallel — regardless of which tab is currently active, so switching tabs is instant rather than triggering a new fetch. When AI Search Mode is disabled, `.gensearch.json` is never called at all.
+
+The active tab persists across page loads via a single, site-wide cookie (`cmp-contentaisearch-tab`, values `search-results`/`ai-mode`), applied by a small synchronous script inline in the component's own markup — not a server-side cookie read — so pages using this component remain fully cacheable.
+
+### Edit Dialog Properties
+The following properties are written to JCR for the component:
+
+1. `./contentSourceType` - the Content AI content source type (default `ACQUISITION`)
+2. `./contentSources` - the selected Content AI content source names
+3. `./primaryContentSource` - optional override for generative search source
+4. `./resultsSize` - default number of results to fetch
+5. `./resultsLayout` - `card` or `list`
+6. `./aiSearchModeEnabled` - whether the AI Mode tab is shown to visitors at all (unchecked = plain Search Results view, no tab bar, generative search never called)
+7. `./genSearchErrorRetryVisible` - whether a retry button is shown when the AI Mode tab's answer fails to generate
+8. `./disclaimerText` - optional disclaimer below the generative summary
+9. `./id` - defines the component HTML ID attribute
+
+Compared to v1: `genSearchEnabledByDefault` is removed (the default tab is always Search Results); `genSearchToggleVisible` is renamed to `aiSearchModeEnabled`; `genSearchErrorFallback`'s three states are replaced by the two-state `genSearchErrorRetryVisible`.
+
+## Configuration - Content AI API Access
+Shares the same `ContentAIClient` OSGi service and configuration as v1 — see the [v1 README](../../v1/contentaisearch/README.md#configuration---content-ai-api-access) for the full `apiKey`/Cloud Manager secret setup. No v2-specific configuration exists; both versions call the same backend.
+
+## Client Libraries
+The component provides a `core.wcm.components.contentaisearch.v2` client library category (base CSS + JS) and a `core.wcm.components.contentaisearch.v2.editor` category (dialog-time JS). Add the site category to a relevant site client library using the `embed` property.
+
+## BEM Description
+```
+BLOCK cmp-contentaisearch
+    MOD cmp-contentaisearch--card
+    MOD cmp-contentaisearch--list
+    ELEMENT cmp-contentaisearch__form
+    ELEMENT cmp-contentaisearch__field
+    ELEMENT cmp-contentaisearch__input
+    ELEMENT cmp-contentaisearch__loading-indicator
+    ELEMENT cmp-contentaisearch__tabs
+    ELEMENT cmp-contentaisearch__tab
+    ELEMENT cmp-contentaisearch__panel
+    ELEMENT cmp-contentaisearch__summary
+    ELEMENT cmp-contentaisearch__summary-card
+    ELEMENT cmp-contentaisearch__summary-header
+    ELEMENT cmp-contentaisearch__summary-icon
+    ELEMENT cmp-contentaisearch__summary-title
+    ELEMENT cmp-contentaisearch__summary-attribution
+    ELEMENT cmp-contentaisearch__summary-text
+    ELEMENT cmp-contentaisearch__sources-section
+    ELEMENT cmp-contentaisearch__sources-label
+    ELEMENT cmp-contentaisearch__sources
+    ELEMENT cmp-contentaisearch__source-chip
+    ELEMENT cmp-contentaisearch__disclaimer
+    ELEMENT cmp-contentaisearch__error
+    ELEMENT cmp-contentaisearch__results-section
+    ELEMENT cmp-contentaisearch__results-toolbar
+    ELEMENT cmp-contentaisearch__results
+    ELEMENT cmp-contentaisearch__item
+    ELEMENT cmp-contentaisearch__card
+    ELEMENT cmp-contentaisearch__card-image
+    ELEMENT cmp-contentaisearch__card-body
+    ELEMENT cmp-contentaisearch__card-title
+    ELEMENT cmp-contentaisearch__card-description
+    ELEMENT cmp-contentaisearch__row
+    ELEMENT cmp-contentaisearch__row-image
+    ELEMENT cmp-contentaisearch__row-body
+    ELEMENT cmp-contentaisearch__row-title
+    ELEMENT cmp-contentaisearch__row-description
+```
+
+## JavaScript Data Attribute Bindings
+Apply a `data-cmp-is="contentaisearch"` attribute to the wrapper block to enable initialization of the JavaScript component.
+
+1. `data-cmp-ai-search-mode-enabled` - populated with `aiSearchModeEnabled`
+2. `data-cmp-gensearch-error-retry-visible` - populated with `genSearchErrorRetryVisible`
+3. `data-cmp-results-layout` - populated with `resultsLayout` (`card` or `list`)
+4. `data-cmp-resource-path` - the component resource path used to build `.search.json` and `.gensearch.json` URLs
+5. `data-i18n-messages` - localized strings for client-side rendering
+
+```
+data-cmp-hook-contentaisearch="form"
+data-cmp-hook-contentaisearch="input"
+data-cmp-hook-contentaisearch="loadingIndicator"
+data-cmp-hook-contentaisearch="clear"
+data-cmp-hook-contentaisearch="tabSearchResults"
+data-cmp-hook-contentaisearch="tabAiMode"
+data-cmp-hook-contentaisearch="panelSearchResults"
+data-cmp-hook-contentaisearch="panelAiMode"
+data-cmp-hook-contentaisearch="summary"
+data-cmp-hook-contentaisearch="summaryText"
+data-cmp-hook-contentaisearch="sources"
+data-cmp-hook-contentaisearch="disclaimer"
+data-cmp-hook-contentaisearch="error"
+data-cmp-hook-contentaisearch="errorMessage"
+data-cmp-hook-contentaisearch="retry"
+data-cmp-hook-contentaisearch="resultsSection"
+data-cmp-hook-contentaisearch="results"
+data-cmp-hook-contentaisearch="itemTemplate"
+data-cmp-hook-contentaisearch="item"
+data-cmp-hook-contentaisearch="itemTitle"
+data-cmp-hook-contentaisearch="itemDescription"
+data-cmp-hook-contentaisearch="itemImage"
+data-cmp-hook-contentaisearch="itemImagePlaceholder"
+data-cmp-hook-contentaisearch="sourceTemplate"
+data-cmp-hook-contentaisearch="sourceLink"
+data-cmp-hook-contentaisearch="sourceText"
+```
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v2
+* **Compatibility**: AEM as a Cloud Service
+* **Status**: work-in-progress

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/README.md
@@ -35,10 +35,11 @@ The following properties are written to JCR for the component:
 3. `./primaryContentSource` - optional override for generative search source
 4. `./resultsSize` - default number of results to fetch
 5. `./resultsLayout` - `card` or `list`
-6. `./aiSearchModeEnabled` - whether the AI Mode tab is shown to visitors at all (unchecked = plain Search Results view, no tab bar, generative search never called)
-7. `./genSearchErrorRetryVisible` - whether a retry button is shown when the AI Mode tab's answer fails to generate
-8. `./disclaimerText` - optional disclaimer below the generative summary
-9. `./id` - defines the component HTML ID attribute
+6. `./placeholder` - placeholder text for the search input
+7. `./aiSearchModeEnabled` - whether the AI Mode tab is shown to visitors at all (unchecked = plain Search Results view, no tab bar, generative search never called)
+8. `./genSearchErrorRetryVisible` - whether a retry button is shown when the AI Mode tab's answer fails to generate
+9. `./disclaimerText` - optional disclaimer below the generative summary
+10. `./id` - defines the component HTML ID attribute
 
 Compared to v1: `genSearchEnabledByDefault` is removed (the default tab is always Search Results); `genSearchToggleVisible` is renamed to `aiSearchModeEnabled`; `genSearchErrorFallback`'s three states are replaced by the two-state `genSearchErrorRetryVisible`.
 
@@ -56,7 +57,11 @@ BLOCK cmp-contentaisearch
     ELEMENT cmp-contentaisearch__form
     ELEMENT cmp-contentaisearch__field
     ELEMENT cmp-contentaisearch__input
+    ELEMENT cmp-contentaisearch__input-label
+    ELEMENT cmp-contentaisearch__icon
     ELEMENT cmp-contentaisearch__loading-indicator
+    ELEMENT cmp-contentaisearch__clear
+    ELEMENT cmp-contentaisearch__clear-icon
     ELEMENT cmp-contentaisearch__tabs
     ELEMENT cmp-contentaisearch__tab
     ELEMENT cmp-contentaisearch__panel
@@ -64,9 +69,14 @@ BLOCK cmp-contentaisearch
     ELEMENT cmp-contentaisearch__summary-card
     ELEMENT cmp-contentaisearch__summary-header
     ELEMENT cmp-contentaisearch__summary-icon
+    ELEMENT cmp-contentaisearch__summary-heading
     ELEMENT cmp-contentaisearch__summary-title
     ELEMENT cmp-contentaisearch__summary-attribution
     ELEMENT cmp-contentaisearch__summary-text
+    ELEMENT cmp-contentaisearch__summary-loading
+    ELEMENT cmp-contentaisearch__summary-loading-content
+    ELEMENT cmp-contentaisearch__summary-loading-indicator
+    ELEMENT cmp-contentaisearch__summary-loading-text
     ELEMENT cmp-contentaisearch__sources-section
     ELEMENT cmp-contentaisearch__sources-label
     ELEMENT cmp-contentaisearch__sources
@@ -75,7 +85,10 @@ BLOCK cmp-contentaisearch
     ELEMENT cmp-contentaisearch__error
     ELEMENT cmp-contentaisearch__results-section
     ELEMENT cmp-contentaisearch__results-toolbar
+    ELEMENT cmp-contentaisearch__layout-toggle
+    ELEMENT cmp-contentaisearch__layout-btn
     ELEMENT cmp-contentaisearch__results
+    ELEMENT cmp-contentaisearch__load-more
     ELEMENT cmp-contentaisearch__item
     ELEMENT cmp-contentaisearch__card
     ELEMENT cmp-contentaisearch__card-image
@@ -92,21 +105,25 @@ BLOCK cmp-contentaisearch
 ## JavaScript Data Attribute Bindings
 Apply a `data-cmp-is="contentaisearch"` attribute to the wrapper block to enable initialization of the JavaScript component.
 
-1. `data-cmp-ai-search-mode-enabled` - populated with `aiSearchModeEnabled`
-2. `data-cmp-gensearch-error-retry-visible` - populated with `genSearchErrorRetryVisible`
-3. `data-cmp-results-layout` - populated with `resultsLayout` (`card` or `list`)
-4. `data-cmp-resource-path` - the component resource path used to build `.search.json` and `.gensearch.json` URLs
-5. `data-i18n-messages` - localized strings for client-side rendering
+1. `data-cmp-content-source` - populated with `primaryContentSource`, specifies the Content AI source for generative search
+2. `data-cmp-ai-search-mode-enabled` - populated with `aiSearchModeEnabled`
+3. `data-cmp-gensearch-error-retry-visible` - populated with `genSearchErrorRetryVisible`
+4. `data-cmp-results-layout` - populated with `resultsLayout` (`card` or `list`)
+5. `data-cmp-resource-path` - the component resource path used to build `.search.json` and `.gensearch.json` URLs
+6. `data-i18n-messages` - localized strings for client-side rendering
 
 ```
 data-cmp-hook-contentaisearch="form"
 data-cmp-hook-contentaisearch="input"
+data-cmp-hook-contentaisearch="icon"
 data-cmp-hook-contentaisearch="loadingIndicator"
 data-cmp-hook-contentaisearch="clear"
+data-cmp-hook-contentaisearch="tabs"
 data-cmp-hook-contentaisearch="tabSearchResults"
 data-cmp-hook-contentaisearch="tabAiMode"
 data-cmp-hook-contentaisearch="panelSearchResults"
 data-cmp-hook-contentaisearch="panelAiMode"
+data-cmp-hook-contentaisearch="summaryLoading"
 data-cmp-hook-contentaisearch="summary"
 data-cmp-hook-contentaisearch="summaryText"
 data-cmp-hook-contentaisearch="sources"
@@ -116,7 +133,11 @@ data-cmp-hook-contentaisearch="errorMessage"
 data-cmp-hook-contentaisearch="retry"
 data-cmp-hook-contentaisearch="resultsSection"
 data-cmp-hook-contentaisearch="results"
-data-cmp-hook-contentaisearch="itemTemplate"
+data-cmp-hook-contentaisearch="loadMore"
+data-cmp-hook-contentaisearch="layoutCard"
+data-cmp-hook-contentaisearch="layoutList"
+data-cmp-hook-contentaisearch="itemTemplateCard"
+data-cmp-hook-contentaisearch="itemTemplateList"
 data-cmp-hook-contentaisearch="item"
 data-cmp-hook-contentaisearch="itemTitle"
 data-cmp-hook-contentaisearch="itemDescription"
@@ -125,6 +146,7 @@ data-cmp-hook-contentaisearch="itemImagePlaceholder"
 data-cmp-hook-contentaisearch="sourceTemplate"
 data-cmp-hook-contentaisearch="sourceLink"
 data-cmp-hook-contentaisearch="sourceText"
+data-cmp-hook-contentaisearch="prepaint"
 ```
 
 ## Information

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/_cq_dialog/.content.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
+    xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="ContentAI Supported Search"
+    sling:resourceType="cq/gui/components/authoring/dialog"
+    extraClientlibs="[core.wcm.components.contentaisearch.v2.editor]">
+    <content
+        granite:class="cmp-contentaisearch__editor"
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <tabs
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/tabs"
+                maximized="{Boolean}true">
+                <items jcr:primaryType="nt:unstructured">
+                    <contentScope
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Content Scope"
+                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <column
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <id
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                        fieldLabel="ID"
+                                        fieldDescription="Optional HTML ID for this component."
+                                        name="./id"/>
+                                    <contentSourceType
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                        fieldLabel="Content Source Type"
+                                        fieldDescription="Filters the list of available Content AI content sources. For public anonymous sites, use ACQUISITION."
+                                        name="./contentSourceType"
+                                        value="ACQUISITION">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <acquisition
+                                                jcr:primaryType="nt:unstructured"
+                                                text="ACQUISITION"
+                                                value="ACQUISITION"/>
+                                            <aemAuthor
+                                                jcr:primaryType="nt:unstructured"
+                                                text="AEM_AUTHOR"
+                                                value="AEM_AUTHOR"/>
+                                            <aemPublish
+                                                jcr:primaryType="nt:unstructured"
+                                                text="AEM_PUBLISH"
+                                                value="AEM_PUBLISH"/>
+                                            <custom
+                                                jcr:primaryType="nt:unstructured"
+                                                text="CUSTOM"
+                                                value="CUSTOM"/>
+                                        </items>
+                                    </contentSourceType>
+                                    <contentSources
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                        fieldLabel="Content Sources"
+                                        fieldDescription="Public Content AI content sources to search. Must contain only published/public content — Content AI does not evaluate AEM ACLs. Requires an OSGi-configured Content AI API key — see the component README."
+                                        name="./contentSources"
+                                        multiple="{Boolean}true"
+                                        required="{Boolean}true"
+                                        translateOptions="{Boolean}false">
+                                        <datasource
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="core/wcm/components/contentaisearch/v1/datasources/contentsources"
+                                            contentSourceType="${param.contentSourceType}"/>
+                                        <granite:data
+                                            jcr:primaryType="nt:unstructured"
+                                            cmp-field-path="${requestPathInfo.resourcePath}"/>
+                                    </contentSources>
+                                </items>
+                            </column>
+                        </items>
+                    </contentScope>
+                    <searchBehavior
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Search Behavior"
+                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <column
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <resultsLayout
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                        fieldLabel="Results Layout"
+                                        name="./resultsLayout"
+                                        value="card">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <card
+                                                jcr:primaryType="nt:unstructured"
+                                                text="Cards"
+                                                value="card"/>
+                                            <list
+                                                jcr:primaryType="nt:unstructured"
+                                                text="List"
+                                                value="list"/>
+                                        </items>
+                                    </resultsLayout>
+                                    <resultsSize
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                        fieldDescription="Number of results fetched per search request. Visitors can load more results when additional matches are available."
+                                        fieldLabel="Results Size"
+                                        min="1"
+                                        name="./resultsSize"
+                                        step="1"
+                                        value="12"/>
+                                    <placeholder
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                        fieldLabel="Placeholder Text"
+                                        fieldDescription="Placeholder text for the search input."
+                                        name="./placeholder"/>
+                                </items>
+                            </column>
+                        </items>
+                    </searchBehavior>
+                    <aiSearchMode
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="AI Search Mode"
+                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <column
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <aiSearchModeEnabled
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                        text="Show AI Mode tab to visitors"
+                                        fieldDescription="When unchecked, no tab bar is shown and the generative-search API is never called — visitors see only a plain Search Results view."
+                                        name="./aiSearchModeEnabled"
+                                        checked="{Boolean}true"
+                                        value="{Boolean}true"
+                                        uncheckedValue="{Boolean}false"/>
+                                    <genSearchErrorRetryVisible
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                        text="Show retry button when AI answer fails"
+                                        fieldDescription="The AI Mode tab always shows an error message on failure; this controls only whether a retry button is shown alongside it."
+                                        name="./genSearchErrorRetryVisible"
+                                        checked="{Boolean}true"
+                                        value="{Boolean}true"
+                                        uncheckedValue="{Boolean}false"/>
+                                    <disclaimerText
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/textarea"
+                                        fieldLabel="Disclaimer Text"
+                                        fieldDescription="Shown below the generative summary in the AI Mode tab. Leave empty to use the default disclaimer."
+                                        name="./disclaimerText"/>
+                                </items>
+                            </column>
+                        </items>
+                    </aiSearchMode>
+                </items>
+            </tabs>
+        </items>
+    </content>
+</jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:folder"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/editor/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/editor/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[core.wcm.components.contentaisearch.v2.editor]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/editor/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/editor/js.txt
@@ -1,0 +1,3 @@
+#base=js
+
+contentaisearch.js

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/editor/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/editor/js.txt
@@ -1,3 +1,19 @@
+###############################################################################
+# Copyright 2026 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
 #base=js
 
 contentaisearch.js

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/editor/js/contentaisearch.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/editor/js/contentaisearch.js
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright 2026 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+(function(window, $, channel, Granite, Coral) {
+    "use strict";
+
+    var CLASS_EDIT_DIALOG = "cmp-contentaisearch__editor";
+    var SELECTOR_CONTENT_SOURCE_TYPE = "coral-select[name='./contentSourceType']";
+    var SELECTOR_CONTENT_SOURCES = "coral-select[name='./contentSources']";
+
+    /**
+     * Refreshes the content sources dropdown when the content source type changes.
+     *
+     * @param {HTMLElement} dialog - the edit dialog root element
+     */
+    function initialize(dialog) {
+        var contentSourceTypeField = dialog.querySelector(SELECTOR_CONTENT_SOURCE_TYPE);
+        var contentSourcesField = dialog.querySelector(SELECTOR_CONTENT_SOURCES);
+
+        if (!contentSourceTypeField || !contentSourcesField || !contentSourcesField.dataset.cmpFieldPath) {
+            return;
+        }
+
+        $(contentSourceTypeField).on("foundation-field-change", function() {
+            refreshContentSources(contentSourcesField, contentSourceTypeField.value);
+        });
+    }
+
+    /**
+     * Loads datasource options for the selected content source type.
+     *
+     * @param {Coral.Select} contentSourcesField - the multi-select field to update
+     * @param {String} contentSourceType - selected content source type
+     */
+    function refreshContentSources(contentSourcesField, contentSourceType) {
+        var url = Granite.HTTP.externalize(contentSourcesField.dataset.cmpFieldPath) + ".html";
+
+        $.get({
+            url: url,
+            data: {
+                contentSourceType: contentSourceType
+            }
+        }).done(function(html) {
+            var doc = new DOMParser().parseFromString(html, "text/html");
+            var items = doc.querySelectorAll("coral-select-item");
+            var selectedValues = contentSourcesField.values || [];
+
+            contentSourcesField.items.clear();
+            items.forEach(function(item) {
+                var label = (item.innerText || item.textContent || "").trim();
+                contentSourcesField.items.add({
+                    value: item.value,
+                    content: {
+                        textContent: label || item.value
+                    },
+                    selected: selectedValues.indexOf(item.value) !== -1
+                });
+            });
+        });
+    }
+
+    channel.on("foundation-contentloaded", function(e) {
+        if (e.target.getElementsByClassName(CLASS_EDIT_DIALOG).length > 0) {
+            Coral.commons.ready(e.target, function(dialog) {
+                initialize(dialog);
+            });
+        }
+    });
+
+})(window, jQuery, jQuery(document), Granite, Coral);

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[core.wcm.components.contentaisearch.v2]"
+    dependencies="[core.wcm.components.commons.site]"
+    embed="[]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css.txt
@@ -1,0 +1,3 @@
+#base=css
+
+contentaisearch.less

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css.txt
@@ -1,3 +1,19 @@
+###############################################################################
+# Copyright 2026 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
 #base=css
 
 contentaisearch.less

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css/contentaisearch.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css/contentaisearch.less
@@ -425,6 +425,15 @@
         -webkit-box-orient: vertical;
         -webkit-line-clamp: 4;
         line-clamp: 4;
+
+        // A plain [hidden] attribute wouldn't hide this on its own: our own
+        // "display: -webkit-box" above is an author-origin rule, which always beats
+        // the user-agent stylesheet's "[hidden] { display: none }" default regardless
+        // of selector specificity. Overriding it explicitly here (this compound
+        // selector outranks the base rule above via specificity) is required.
+        &[hidden] {
+            display: none;
+        }
     }
 
     &--list &__item {
@@ -477,6 +486,12 @@
         -webkit-box-orient: vertical;
         -webkit-line-clamp: 2;
         line-clamp: 2;
+
+        // See the matching &[hidden] rule on __card-description above for why this
+        // is needed - a bare [hidden] attribute alone won't hide this element.
+        &[hidden] {
+            display: none;
+        }
     }
 }
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css/contentaisearch.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css/contentaisearch.less
@@ -1,0 +1,509 @@
+/*******************************************************************************
+ * Copyright 2026 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+@summary-accent: #5b2be0;
+@summary-bg: #f4f2ef;
+@card-border: #e2e0dc;
+@text-muted: #666;
+
+.cmp-contentaisearch {
+    position: relative;
+
+    &__field {
+        position: relative;
+        height: 2rem;
+    }
+
+    &__input {
+        box-sizing: border-box;
+        margin: 0;
+        padding-left: 2rem;
+        padding-right: 2rem;
+        height: 100%;
+        width: 100%;
+        border: 1px solid #ccc;
+        border-radius: 0;
+        background-color: #fff;
+        font: inherit;
+        line-height: 1.15;
+
+        &::placeholder {
+            color: #767676;
+        }
+
+        &:focus {
+            outline: .125rem solid #1473e6;
+            outline-offset: -1px;
+        }
+    }
+
+    &__input-label {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
+
+    &__icon {
+        display: block;
+        position: absolute;
+        left: .5rem;
+        top: .5rem;
+        background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxNi4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB3aWR0aD0iMTE1MnB4IiBoZWlnaHQ9IjExNTJweCIgdmlld0JveD0iMCAwIDExNTIgMTE1MiIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMTE1MiAxMTUyIiB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxwYXRoIGQ9Ik02NzIsMEM0MDYuOTAzLDAsMTkyLDIxNC45MDMsMTkyLDQ4MGMwLDk1LjcsMjguMDExLDE4NC44NTUsNzYuMjc1LDI1OS43MjVDMTgxLjY0Niw4MjYuMzU0LDQ4LjA3NSw5NTkuOTI1LDM2LDk3Mg0KCWMtMTgsMTgtMzYsMzYtMzYsNzJzMTgsNTQsMzYsNzJzMzYuMDEyLDM2LDcyLDM2czU0LTE4LDcyLTM2YzEyLjA3NS0xMi4wNzUsMTQ1LjY0Ni0xNDUuNjQ2LDIzMi4yNzUtMjMyLjI3NQ0KCUM0ODcuMTQ0LDkzMS45ODgsNTc2LjMsOTYwLDY3Miw5NjBjMjY1LjA5NywwLDQ4MC0yMTQuOTAzLDQ4MC00ODBDMTE1MiwyMTQuOTAzLDkzNy4wOTcsMCw2NzIsMHogTTY3Miw4MTYNCgljLTE4NS41NjgsMC0zMzYtMTUwLjQzMy0zMzYtMzM2YzAtMTg1LjU2OCwxNTAuNDMyLTMzNiwzMzYtMzM2YzE4NS41NjcsMCwzMzYsMTUwLjQzMiwzMzYsMzM2QzEwMDgsNjY1LjU2Nyw4NTcuNTY3LDgxNiw2NzIsODE2eiINCgkvPg0KPC9zdmc+DQo=");
+        background-size: contain;
+        width: 1rem;
+        height: 1rem;
+        pointer-events: none;
+    }
+
+    &__loading-indicator {
+        display: none;
+        position: absolute;
+        top: .5rem;
+        left: .5rem;
+        border: 3px solid #ccc;
+        border-top-color: #333;
+        border-radius: 50%;
+        width: 1rem;
+        height: 1rem;
+        animation: cmp-contentaisearch__loading-indicator-spin 2s linear infinite;
+    }
+
+    &__clear {
+        display: none;
+        margin: 0;
+        padding: 0;
+        border: none;
+        background: transparent;
+    }
+
+    &__clear-icon {
+        position: absolute;
+        top: .5rem;
+        right: .5rem;
+        background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxOS4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB3aWR0aD0iMTE1MnB4IiBoZWlnaHQ9IjExNTJweCIgdmlld0JveD0iMCAwIDExNTIgMTE1MiIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMTE1MiAxMTUyIiB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxwYXRoIGlkPSJYTUxJRF85XyIgZD0iTTgyLjYsOTM3LjJsMzYyLTM2Mkw4NCwyMTQuOGMtMTQuMS0xNC4xLTE0LjEtMzYuOSwwLTUxbDgxLjItODEuMmMxNC4xLTE0LjEsMzYuOS0xNC4xLDUxLDBsMzYwLjUsMzYwLjUNCglMOTM3LjIsODIuNmMxNC4xLTE0LjEsMzYuOS0xNC4xLDUxLDBsODEuMiw4MS4yYzE0LjEsMTQuMSwxNC4xLDM2LjksMCw1MUw3MDguOSw1NzUuM2wzNjAuNSwzNjAuNWMxNC4xLDE0LjEsMTQuMSwzNi45LDAsNTENCglsLTgxLjIsODEuMmMtMTQuMSwxNC4xLTM2LjksMTQuMS01MSwwTDU3Ni43LDcwNy41bC0zNjIsMzYyYy0xNC4xLDE0LjEtMzYuOSwxNC4xLTUxLDBsLTgxLjItODEuMg0KCUM2OC41LDk3NC4yLDY4LjUsOTUxLjMsODIuNiw5MzcuMnoiLz4NCjwvc3ZnPg0K");
+        background-size: contain;
+        width: 1rem;
+        height: 1rem;
+    }
+
+    &__tabs {
+        display: flex;
+        gap: .25rem;
+        margin-top: .75rem;
+        border-bottom: 1px solid @card-border;
+    }
+
+    &__tab {
+        margin: 0 0 -1px;
+        padding: .5em 1em;
+        border: 1px solid transparent;
+        border-bottom: none;
+        border-radius: 6px 6px 0 0;
+        background: transparent;
+        font-size: .875rem;
+        font-weight: 600;
+        color: @text-muted;
+        cursor: pointer;
+
+        &[aria-selected="true"] {
+            border-color: @card-border;
+            background: #fff;
+            color: @summary-accent;
+        }
+
+        &:focus-visible {
+            outline: .125rem solid #1473e6;
+            outline-offset: .125rem;
+        }
+    }
+
+    &__panel {
+        &[hidden] {
+            display: none;
+        }
+    }
+
+    &__summary-loading {
+        margin: 1.25em 0;
+
+        &[hidden] {
+            display: none;
+        }
+    }
+
+    &__summary-loading-content {
+        display: flex;
+        align-items: center;
+        gap: .75em;
+        min-height: 3rem;
+    }
+
+    &__summary-loading-indicator {
+        flex-shrink: 0;
+        border: 3px solid #ccc;
+        border-top-color: @summary-accent;
+        border-radius: 50%;
+        width: 1.5rem;
+        height: 1.5rem;
+        animation: cmp-contentaisearch__loading-indicator-spin 2s linear infinite;
+    }
+
+    &__summary-loading-text {
+        margin: 0;
+        font-size: .875rem;
+        color: @text-muted;
+    }
+
+    &__summary {
+        margin: 1.25em 0;
+    }
+
+    &__summary:not([hidden]), &__summary-loading:not([hidden]) {
+        animation: cmp-contentaisearch__fade-in 400ms ease-out;
+    }
+
+    &__summary-card {
+        padding: 1.25em 1.5em;
+        border-radius: 12px;
+        background: @summary-bg;
+        border: 1px solid @card-border;
+    }
+
+    &__summary-header {
+        display: flex;
+        align-items: flex-start;
+        gap: .75em;
+        margin-bottom: 1em;
+    }
+
+    &__summary-icon {
+        flex-shrink: 0;
+        width: 2rem;
+        height: 2rem;
+        border-radius: 50%;
+        background: @summary-accent;
+        position: relative;
+
+        &:before {
+            content: "✦";
+            position: absolute;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #fff;
+            font-size: .875rem;
+        }
+    }
+
+    &__summary-title {
+        margin: 0;
+        font-size: .75rem;
+        font-weight: 700;
+        letter-spacing: .08em;
+        text-transform: uppercase;
+        color: @summary-accent;
+    }
+
+    &__summary-attribution {
+        margin: .15em 0 0;
+        font-size: .75rem;
+        color: @text-muted;
+    }
+
+    &__summary-text {
+        margin: 0 0 1em;
+        line-height: 1.6;
+
+        p { /* stylelint-disable-line selector-max-type */
+            margin: 0 0 .75em;
+        }
+
+        ul { /* stylelint-disable-line selector-max-type */
+            margin: 0 0 .75em;
+            padding-left: 1.25em;
+        }
+
+        li { /* stylelint-disable-line selector-max-type */
+            margin: 0 0 .35em;
+        }
+
+        strong { /* stylelint-disable-line selector-max-type */
+            font-weight: 700;
+        }
+
+        a { /* stylelint-disable-line selector-max-type */
+            color: @summary-accent;
+            text-decoration: underline;
+        }
+    }
+
+    &__sources-section {
+        border-top: 1px solid @card-border;
+        padding-top: .75em;
+    }
+
+    &__sources-label {
+        margin: 0 0 .5em;
+        font-size: .6875rem;
+        font-weight: 700;
+        letter-spacing: .08em;
+        text-transform: uppercase;
+        color: @text-muted;
+    }
+
+    &__sources {
+        display: flex;
+        flex-wrap: wrap;
+        gap: .5em;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    &__source-chip {
+        display: inline-block;
+        padding: .35em .75em;
+        border-radius: 999px;
+        background: #fff;
+        border: 1px solid @card-border;
+        font-size: .8125rem;
+        text-decoration: none;
+        color: inherit;
+
+        &:hover {
+            border-color: @summary-accent;
+            color: @summary-accent;
+        }
+    }
+
+    &__disclaimer {
+        margin: 1em 0 0;
+        font-size: .75rem;
+        color: @text-muted;
+    }
+
+    &__error {
+        margin: 1em 0;
+        color: #b00;
+    }
+
+    &__results-section {
+        margin-top: 1.5em;
+    }
+
+    &__results-toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: flex-end;
+        gap: .75em;
+        margin-bottom: 1em;
+    }
+
+    &__layout-toggle {
+        display: inline-flex;
+        border: 1px solid @card-border;
+        border-radius: 6px;
+        overflow: hidden;
+    }
+
+    &__layout-btn {
+        margin: 0;
+        padding: .35em .75em;
+        border: 0;
+        background: #fff;
+        font-size: .8125rem;
+        cursor: pointer;
+        color: inherit;
+
+        &[aria-pressed="true"] {
+            background: @summary-accent;
+            color: #fff;
+        }
+    }
+
+    &__load-more {
+        display: block;
+        margin: 1em auto 0;
+        padding: .4em .9em;
+        border: 1px solid @card-border;
+        border-radius: 6px;
+        background: #fff;
+        font-size: .875rem;
+        cursor: pointer;
+
+        &:disabled {
+            opacity: .45;
+            cursor: not-allowed;
+        }
+    }
+
+    &__results {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    &__results--refresh {
+        animation: cmp-contentaisearch__fade-in 320ms ease-out;
+    }
+
+    &--card &__results {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+        gap: 1rem;
+        width: 100%;
+    }
+
+    &--list &__results {
+        display: block;
+    }
+
+    &__item {
+        margin: 0;
+    }
+
+    &__card {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        border: 1px solid @card-border;
+        border-radius: 10px;
+        overflow: hidden;
+        background: #fff;
+        text-decoration: none;
+        color: inherit;
+        transition: box-shadow .15s ease;
+
+        &:hover {
+            box-shadow: 0 4px 16px rgba(0, 0, 0, .08);
+        }
+    }
+
+    &__card-image {
+        width: 100%;
+        height: 7rem;
+        object-fit: cover;
+        background: #eceae6;
+
+        &--placeholder {
+            display: block;
+        }
+    }
+
+    &__card-body {
+        padding: .75em;
+        display: flex;
+        flex-direction: column;
+        gap: .35em;
+        flex: 1;
+    }
+
+    &__card-title {
+        margin: 0;
+        font-size: .9375rem;
+        font-weight: 700;
+        line-height: 1.35;
+    }
+
+    &__card-description {
+        margin: 0;
+        font-size: .8125rem;
+        line-height: 1.45;
+        color: @text-muted;
+        overflow: hidden;
+
+        /* stylelint-disable-next-line value-no-vendor-prefix */
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+        line-clamp: 3;
+    }
+
+    &--list &__item {
+        border-bottom: 1px solid @card-border;
+        padding: 1em 0;
+    }
+
+    &__row {
+        display: flex;
+        gap: 1em;
+        text-decoration: none;
+        color: inherit;
+    }
+
+    &__row-image {
+        flex-shrink: 0;
+        width: 5rem;
+        height: 3.5rem;
+        object-fit: cover;
+        border-radius: 6px;
+        background: #eceae6;
+    }
+
+    &__row-body {
+        flex: 1;
+        min-width: 0;
+    }
+
+    &__row-title {
+        margin: 0 0 .35em;
+        font-size: 1rem;
+        font-weight: 700;
+        line-height: 1.35;
+    }
+
+    &__row:hover &__row-title {
+        color: @summary-accent;
+    }
+
+    &__row-description {
+        margin: 0;
+        font-size: .875rem;
+        line-height: 1.5;
+        color: @text-muted;
+        overflow: hidden;
+
+        /* stylelint-disable-next-line value-no-vendor-prefix */
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+        line-clamp: 3;
+    }
+}
+
+@keyframes cmp-contentaisearch__loading-indicator-spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+@keyframes cmp-contentaisearch__fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(-6px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css/contentaisearch.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css/contentaisearch.less
@@ -73,19 +73,6 @@
         pointer-events: none;
     }
 
-    &__loading-indicator {
-        display: none;
-        position: absolute;
-        top: .5rem;
-        left: .5rem;
-        border: 3px solid #ccc;
-        border-top-color: #333;
-        border-radius: 50%;
-        width: 1rem;
-        height: 1rem;
-        animation: cmp-contentaisearch__loading-indicator-spin 2s linear infinite;
-    }
-
     &__clear {
         display: none;
         margin: 0;

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css/contentaisearch.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css/contentaisearch.less
@@ -470,12 +470,13 @@
         line-height: 1.5;
         color: @text-muted;
         overflow: hidden;
+        text-overflow: ellipsis;
 
         /* stylelint-disable-next-line value-no-vendor-prefix */
         display: -webkit-box;
         -webkit-box-orient: vertical;
-        -webkit-line-clamp: 3;
-        line-clamp: 3;
+        -webkit-line-clamp: 2;
+        line-clamp: 2;
     }
 }
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css/contentaisearch.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/css/contentaisearch.less
@@ -418,12 +418,13 @@
         line-height: 1.45;
         color: @text-muted;
         overflow: hidden;
+        text-overflow: ellipsis;
 
         /* stylelint-disable-next-line value-no-vendor-prefix */
         display: -webkit-box;
         -webkit-box-orient: vertical;
-        -webkit-line-clamp: 3;
-        line-clamp: 3;
+        -webkit-line-clamp: 4;
+        line-clamp: 4;
     }
 
     &--list &__item {

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js.txt
@@ -1,0 +1,3 @@
+#base=js
+
+contentaisearch.js

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js.txt
@@ -1,3 +1,19 @@
+###############################################################################
+# Copyright 2026 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
 #base=js
 
 contentaisearch.js

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
@@ -229,6 +229,12 @@
 
     ContentAISearch.prototype._onInput = function() {
         this._syncClearButton();
+        // Backspacing a query down to empty (without submitting or hitting the
+        // explicit clear button) should also clear stale results/summary - otherwise
+        // an emptied field is left showing results for whatever was last submitted.
+        if (!this._elements.input.value) {
+            this._clearResults();
+        }
     };
 
     ContentAISearch.prototype._onFormSubmit = function(event) {

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
@@ -67,7 +67,12 @@
         this._element = element;
         this._cacheElements();
         this._resourcePath = this._resolveResourcePath();
-        this._aiSearchModeEnabled = this._element.getAttribute("data-cmp-ai-search-mode-enabled") === "true";
+        // Sightly renders boolean-typed attributes as bare (present when true, omitted
+        // when false) rather than as the literal string "true" - hasAttribute is the
+        // correct read here, matching the convention used elsewhere in this codebase
+        // (e.g. data-cmp-data-layer-enabled), not a getAttribute() === "true" string
+        // comparison, which would always evaluate to false against real HTL output.
+        this._aiSearchModeEnabled = this._element.hasAttribute("data-cmp-ai-search-mode-enabled");
         this._resultsLayout = this._element.getAttribute("data-cmp-results-layout") === "list" ? "list" : "card";
         this._revealTimer = null;
         this._currentQuery = "";
@@ -243,8 +248,6 @@
             this._elements.input.value = "";
         }
         toggleShow(this._elements.clear, false);
-        toggleShow(this._elements.loadingIndicator, false);
-        toggleShow(this._elements.icon, true);
         this._clearResults();
     };
 
@@ -302,13 +305,6 @@
         toggleShow(this._elements.summary, false);
         toggleShow(this._elements.summaryLoading, false);
         toggleShow(this._elements.error, false);
-        toggleShow(this._elements.loadingIndicator, false);
-        toggleShow(this._elements.icon, true);
-    };
-
-    ContentAISearch.prototype._setFieldLoading = function(loading) {
-        toggleShow(this._elements.loadingIndicator, loading);
-        toggleShow(this._elements.icon, !loading);
     };
 
     ContentAISearch.prototype._setSummaryLoading = function(show) {
@@ -336,10 +332,8 @@
 
     ContentAISearch.prototype._runResultsSearch = function(query) {
         var self = this;
-        var searchStart = Date.now();
         var requestId = ++this._resultsRequestId;
         this._pendingResultsQuery = query;
-        this._setFieldLoading(true);
         var url = this._resourcePath + ".search.json?q=" + encodeURIComponent(query);
         this._fetchJson(url)
             .then(function(data) {
@@ -367,11 +361,6 @@
                     return;
                 }
                 self._pendingResultsQuery = null;
-                var elapsed = Date.now() - searchStart;
-                var delay = Math.max(0, LOADING_DISPLAY_DELAY - elapsed);
-                setTimeout(function() {
-                    self._setFieldLoading(false);
-                }, delay);
             });
     };
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
@@ -60,7 +60,7 @@
     function setCookie(name, value) {
         var oneYearSeconds = 365 * 24 * 60 * 60;
         document.cookie = name + "=" + encodeURIComponent(value) +
-            "; path=/; max-age=" + oneYearSeconds + "; SameSite=Lax";
+            "; path=/; max-age=" + oneYearSeconds + "; SameSite=Lax; Secure";
     }
 
     function ContentAISearch(element) {

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
@@ -51,6 +51,7 @@
         }
     }
 
+    // eslint-disable-next-line no-unused-vars
     function getCookie(name) {
         var match = document.cookie.match(new RegExp("(?:^|; )" + name + "=([^;]*)"));
         return match ? decodeURIComponent(match[1]) : null;

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
@@ -576,10 +576,15 @@
         if (descriptionNode) {
             if (description) {
                 descriptionNode.textContent = description;
-                toggleShow(descriptionNode, true);
+                // Not toggleShow(): it sets an inline style="display: block", which
+                // (being more specific than a stylesheet class rule) would permanently
+                // clobber the __card-description/__row-description CSS's
+                // "display: -webkit-box", silently breaking the line-clamp truncation.
+                // Just clearing "hidden" lets that stylesheet display value apply.
+                descriptionNode.removeAttribute("hidden");
             } else {
                 descriptionNode.textContent = "";
-                toggleShow(descriptionNode, false);
+                descriptionNode.setAttribute("hidden", "hidden");
             }
         }
         if (imageNode && placeholderNode) {

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
@@ -1,0 +1,835 @@
+/*******************************************************************************
+ * Copyright 2026 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+(function() {
+    "use strict";
+
+    var NS = "cmp";
+    var IS = "contentaisearch";
+    var LOADING_DISPLAY_DELAY = 300;
+    var REVEAL_WORD_INTERVAL_MS = 12;
+    var TAB_COOKIE_NAME = "cmp-contentaisearch-tab";
+    var TAB_RESULTS = "search-results";
+    var TAB_AI = "ai-mode";
+
+    var selectors = {
+        self: "[data-" + NS + '-is="' + IS + '"]',
+        item: {
+            self: "[data-" + NS + "-hook-" + IS + '="item"]',
+            title: "[data-" + NS + "-hook-" + IS + '="itemTitle"]',
+            description: "[data-" + NS + "-hook-" + IS + '="itemDescription"]',
+            image: "[data-" + NS + "-hook-" + IS + '="itemImage"]',
+            imagePlaceholder: "[data-" + NS + "-hook-" + IS + '="itemImagePlaceholder"]'
+        },
+        source: {
+            link: "[data-" + NS + "-hook-" + IS + '="sourceLink"]',
+            text: "[data-" + NS + "-hook-" + IS + '="sourceText"]'
+        }
+    };
+
+    function toggleShow(element, show) {
+        if (element) {
+            if (show !== false) {
+                element.style.display = "block";
+                element.removeAttribute("hidden");
+            } else {
+                element.style.display = "none";
+                element.setAttribute("hidden", "hidden");
+            }
+        }
+    }
+
+    function getCookie(name) {
+        var match = document.cookie.match(new RegExp("(?:^|; )" + name + "=([^;]*)"));
+        return match ? decodeURIComponent(match[1]) : null;
+    }
+
+    function setCookie(name, value) {
+        var oneYearSeconds = 365 * 24 * 60 * 60;
+        document.cookie = name + "=" + encodeURIComponent(value) +
+            "; path=/; max-age=" + oneYearSeconds + "; SameSite=Lax";
+    }
+
+    function ContentAISearch(element) {
+        this._element = element;
+        this._cacheElements();
+        this._resourcePath = this._resolveResourcePath();
+        this._aiSearchModeEnabled = this._element.getAttribute("data-cmp-ai-search-mode-enabled") === "true";
+        this._resultsLayout = this._element.getAttribute("data-cmp-results-layout") === "list" ? "list" : "card";
+        this._i18n = this._parseI18n();
+        this._revealTimer = null;
+        this._currentQuery = "";
+        this._allResults = [];
+        this._hasMore = false;
+        this._sourceCursors = {};
+        this._resultsRequestId = 0;
+        this._genSearchRequestId = 0;
+        this._pendingResultsQuery = null;
+        this._pendingGenSearchQuery = null;
+        this._activeTab = TAB_RESULTS;
+
+        this._applyLayoutClass();
+        this._syncLayoutButtons();
+        if (this._aiSearchModeEnabled) {
+            this._syncActiveTabFromDom();
+        }
+
+        if (this._elements.input) {
+            this._elements.input.addEventListener("input", this._onInput.bind(this));
+        }
+        if (this._elements.clear) {
+            this._elements.clear.addEventListener("click", this._onClearClick.bind(this));
+        }
+        if (this._elements.retry) {
+            this._elements.retry.addEventListener("click", this._onRetry.bind(this));
+        }
+        if (this._elements.layoutCard) {
+            this._elements.layoutCard.addEventListener("click", this._onLayoutCard.bind(this));
+        }
+        if (this._elements.layoutList) {
+            this._elements.layoutList.addEventListener("click", this._onLayoutList.bind(this));
+        }
+        if (this._elements.loadMore) {
+            this._elements.loadMore.addEventListener("click", this._onLoadMore.bind(this));
+        }
+        if (this._elements.form) {
+            this._elements.form.addEventListener("submit", this._onFormSubmit.bind(this));
+        }
+        if (this._elements.tabSearchResults) {
+            this._elements.tabSearchResults.addEventListener("click", this._onTabResultsClick.bind(this));
+            this._elements.tabSearchResults.addEventListener("keydown", this._onTabKeydown.bind(this));
+        }
+        if (this._elements.tabAiMode) {
+            this._elements.tabAiMode.addEventListener("click", this._onTabAiClick.bind(this));
+            this._elements.tabAiMode.addEventListener("keydown", this._onTabKeydown.bind(this));
+        }
+    }
+
+    ContentAISearch.prototype._parseI18n = function() {
+        var raw = this._element.getAttribute("data-i18n-messages");
+        if (!raw) {
+            return {};
+        }
+        try {
+            return JSON.parse(raw);
+        } catch (e) {
+            return {};
+        }
+    };
+
+    ContentAISearch.prototype._cacheElements = function() {
+        this._elements = {};
+        var hooks = this._element.querySelectorAll("[data-" + NS + "-hook-" + IS + "]");
+        for (var i = 0; i < hooks.length; i++) {
+            var hook = hooks[i];
+            var key = hook.dataset[NS + "Hook" + IS.charAt(0).toUpperCase() + IS.slice(1)];
+            this._elements[key] = hook;
+        }
+    };
+
+    ContentAISearch.prototype._resolveResourcePath = function() {
+        return this._element.getAttribute("data-cmp-resource-path");
+    };
+
+    ContentAISearch.prototype._applyLayoutClass = function() {
+        this._element.classList.remove("cmp-contentaisearch--card", "cmp-contentaisearch--list");
+        this._element.classList.add(this._resultsLayout === "list" ? "cmp-contentaisearch--list" : "cmp-contentaisearch--card");
+    };
+
+    ContentAISearch.prototype._syncLayoutButtons = function() {
+        var isList = this._resultsLayout === "list";
+        if (this._elements.layoutCard) {
+            this._elements.layoutCard.setAttribute("aria-pressed", isList ? "false" : "true");
+        }
+        if (this._elements.layoutList) {
+            this._elements.layoutList.setAttribute("aria-pressed", isList ? "true" : "false");
+        }
+    };
+
+    ContentAISearch.prototype._getActiveItemTemplate = function() {
+        return this._resultsLayout === "list" ? this._elements.itemTemplateList : this._elements.itemTemplateCard;
+    };
+
+    ContentAISearch.prototype._onLayoutCard = function() {
+        if (this._resultsLayout === "card") {
+            return;
+        }
+        this._resultsLayout = "card";
+        this._applyLayoutClass();
+        this._syncLayoutButtons();
+        this._renderResults();
+    };
+
+    ContentAISearch.prototype._onLayoutList = function() {
+        if (this._resultsLayout === "list") {
+            return;
+        }
+        this._resultsLayout = "list";
+        this._applyLayoutClass();
+        this._syncLayoutButtons();
+        this._renderResults();
+    };
+
+    // Reads whatever the HTL's synchronous pre-paint script already applied to the
+    // DOM (aria-selected on the AI Mode tab) rather than re-reading the cookie here -
+    // a single source of truth for "what's the initial tab" instead of two places
+    // that could disagree.
+    ContentAISearch.prototype._syncActiveTabFromDom = function() {
+        if (this._elements.tabAiMode && this._elements.tabAiMode.getAttribute("aria-selected") === "true") {
+            this._activeTab = TAB_AI;
+        }
+    };
+
+    ContentAISearch.prototype._onTabResultsClick = function() {
+        this._activateTab(TAB_RESULTS, true);
+    };
+
+    ContentAISearch.prototype._onTabAiClick = function() {
+        this._activateTab(TAB_AI, true);
+    };
+
+    ContentAISearch.prototype._onTabKeydown = function(event) {
+        if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+            return;
+        }
+        event.preventDefault();
+        var next = this._activeTab === TAB_RESULTS ? TAB_AI : TAB_RESULTS;
+        this._activateTab(next, true);
+        var nextElement = next === TAB_AI ? this._elements.tabAiMode : this._elements.tabSearchResults;
+        if (nextElement) {
+            nextElement.focus();
+        }
+    };
+
+    ContentAISearch.prototype._activateTab = function(tab, persist) {
+        if (tab === this._activeTab) {
+            return;
+        }
+        this._activeTab = tab;
+        var showAi = tab === TAB_AI;
+
+        if (this._elements.tabAiMode) {
+            this._elements.tabAiMode.setAttribute("aria-selected", showAi ? "true" : "false");
+            this._elements.tabAiMode.setAttribute("tabindex", showAi ? "0" : "-1");
+        }
+        if (this._elements.tabSearchResults) {
+            this._elements.tabSearchResults.setAttribute("aria-selected", showAi ? "false" : "true");
+            this._elements.tabSearchResults.setAttribute("tabindex", showAi ? "-1" : "0");
+        }
+        toggleShow(this._elements.panelAiMode, showAi);
+        toggleShow(this._elements.panelSearchResults, !showAi);
+
+        if (persist) {
+            setCookie(TAB_COOKIE_NAME, tab);
+        }
+    };
+
+    ContentAISearch.prototype._onInput = function() {
+        this._syncClearButton();
+    };
+
+    ContentAISearch.prototype._onFormSubmit = function(event) {
+        event.preventDefault();
+        this._runQuery();
+    };
+
+    ContentAISearch.prototype._syncClearButton = function() {
+        var hasValue = this._elements.input && this._elements.input.value.length > 0;
+        toggleShow(this._elements.clear, hasValue);
+    };
+
+    ContentAISearch.prototype._onClearClick = function() {
+        if (this._elements.input) {
+            this._elements.input.value = "";
+        }
+        toggleShow(this._elements.clear, false);
+        toggleShow(this._elements.loadingIndicator, false);
+        toggleShow(this._elements.icon, true);
+        this._clearResults();
+    };
+
+    ContentAISearch.prototype._onLoadMore = function() {
+        this._runLoadMore();
+    };
+
+    ContentAISearch.prototype._onRetry = function() {
+        var query = this._elements.input.value;
+        if (this._pendingGenSearchQuery === query) {
+            return;
+        }
+        this._runGenSearch(query);
+    };
+
+    ContentAISearch.prototype._runQuery = function() {
+        var query = this._elements.input.value;
+        if (!query) {
+            this._currentQuery = query;
+            this._clearResults();
+            return;
+        }
+        if (query === this._currentQuery &&
+            (this._pendingResultsQuery === query || this._pendingGenSearchQuery === query)) {
+            return;
+        }
+        this._currentQuery = query;
+        this._runResultsSearch(query);
+        if (this._aiSearchModeEnabled) {
+            this._runGenSearch(query);
+        }
+    };
+
+    ContentAISearch.prototype._clearResults = function() {
+        this._currentQuery = "";
+        this._allResults = [];
+        this._hasMore = false;
+        this._sourceCursors = {};
+        this._resultsRequestId++;
+        this._genSearchRequestId++;
+        this._pendingResultsQuery = null;
+        this._pendingGenSearchQuery = null;
+        if (this._revealTimer) {
+            clearTimeout(this._revealTimer);
+            this._revealTimer = null;
+        }
+        if (this._elements.sources) {
+            this._elements.sources.style.visibility = "";
+        }
+        if (this._elements.results) {
+            this._elements.results.innerHTML = "";
+        }
+        toggleShow(this._elements.resultsSection, false);
+        toggleShow(this._elements.loadMore, false);
+        toggleShow(this._elements.summary, false);
+        toggleShow(this._elements.summaryLoading, false);
+        toggleShow(this._elements.error, false);
+        toggleShow(this._elements.loadingIndicator, false);
+        toggleShow(this._elements.icon, true);
+    };
+
+    ContentAISearch.prototype._setFieldLoading = function(loading) {
+        toggleShow(this._elements.loadingIndicator, loading);
+        toggleShow(this._elements.icon, !loading);
+    };
+
+    ContentAISearch.prototype._setSummaryLoading = function(show) {
+        toggleShow(this._elements.summaryLoading, show);
+        if (this._elements.summaryLoading) {
+            if (show) {
+                this._elements.summaryLoading.setAttribute("aria-busy", "true");
+            } else {
+                this._elements.summaryLoading.removeAttribute("aria-busy");
+            }
+        }
+    };
+
+    ContentAISearch.prototype._hideSummaryLoading = function(startTime, callback) {
+        var elapsed = Date.now() - startTime;
+        var delay = Math.max(0, LOADING_DISPLAY_DELAY - elapsed);
+        var self = this;
+        setTimeout(function() {
+            self._setSummaryLoading(false);
+            if (callback) {
+                callback();
+            }
+        }, delay);
+    };
+
+    ContentAISearch.prototype._runResultsSearch = function(query) {
+        var self = this;
+        var searchStart = Date.now();
+        var requestId = ++this._resultsRequestId;
+        this._pendingResultsQuery = query;
+        this._setFieldLoading(true);
+        var url = this._resourcePath + ".search.json?q=" + encodeURIComponent(query);
+        this._fetchJson(url)
+            .then(function(data) {
+                if (requestId !== self._resultsRequestId) {
+                    return;
+                }
+                self._storeResults(data);
+                self._renderResults();
+            })
+            .catch(function() {
+                if (requestId !== self._resultsRequestId) {
+                    return;
+                }
+                self._allResults = [];
+                self._hasMore = false;
+                self._sourceCursors = {};
+                if (self._elements.results) {
+                    self._elements.results.innerHTML = "";
+                }
+                toggleShow(self._elements.resultsSection, false);
+                toggleShow(self._elements.loadMore, false);
+            })
+            .then(function() {
+                if (requestId !== self._resultsRequestId) {
+                    return;
+                }
+                self._pendingResultsQuery = null;
+                var elapsed = Date.now() - searchStart;
+                var delay = Math.max(0, LOADING_DISPLAY_DELAY - elapsed);
+                setTimeout(function() {
+                    self._setFieldLoading(false);
+                }, delay);
+            });
+    };
+
+    ContentAISearch.prototype._storeResults = function(data, append) {
+        var results = (data && data.results) || [];
+        if (!append) {
+            this._allResults = results;
+        } else {
+            var existingIds = {};
+            var self = this;
+            this._allResults.forEach(function(result) {
+                if (result && result.id) {
+                    existingIds[result.id] = true;
+                }
+            });
+            results.forEach(function(result) {
+                if (result && result.id && !existingIds[result.id]) {
+                    self._allResults.push(result);
+                    existingIds[result.id] = true;
+                }
+            });
+            this._allResults.sort(function(a, b) {
+                return (b.score || 0) - (a.score || 0);
+            });
+        }
+        this._hasMore = !!(data && data.hasMore);
+        this._sourceCursors = (data && data.sourceCursors) || {};
+    };
+
+    ContentAISearch.prototype._runLoadMore = function() {
+        if (!this._hasMore || !this._currentQuery) {
+            return;
+        }
+        var self = this;
+        var query = this._currentQuery;
+        var requestId = ++this._resultsRequestId;
+        if (this._elements.loadMore) {
+            this._elements.loadMore.disabled = true;
+        }
+        var url = this._resourcePath + ".search.json?q=" + encodeURIComponent(query) +
+            "&cursors=" + encodeURIComponent(JSON.stringify(this._sourceCursors));
+        this._fetchJson(url)
+            .then(function(data) {
+                if (requestId !== self._resultsRequestId) {
+                    return;
+                }
+                self._storeResults(data, true);
+                self._renderResults();
+            })
+            .catch(function() {
+                // A failed page fetch shouldn't leave "Load More" stuck disabled forever.
+            })
+            .then(function() {
+                if (requestId !== self._resultsRequestId) {
+                    return;
+                }
+                if (self._elements.loadMore) {
+                    self._elements.loadMore.disabled = false;
+                }
+            });
+    };
+
+    ContentAISearch.prototype._runGenSearch = function(query) {
+        var self = this;
+        var genSearchStart = Date.now();
+        var requestId = ++this._genSearchRequestId;
+        this._pendingGenSearchQuery = query;
+        toggleShow(this._elements.error, false);
+        toggleShow(this._elements.summary, false);
+        this._setSummaryLoading(true);
+        this._fetchJson(this._resourcePath + ".gensearch.json?q=" + encodeURIComponent(query))
+            .then(function(data) {
+                if (requestId !== self._genSearchRequestId) {
+                    return;
+                }
+                self._hideSummaryLoading(genSearchStart, function() {
+                    if (requestId !== self._genSearchRequestId) {
+                        return;
+                    }
+                    self._pendingGenSearchQuery = null;
+                    self._renderSummary(data, requestId);
+                });
+            })
+            .catch(function() {
+                if (requestId !== self._genSearchRequestId) {
+                    return;
+                }
+                self._hideSummaryLoading(genSearchStart, function() {
+                    if (requestId !== self._genSearchRequestId) {
+                        return;
+                    }
+                    self._pendingGenSearchQuery = null;
+                    toggleShow(self._elements.error, true);
+                });
+            });
+    };
+
+    ContentAISearch.prototype._fetchJson = function(url) {
+        return fetch(url).then(function(response) {
+            if (!response.ok) {
+                throw new Error("Request to " + url + " failed with status " + response.status);
+            }
+            return response.json();
+        });
+    };
+
+    ContentAISearch.prototype._getItemMetadata = function(item) {
+        return (item && item.data && item.data.metadata) || {};
+    };
+
+    function resolveMetadataUrl(metadata, fallbackUrl) {
+        var m = metadata || {};
+        return m.url || m.source || fallbackUrl || "";
+    }
+
+    ContentAISearch.prototype._resolveItemLabel = function(item) {
+        if (!item) {
+            return "";
+        }
+        var data = item.data || {};
+        var metadata = data.metadata || {};
+        if (metadata.title) {
+            return metadata.title;
+        }
+        if (data.title) {
+            return data.title;
+        }
+        if (data.name) {
+            return data.name;
+        }
+        if (metadata.description) {
+            return metadata.description;
+        }
+        if (data.text) {
+            var headingMatch = String(data.text).match(/^#\s+(.+)$/m);
+            if (headingMatch) {
+                return headingMatch[1].trim();
+            }
+        }
+        var url = resolveMetadataUrl(metadata, data.source);
+        if (url) {
+            return this._labelFromUrl(url);
+        }
+        return item.id || "";
+    };
+
+    ContentAISearch.prototype._resolveItemDescription = function(item) {
+        var metadata = this._getItemMetadata(item);
+        if (metadata.description) {
+            return metadata.description;
+        }
+        var data = (item && item.data) || {};
+        if (data.text) {
+            var text = String(data.text).replace(/^#\s+.+\n+/m, "").trim();
+            text = text.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+            text = text.replace(/[*_`#]/g, "");
+            return text;
+        }
+        return "";
+    };
+
+    ContentAISearch.prototype._resolveItemImage = function(item) {
+        var metadata = this._getItemMetadata(item);
+        var image = metadata.image;
+        if (image && this._isSafeUrl(image)) {
+            return image;
+        }
+        return "";
+    };
+
+    ContentAISearch.prototype._resolveHitLabel = function(hit) {
+        if (!hit) {
+            return "";
+        }
+        var metadata = hit.metadata || {};
+        if (metadata.title) {
+            return metadata.title;
+        }
+        var url = resolveMetadataUrl(metadata, hit.source);
+        if (url) {
+            return this._labelFromUrl(url);
+        }
+        return hit.id || "";
+    };
+
+    ContentAISearch.prototype._labelFromUrl = function(url) {
+        try {
+            var parsed = new URL(url, window.location.origin);
+            var segments = parsed.pathname.split("/").filter(Boolean);
+            if (segments.length) {
+                var slug = decodeURIComponent(segments[segments.length - 1])
+                    .replace(/\.(html?|php|aspx?)$/i, "")
+                    .replace(/[-_]+/g, " ")
+                    .trim();
+                if (slug) {
+                    return slug.replace(/\S+/g, function(word) {
+                        return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+                    });
+                }
+            }
+        } catch (e) {
+            // fall through
+        }
+        return url;
+    };
+
+    ContentAISearch.prototype._populateItemNode = function(root, item) {
+        var metadata = this._getItemMetadata(item);
+        var url = resolveMetadataUrl(metadata, item && item.data && item.data.source);
+        var title = this._resolveItemLabel(item);
+        var description = this._resolveItemDescription(item);
+        var image = this._resolveItemImage(item);
+        var itemRoot = root.querySelector(selectors.item.self);
+        var titleNode = root.querySelector(selectors.item.title);
+        var descriptionNode = root.querySelector(selectors.item.description);
+        var imageNode = root.querySelector(selectors.item.image);
+        var placeholderNode = root.querySelector(selectors.item.imagePlaceholder);
+
+        if (titleNode) {
+            titleNode.textContent = title;
+        }
+        if (descriptionNode) {
+            if (description) {
+                descriptionNode.textContent = description;
+                toggleShow(descriptionNode, true);
+            } else {
+                descriptionNode.textContent = "";
+                toggleShow(descriptionNode, false);
+            }
+        }
+        if (imageNode && placeholderNode) {
+            if (image) {
+                imageNode.setAttribute("src", image);
+                toggleShow(imageNode, true);
+                toggleShow(placeholderNode, false);
+            } else {
+                imageNode.removeAttribute("src");
+                toggleShow(imageNode, false);
+                toggleShow(placeholderNode, true);
+            }
+        }
+        if (itemRoot) {
+            if (url && this._isSafeUrl(url)) {
+                itemRoot.setAttribute("href", url);
+            } else {
+                itemRoot.removeAttribute("href");
+                if (itemRoot.tagName === "A") {
+                    var article = document.createElement(itemRoot.classList.contains("cmp-contentaisearch__row") ? "div" : "article");
+                    article.className = itemRoot.className;
+                    while (itemRoot.firstChild) {
+                        article.appendChild(itemRoot.firstChild);
+                    }
+                    itemRoot.parentNode.replaceChild(article, itemRoot);
+                }
+            }
+        }
+    };
+
+    ContentAISearch.prototype._generateResultItems = function(results) {
+        var self = this;
+        var html = "";
+        var template = this._getActiveItemTemplate();
+        if (!template) {
+            return html;
+        }
+        results.forEach(function(item) {
+            var el = document.createElement("div");
+            el.innerHTML = template.innerHTML;
+            self._populateItemNode(el, item);
+            html += el.innerHTML;
+        });
+        return html;
+    };
+
+    ContentAISearch.prototype._generateSourceItems = function(hits) {
+        var self = this;
+        var html = "";
+        if (!this._elements.sourceTemplate) {
+            return html;
+        }
+        hits.forEach(function(hit) {
+            var url = resolveMetadataUrl(hit.metadata, hit.source);
+            var label = self._resolveHitLabel(hit);
+            var el = document.createElement("div");
+            el.innerHTML = self._elements.sourceTemplate.innerHTML;
+            var linkNode = el.querySelector(selectors.source.link);
+            var textNode = el.querySelector(selectors.source.text);
+            if (url && self._isSafeUrl(url) && linkNode) {
+                linkNode.setAttribute("href", url);
+                linkNode.textContent = label;
+                toggleShow(linkNode, true);
+                toggleShow(textNode, false);
+            } else if (textNode) {
+                textNode.textContent = label;
+                toggleShow(textNode, true);
+                toggleShow(linkNode, false);
+            }
+            html += el.innerHTML;
+        });
+        return html;
+    };
+
+    ContentAISearch.prototype._renderResults = function() {
+        if (!this._allResults.length) {
+            this._elements.results.innerHTML = "";
+            toggleShow(this._elements.resultsSection, false);
+            toggleShow(this._elements.loadMore, false);
+            return;
+        }
+
+        this._elements.results.innerHTML = this._generateResultItems(this._allResults);
+        this._elements.results.classList.remove("cmp-contentaisearch__results--refresh");
+        void this._elements.results.offsetWidth;
+        this._elements.results.classList.add("cmp-contentaisearch__results--refresh");
+
+        toggleShow(this._elements.resultsSection, true);
+        toggleShow(this._elements.loadMore, this._hasMore);
+    };
+
+    ContentAISearch.prototype._renderSummary = function(data, requestId) {
+        var self = this;
+        var fullText = data.result || "";
+        var hits = data.hits || [];
+        var tokens = fullText.split(/(\s+)/);
+        var idx = 0;
+
+        if (this._revealTimer) {
+            clearTimeout(this._revealTimer);
+            this._revealTimer = null;
+        }
+
+        if (this._elements.sources) {
+            this._elements.sources.innerHTML = this._generateSourceItems(hits);
+            this._elements.sources.style.visibility = "hidden";
+        }
+        toggleShow(this._elements.summary, true);
+
+        function tick() {
+            if (requestId !== self._genSearchRequestId) {
+                self._revealTimer = null;
+                return;
+            }
+            idx++;
+            self._elements.summaryText.innerHTML = self._renderMarkdownSummary(tokens.slice(0, idx).join(""));
+            if (idx < tokens.length) {
+                self._revealTimer = setTimeout(tick, REVEAL_WORD_INTERVAL_MS);
+            } else {
+                self._revealTimer = null;
+                if (self._elements.sources) {
+                    self._elements.sources.style.visibility = "";
+                }
+            }
+        }
+
+        tick();
+    };
+
+    function escapeHtml(str) {
+        return String(str)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
+    }
+
+    ContentAISearch.prototype._renderMarkdownInline = function(text) {
+        var self = this;
+        var html = escapeHtml(text);
+        html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+        html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, function(match, label, url) {
+            return self._isSafeUrl(url) ? '<a href="' + url + '">' + label + "</a>" : label;
+        });
+        return html;
+    };
+
+    ContentAISearch.prototype._renderMarkdownSummary = function(text) {
+        var lines = String(text || "").split(/\r?\n/);
+        var html = "";
+        var listOpen = false;
+        var i;
+        var trimmed;
+        for (i = 0; i < lines.length; i++) {
+            trimmed = lines[i].replace(/^\s+/, "");
+            if (/^[-*]\s+/.test(trimmed)) {
+                if (!listOpen) {
+                    html += "<ul>";
+                    listOpen = true;
+                }
+                html += "<li>" + this._renderMarkdownInline(trimmed.replace(/^[-*]\s+/, "")) + "</li>";
+            } else {
+                if (listOpen) {
+                    html += "</ul>";
+                    listOpen = false;
+                }
+                if (trimmed.length > 0) {
+                    html += "<p>" + this._renderMarkdownInline(trimmed) + "</p>";
+                }
+            }
+        }
+        if (listOpen) {
+            html += "</ul>";
+        }
+        return html;
+    };
+
+    function stripAsciiControlsAndWhitespaceForSchemeCheck(str) {
+        var out = "";
+        var i;
+        var ch;
+        var c;
+        for (i = 0; i < str.length; i++) {
+            ch = str.charAt(i);
+            c = str.charCodeAt(i);
+            if (c <= 31 || c === 127) {
+                continue;
+            }
+            if (/\s/.test(ch)) {
+                continue;
+            }
+            out += ch;
+        }
+        return out;
+    }
+
+    ContentAISearch.prototype._isSafeUrl = function(url) {
+        if (!url) {
+            return false;
+        }
+        var sanitized = stripAsciiControlsAndWhitespaceForSchemeCheck(String(url));
+        if (/^https?:\/\//i.test(sanitized)) {
+            return true;
+        }
+        return !/^[a-z][a-z0-9+.-]*:/i.test(sanitized);
+    };
+
+    function onDocumentReady() {
+        var elements = document.querySelectorAll(selectors.self);
+        for (var i = 0; i < elements.length; i++) {
+            new ContentAISearch(elements[i]);
+        }
+    }
+
+    if (document.readyState !== "loading") {
+        onDocumentReady();
+    } else {
+        document.addEventListener("DOMContentLoaded", onDocumentReady);
+    }
+})();

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
@@ -19,7 +19,6 @@
     var NS = "cmp";
     var IS = "contentaisearch";
     var LOADING_DISPLAY_DELAY = 300;
-    var REVEAL_WORD_INTERVAL_MS = 12;
     var TAB_COOKIE_NAME = "cmp-contentaisearch-tab";
     var TAB_RESULTS = "search-results";
     var TAB_AI = "ai-mode";
@@ -74,7 +73,6 @@
         // comparison, which would always evaluate to false against real HTL output.
         this._aiSearchModeEnabled = this._element.hasAttribute("data-cmp-ai-search-mode-enabled");
         this._resultsLayout = this._element.getAttribute("data-cmp-results-layout") === "list" ? "list" : "card";
-        this._revealTimer = null;
         this._currentQuery = "";
         this._allResults = [];
         this._hasMore = false;
@@ -290,13 +288,6 @@
         this._genSearchRequestId++;
         this._pendingResultsQuery = null;
         this._pendingGenSearchQuery = null;
-        if (this._revealTimer) {
-            clearTimeout(this._revealTimer);
-            this._revealTimer = null;
-        }
-        if (this._elements.sources) {
-            this._elements.sources.style.visibility = "";
-        }
         if (this._elements.results) {
             this._elements.results.innerHTML = "";
         }
@@ -681,41 +672,18 @@
     };
 
     ContentAISearch.prototype._renderSummary = function(data, requestId) {
-        var self = this;
         var fullText = data.result || "";
         var hits = data.hits || [];
-        var tokens = fullText.split(/(\s+)/);
-        var idx = 0;
 
-        if (this._revealTimer) {
-            clearTimeout(this._revealTimer);
-            this._revealTimer = null;
+        if (requestId !== this._genSearchRequestId) {
+            return;
         }
 
         if (this._elements.sources) {
             this._elements.sources.innerHTML = this._generateSourceItems(hits);
-            this._elements.sources.style.visibility = "hidden";
         }
+        this._elements.summaryText.innerHTML = this._renderMarkdownSummary(fullText);
         toggleShow(this._elements.summary, true);
-
-        function tick() {
-            if (requestId !== self._genSearchRequestId) {
-                self._revealTimer = null;
-                return;
-            }
-            idx++;
-            self._elements.summaryText.innerHTML = self._renderMarkdownSummary(tokens.slice(0, idx).join(""));
-            if (idx < tokens.length) {
-                self._revealTimer = setTimeout(tick, REVEAL_WORD_INTERVAL_MS);
-            } else {
-                self._revealTimer = null;
-                if (self._elements.sources) {
-                    self._elements.sources.style.visibility = "";
-                }
-            }
-        }
-
-        tick();
     };
 
     function escapeHtml(str) {

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js
@@ -69,7 +69,6 @@
         this._resourcePath = this._resolveResourcePath();
         this._aiSearchModeEnabled = this._element.getAttribute("data-cmp-ai-search-mode-enabled") === "true";
         this._resultsLayout = this._element.getAttribute("data-cmp-results-layout") === "list" ? "list" : "card";
-        this._i18n = this._parseI18n();
         this._revealTimer = null;
         this._currentQuery = "";
         this._allResults = [];
@@ -117,18 +116,6 @@
             this._elements.tabAiMode.addEventListener("keydown", this._onTabKeydown.bind(this));
         }
     }
-
-    ContentAISearch.prototype._parseI18n = function() {
-        var raw = this._element.getAttribute("data-i18n-messages");
-        if (!raw) {
-            return {};
-        }
-        try {
-            return JSON.parse(raw);
-        } catch (e) {
-            return {};
-        }
-    };
 
     ContentAISearch.prototype._cacheElements = function() {
         this._elements = {};

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/contentaisearch.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/contentaisearch.html
@@ -22,8 +22,7 @@
          data-cmp-ai-search-mode-enabled="${search.aiSearchModeEnabled}"
          data-cmp-gensearch-error-retry-visible="${search.genSearchErrorRetryVisible}"
          data-cmp-results-layout="${search.resultsLayout}"
-         data-cmp-resource-path="${resource.path}"
-         data-i18n-messages='${search.i18nMessages}'>
+         data-cmp-resource-path="${resource.path}">
     <form class="cmp-contentaisearch__form" data-cmp-hook-contentaisearch="form" autocomplete="off">
         <div class="cmp-contentaisearch__field">
             <label class="cmp-contentaisearch__input-label" for="${search.id}-input">${'Search' @ i18n}</label>
@@ -38,7 +37,7 @@
     </form>
 
     <sly data-sly-test="${search.aiSearchModeEnabled}">
-        <div class="cmp-contentaisearch__tabs" role="tablist" data-cmp-hook-contentaisearch="tabs">
+        <div class="cmp-contentaisearch__tabs" role="tablist" aria-label="${'Search mode' @ i18n}" data-cmp-hook-contentaisearch="tabs">
             <button type="button" role="tab" id="${search.id}-tab-results" class="cmp-contentaisearch__tab"
                     aria-controls="${search.id}-panel-results" aria-selected="true"
                     data-cmp-hook-contentaisearch="tabSearchResults">${'Search Results' @ i18n}</button>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/contentaisearch.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/contentaisearch.html
@@ -27,7 +27,6 @@
         <div class="cmp-contentaisearch__field">
             <label class="cmp-contentaisearch__input-label" for="${search.id}-input">${'Search' @ i18n}</label>
             <i class="cmp-contentaisearch__icon" data-cmp-hook-contentaisearch="icon" aria-hidden="true"></i>
-            <span class="cmp-contentaisearch__loading-indicator" data-cmp-hook-contentaisearch="loadingIndicator"></span>
             <input id="${search.id}-input" class="cmp-contentaisearch__input" data-cmp-hook-contentaisearch="input"
                    type="text" name="q" placeholder="${search.placeholder || 'Search' @ i18n}" autocomplete="off">
             <button type="button" class="cmp-contentaisearch__clear" data-cmp-hook-contentaisearch="clear" aria-label="${'Clear' @ i18n}" hidden="hidden">

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/contentaisearch.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/contentaisearch.html
@@ -1,0 +1,142 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2026 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<section data-sly-use.search="com.adobe.cq.wcm.core.components.models.ContentAISupportedSearchV2"
+         id="${search.id}"
+         class="cmp-contentaisearch cmp-contentaisearch--${search.resultsLayout}"
+         role="search"
+         data-cmp-is="contentaisearch"
+         data-cmp-content-source="${search.primaryContentSource}"
+         data-cmp-ai-search-mode-enabled="${search.aiSearchModeEnabled}"
+         data-cmp-gensearch-error-retry-visible="${search.genSearchErrorRetryVisible}"
+         data-cmp-results-layout="${search.resultsLayout}"
+         data-cmp-resource-path="${resource.path}"
+         data-i18n-messages='${search.i18nMessages}'>
+    <form class="cmp-contentaisearch__form" data-cmp-hook-contentaisearch="form" autocomplete="off">
+        <div class="cmp-contentaisearch__field">
+            <label class="cmp-contentaisearch__input-label" for="${search.id}-input">${'Search' @ i18n}</label>
+            <i class="cmp-contentaisearch__icon" data-cmp-hook-contentaisearch="icon" aria-hidden="true"></i>
+            <span class="cmp-contentaisearch__loading-indicator" data-cmp-hook-contentaisearch="loadingIndicator"></span>
+            <input id="${search.id}-input" class="cmp-contentaisearch__input" data-cmp-hook-contentaisearch="input"
+                   type="text" name="q" placeholder="${search.placeholder || 'Search' @ i18n}" autocomplete="off">
+            <button type="button" class="cmp-contentaisearch__clear" data-cmp-hook-contentaisearch="clear" aria-label="${'Clear' @ i18n}" hidden="hidden">
+                <i class="cmp-contentaisearch__clear-icon" aria-hidden="true"></i>
+            </button>
+        </div>
+    </form>
+
+    <sly data-sly-test="${search.aiSearchModeEnabled}">
+        <div class="cmp-contentaisearch__tabs" role="tablist" data-cmp-hook-contentaisearch="tabs">
+            <button type="button" role="tab" id="${search.id}-tab-results" class="cmp-contentaisearch__tab"
+                    aria-controls="${search.id}-panel-results" aria-selected="true"
+                    data-cmp-hook-contentaisearch="tabSearchResults">${'Search Results' @ i18n}</button>
+            <button type="button" role="tab" id="${search.id}-tab-ai" class="cmp-contentaisearch__tab"
+                    aria-controls="${search.id}-panel-ai" aria-selected="false" tabindex="-1"
+                    data-cmp-hook-contentaisearch="tabAiMode">${'AI Mode' @ i18n}</button>
+        </div>
+
+        <div class="cmp-contentaisearch__panel" role="tabpanel" id="${search.id}-panel-ai"
+             aria-labelledby="${search.id}-tab-ai" data-cmp-hook-contentaisearch="panelAiMode" hidden="hidden">
+            <div class="cmp-contentaisearch__summary-loading" data-cmp-hook-contentaisearch="summaryLoading" hidden="hidden" aria-live="polite">
+                <div class="cmp-contentaisearch__summary-card">
+                    <div class="cmp-contentaisearch__summary-loading-content">
+                        <span class="cmp-contentaisearch__summary-loading-indicator" aria-hidden="true"></span>
+                        <p class="cmp-contentaisearch__summary-loading-text">${'Generating answer...' @ i18n}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="cmp-contentaisearch__summary" data-cmp-hook-contentaisearch="summary" hidden="hidden">
+                <div class="cmp-contentaisearch__summary-card">
+                    <div class="cmp-contentaisearch__summary-header">
+                        <span class="cmp-contentaisearch__summary-icon" aria-hidden="true"></span>
+                        <div class="cmp-contentaisearch__summary-heading">
+                            <p class="cmp-contentaisearch__summary-title">${'Generative answer' @ i18n}</p>
+                            <p class="cmp-contentaisearch__summary-attribution">${'Powered by Content AI' @ i18n}</p>
+                        </div>
+                    </div>
+                    <p class="cmp-contentaisearch__summary-text" data-cmp-hook-contentaisearch="summaryText"></p>
+                    <div class="cmp-contentaisearch__sources-section">
+                        <p class="cmp-contentaisearch__sources-label">${'Sources' @ i18n}</p>
+                        <ul class="cmp-contentaisearch__sources" data-cmp-hook-contentaisearch="sources"></ul>
+                    </div>
+                    <p class="cmp-contentaisearch__disclaimer" data-cmp-hook-contentaisearch="disclaimer">
+                        ${search.disclaimerText || 'AI-generated responses may be inaccurate. Verify important information.' @ i18n}
+                    </p>
+                </div>
+            </div>
+            <div class="cmp-contentaisearch__error" data-cmp-hook-contentaisearch="error" hidden="hidden">
+                <p data-cmp-hook-contentaisearch="errorMessage">${'Something went wrong generating the summary.' @ i18n}</p>
+                <button type="button" data-cmp-hook-contentaisearch="retry" data-sly-test="${search.genSearchErrorRetryVisible}">${'Try again' @ i18n}</button>
+            </div>
+        </div>
+
+        <div class="cmp-contentaisearch__panel" role="tabpanel" id="${search.id}-panel-results"
+             aria-labelledby="${search.id}-tab-results" data-cmp-hook-contentaisearch="panelSearchResults">
+            <div class="cmp-contentaisearch__results-section" data-cmp-hook-contentaisearch="resultsSection" hidden="hidden">
+                <div class="cmp-contentaisearch__results-toolbar">
+                    <div class="cmp-contentaisearch__layout-toggle" role="group" aria-label="${'Results layout' @ i18n}">
+                        <button type="button" class="cmp-contentaisearch__layout-btn" data-cmp-hook-contentaisearch="layoutCard" aria-pressed="true">${'Cards' @ i18n}</button>
+                        <button type="button" class="cmp-contentaisearch__layout-btn" data-cmp-hook-contentaisearch="layoutList" aria-pressed="false">${'List' @ i18n}</button>
+                    </div>
+                </div>
+                <ul class="cmp-contentaisearch__results" data-cmp-hook-contentaisearch="results" aria-label="${'Search results' @ i18n}"></ul>
+                <button type="button" class="cmp-contentaisearch__load-more" data-cmp-hook-contentaisearch="loadMore" hidden="hidden">${'Load more results' @ i18n}</button>
+            </div>
+        </div>
+
+        <script data-cmp-hook-contentaisearch="prepaint">
+            (function() {
+                try {
+                    var root = document.currentScript.closest(".cmp-contentaisearch");
+                    if (!root) { return; }
+                    var match = document.cookie.match(/(?:^|; )cmp-contentaisearch-tab=([^;]*)/);
+                    var wantAi = match && decodeURIComponent(match[1]) === "ai-mode";
+                    if (!wantAi) { return; }
+                    var tabResults = root.querySelector('[data-cmp-hook-contentaisearch="tabSearchResults"]');
+                    var tabAi = root.querySelector('[data-cmp-hook-contentaisearch="tabAiMode"]');
+                    var panelResults = root.querySelector('[data-cmp-hook-contentaisearch="panelSearchResults"]');
+                    var panelAi = root.querySelector('[data-cmp-hook-contentaisearch="panelAiMode"]');
+                    if (tabResults && tabAi && panelResults && panelAi) {
+                        tabResults.setAttribute("aria-selected", "false");
+                        tabResults.setAttribute("tabindex", "-1");
+                        tabAi.setAttribute("aria-selected", "true");
+                        tabAi.removeAttribute("tabindex");
+                        panelResults.setAttribute("hidden", "hidden");
+                        panelAi.removeAttribute("hidden");
+                    }
+                } catch (e) {
+                    // Fails open to the default (Search Results) tab already rendered above.
+                }
+            })();
+        </script>
+    </sly>
+
+    <sly data-sly-test="${!search.aiSearchModeEnabled}">
+        <div class="cmp-contentaisearch__results-section" data-cmp-hook-contentaisearch="resultsSection" hidden="hidden">
+            <div class="cmp-contentaisearch__results-toolbar">
+                <div class="cmp-contentaisearch__layout-toggle" role="group" aria-label="${'Results layout' @ i18n}">
+                    <button type="button" class="cmp-contentaisearch__layout-btn" data-cmp-hook-contentaisearch="layoutCard" aria-pressed="true">${'Cards' @ i18n}</button>
+                    <button type="button" class="cmp-contentaisearch__layout-btn" data-cmp-hook-contentaisearch="layoutList" aria-pressed="false">${'List' @ i18n}</button>
+                </div>
+            </div>
+            <ul class="cmp-contentaisearch__results" data-cmp-hook-contentaisearch="results" aria-label="${'Search results' @ i18n}"></ul>
+            <button type="button" class="cmp-contentaisearch__load-more" data-cmp-hook-contentaisearch="loadMore" hidden="hidden">${'Load more results' @ i18n}</button>
+        </div>
+    </sly>
+
+    <sly data-sly-include="itemTemplateCard.html"/>
+    <sly data-sly-include="itemTemplateList.html"/>
+    <sly data-sly-include="sourceTemplate.html"/>
+</section>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/itemTemplateCard.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/itemTemplateCard.html
@@ -1,0 +1,27 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2026 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<script data-cmp-hook-contentaisearch="itemTemplateCard" type="x-template">
+    <li class="cmp-contentaisearch__item">
+        <a class="cmp-contentaisearch__card" data-cmp-hook-contentaisearch="item" href="#">
+            <img class="cmp-contentaisearch__card-image" data-cmp-hook-contentaisearch="itemImage" alt="" loading="lazy" hidden="hidden">
+            <div class="cmp-contentaisearch__card-image cmp-contentaisearch__card-image--placeholder" data-cmp-hook-contentaisearch="itemImagePlaceholder" aria-hidden="true"></div>
+            <div class="cmp-contentaisearch__card-body">
+                <h3 class="cmp-contentaisearch__card-title" data-cmp-hook-contentaisearch="itemTitle"></h3>
+                <p class="cmp-contentaisearch__card-description" data-cmp-hook-contentaisearch="itemDescription" hidden="hidden"></p>
+            </div>
+        </a>
+    </li>
+</script>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/itemTemplateList.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/itemTemplateList.html
@@ -1,0 +1,26 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2026 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<script data-cmp-hook-contentaisearch="itemTemplateList" type="x-template">
+    <li class="cmp-contentaisearch__item">
+        <a class="cmp-contentaisearch__row" data-cmp-hook-contentaisearch="item" href="#">
+            <img class="cmp-contentaisearch__row-image" data-cmp-hook-contentaisearch="itemImage" alt="" loading="lazy" hidden="hidden">
+            <div class="cmp-contentaisearch__row-body">
+                <h3 class="cmp-contentaisearch__row-title" data-cmp-hook-contentaisearch="itemTitle"></h3>
+                <p class="cmp-contentaisearch__row-description" data-cmp-hook-contentaisearch="itemDescription" hidden="hidden"></p>
+            </div>
+        </a>
+    </li>
+</script>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/sourceTemplate.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/sourceTemplate.html
@@ -1,0 +1,21 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2026 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<script data-cmp-hook-contentaisearch="sourceTemplate" type="x-template">
+    <li>
+        <a class="cmp-contentaisearch__source-chip" data-cmp-hook-contentaisearch="sourceLink" href="#" hidden="hidden"></a>
+        <span class="cmp-contentaisearch__source-chip" data-cmp-hook-contentaisearch="sourceText" hidden="hidden"></span>
+    </li>
+</script>

--- a/content/test/jest/contentaisearch/contentaisearch-v2.test.js
+++ b/content/test/jest/contentaisearch/contentaisearch-v2.test.js
@@ -1,0 +1,153 @@
+/*
+ * Jest harness for v2's contentaisearch.js, covering the tab-switching and
+ * cookie-persistence behavior that's new in v2 (request-ID/in-flight-guard
+ * concurrency logic is already covered by contentaisearch.test.js against v1's
+ * script, and v2 reuses that same logic verbatim for the shared search/gensearch
+ * fetch paths - not re-tested here).
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const SCRIPT_PATH = path.join(
+    __dirname,
+    "../../../src/content/jcr_root/apps/core/wcm/components/contentaisearch/v2/contentaisearch/clientlibs/site/js/contentaisearch.js"
+);
+
+if (!fs.existsSync(SCRIPT_PATH)) {
+    throw new Error("contentaisearch.js (v2) not found at " + SCRIPT_PATH + " - update SCRIPT_PATH in this test file.");
+}
+
+const RESOURCE_PATH = "/content/wknd/us/en/search/jcr:content/root/container/contentaisearch";
+
+function renderComponentHtml(options) {
+    const opts = Object.assign({ aiSearchModeEnabled: true }, options);
+    const tabsMarkup = opts.aiSearchModeEnabled
+        ? '<div role="tablist">' +
+          '<button type="button" data-cmp-hook-contentaisearch="tabSearchResults" aria-selected="true"></button>' +
+          '<button type="button" data-cmp-hook-contentaisearch="tabAiMode" aria-selected="false" tabindex="-1"></button>' +
+          "</div>" +
+          '<div data-cmp-hook-contentaisearch="panelAiMode" hidden>' +
+          '<div data-cmp-hook-contentaisearch="summaryLoading" hidden></div>' +
+          '<div data-cmp-hook-contentaisearch="summary" hidden>' +
+          '<p data-cmp-hook-contentaisearch="summaryText"></p>' +
+          '<ul data-cmp-hook-contentaisearch="sources"></ul>' +
+          "</div>" +
+          '<div data-cmp-hook-contentaisearch="error" hidden>' +
+          '<p data-cmp-hook-contentaisearch="errorMessage"></p>' +
+          '<button type="button" data-cmp-hook-contentaisearch="retry"></button>' +
+          "</div>" +
+          "</div>" +
+          '<div data-cmp-hook-contentaisearch="panelSearchResults">'
+        : "";
+    return (
+        '<section data-cmp-is="contentaisearch"' +
+        ' data-cmp-resource-path="' + RESOURCE_PATH + '"' +
+        ' data-cmp-ai-search-mode-enabled="' + String(opts.aiSearchModeEnabled) + '"' +
+        ' data-cmp-gensearch-error-retry-visible="true"' +
+        ' data-cmp-results-layout="card">' +
+        '<form data-cmp-hook-contentaisearch="form">' +
+        '<i data-cmp-hook-contentaisearch="icon"></i>' +
+        '<span data-cmp-hook-contentaisearch="loadingIndicator" hidden></span>' +
+        '<input data-cmp-hook-contentaisearch="input" type="text">' +
+        '<button type="button" data-cmp-hook-contentaisearch="clear" hidden></button>' +
+        "</form>" +
+        tabsMarkup +
+        '<div data-cmp-hook-contentaisearch="resultsSection" hidden>' +
+        '<button type="button" data-cmp-hook-contentaisearch="layoutCard"></button>' +
+        '<button type="button" data-cmp-hook-contentaisearch="layoutList"></button>' +
+        '<ul data-cmp-hook-contentaisearch="results"></ul>' +
+        '<button type="button" data-cmp-hook-contentaisearch="loadMore" hidden></button>' +
+        "</div>" +
+        (opts.aiSearchModeEnabled ? "</div>" : "") +
+        "</section>"
+    );
+}
+
+function loadFreshScript() {
+    jest.resetModules();
+    require(SCRIPT_PATH);
+    document.dispatchEvent(new Event("DOMContentLoaded", { bubbles: true, cancelable: true }));
+}
+
+describe("contentaisearch.js v2 - tab switching", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        document.cookie = "cmp-contentaisearch-tab=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/";
+        global.fetch = jest.fn(() => new Promise(() => {}));
+    });
+
+    test("clicking AI Mode tab shows the AI panel and hides the results panel", () => {
+        document.body.innerHTML = renderComponentHtml({});
+        loadFreshScript();
+        const tabAi = document.querySelector('[data-cmp-hook-contentaisearch="tabAiMode"]');
+        const panelAi = document.querySelector('[data-cmp-hook-contentaisearch="panelAiMode"]');
+        const panelResults = document.querySelector('[data-cmp-hook-contentaisearch="panelSearchResults"]');
+
+        tabAi.click();
+
+        expect(panelAi.hasAttribute("hidden")).toBe(false);
+        expect(panelResults.hasAttribute("hidden")).toBe(true);
+        expect(tabAi.getAttribute("aria-selected")).toBe("true");
+    });
+
+    test("clicking AI Mode tab writes the cookie", () => {
+        document.body.innerHTML = renderComponentHtml({});
+        loadFreshScript();
+        document.querySelector('[data-cmp-hook-contentaisearch="tabAiMode"]').click();
+
+        expect(document.cookie).toContain("cmp-contentaisearch-tab=ai-mode");
+    });
+
+    test("clicking Search Results tab after AI Mode writes the cookie back", () => {
+        document.body.innerHTML = renderComponentHtml({});
+        loadFreshScript();
+        document.querySelector('[data-cmp-hook-contentaisearch="tabAiMode"]').click();
+        document.querySelector('[data-cmp-hook-contentaisearch="tabSearchResults"]').click();
+
+        expect(document.cookie).toContain("cmp-contentaisearch-tab=search-results");
+    });
+
+    test("ArrowRight on the Search Results tab moves focus and activates AI Mode", () => {
+        document.body.innerHTML = renderComponentHtml({});
+        loadFreshScript();
+        const tabResults = document.querySelector('[data-cmp-hook-contentaisearch="tabSearchResults"]');
+        const tabAi = document.querySelector('[data-cmp-hook-contentaisearch="tabAiMode"]');
+        tabResults.focus();
+
+        tabResults.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+
+        expect(tabAi.getAttribute("aria-selected")).toBe("true");
+        expect(document.activeElement).toBe(tabAi);
+    });
+
+    test("submitting a query with AI Search Mode disabled never calls .gensearch.json", () => {
+        document.body.innerHTML = renderComponentHtml({ aiSearchModeEnabled: false });
+        loadFreshScript();
+        const form = document.querySelector('[data-cmp-hook-contentaisearch="form"]');
+        const input = document.querySelector('[data-cmp-hook-contentaisearch="input"]');
+        input.value = "surfing";
+
+        form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+        const calledUrls = global.fetch.mock.calls.map((call) => call[0]);
+        expect(calledUrls.some((url) => url.indexOf(".gensearch.json") !== -1)).toBe(false);
+        expect(calledUrls.some((url) => url.indexOf(".search.json") !== -1)).toBe(true);
+    });
+
+    test("submitting a query with AI Search Mode enabled calls both endpoints in parallel", () => {
+        document.body.innerHTML = renderComponentHtml({});
+        loadFreshScript();
+        const form = document.querySelector('[data-cmp-hook-contentaisearch="form"]');
+        const input = document.querySelector('[data-cmp-hook-contentaisearch="input"]');
+        input.value = "surfing";
+
+        form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+        const calledUrls = global.fetch.mock.calls.map((call) => call[0]);
+        expect(calledUrls.some((url) => url.indexOf(".search.json") !== -1)).toBe(true);
+        expect(calledUrls.some((url) => url.indexOf(".gensearch.json") !== -1)).toBe(true);
+    });
+});

--- a/content/test/jest/contentaisearch/contentaisearch-v2.test.js
+++ b/content/test/jest/contentaisearch/contentaisearch-v2.test.js
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright 2026 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 /*
  * Jest harness for v2's contentaisearch.js, covering the tab-switching and
  * cookie-persistence behavior that's new in v2 (request-ID/in-flight-guard
@@ -45,12 +61,15 @@ function renderComponentHtml(options) {
     return (
         '<section data-cmp-is="contentaisearch"' +
         ' data-cmp-resource-path="' + RESOURCE_PATH + '"' +
-        ' data-cmp-ai-search-mode-enabled="' + String(opts.aiSearchModeEnabled) + '"' +
+        // aiSearchModeEnabled is a Sightly boolean-typed attribute: real HTL output is a
+        // bare attribute (present) when true and omits it entirely when false - never the
+        // literal string "false". Mirroring that here is what makes this fixture actually
+        // catch a regression to the old (buggy) getAttribute() === "true" read.
+        (opts.aiSearchModeEnabled ? " data-cmp-ai-search-mode-enabled" : "") +
         ' data-cmp-gensearch-error-retry-visible="true"' +
         ' data-cmp-results-layout="card">' +
         '<form data-cmp-hook-contentaisearch="form">' +
         '<i data-cmp-hook-contentaisearch="icon"></i>' +
-        '<span data-cmp-hook-contentaisearch="loadingIndicator" hidden></span>' +
         '<input data-cmp-hook-contentaisearch="input" type="text">' +
         '<button type="button" data-cmp-hook-contentaisearch="clear" hidden></button>' +
         "</form>" +

--- a/content/test/jest/contentaisearch/contentaisearch-v2.test.js
+++ b/content/test/jest/contentaisearch/contentaisearch-v2.test.js
@@ -137,6 +137,48 @@ describe("contentaisearch.js v2 - tab switching", () => {
         expect(calledUrls.some((url) => url.indexOf(".search.json") !== -1)).toBe(true);
     });
 
+    test("picks up the pre-paint script's already-applied DOM state as its initial active tab", () => {
+        // Simulate what the HTL's synchronous pre-paint script does before the JS
+        // component initializes: it already flips aria-selected on the tabs and
+        // hidden on the panels based on the cookie. The JS must read that state
+        // (via _syncActiveTabFromDom) into its own _activeTab, rather than assuming
+        // the default (Search Results) - otherwise a subsequent tab interaction
+        // would be computed from the wrong starting point.
+        const html = renderComponentHtml({}).replace(
+            'data-cmp-hook-contentaisearch="tabAiMode" aria-selected="false" tabindex="-1"',
+            'data-cmp-hook-contentaisearch="tabAiMode" aria-selected="true"'
+        ).replace(
+            'data-cmp-hook-contentaisearch="tabSearchResults" aria-selected="true"',
+            'data-cmp-hook-contentaisearch="tabSearchResults" aria-selected="false" tabindex="-1"'
+        ).replace(
+            'data-cmp-hook-contentaisearch="panelAiMode" hidden',
+            'data-cmp-hook-contentaisearch="panelAiMode"'
+        ).replace(
+            'data-cmp-hook-contentaisearch="panelSearchResults">',
+            'data-cmp-hook-contentaisearch="panelSearchResults" hidden>'
+        );
+        document.body.innerHTML = html;
+        loadFreshScript();
+
+        const panelAi = document.querySelector('[data-cmp-hook-contentaisearch="panelAiMode"]');
+        const panelResults = document.querySelector('[data-cmp-hook-contentaisearch="panelSearchResults"]');
+
+        // Sanity check: the pre-paint state as rendered is still what we expect
+        // before any JS-driven interaction.
+        expect(panelAi.hasAttribute("hidden")).toBe(false);
+        expect(panelResults.hasAttribute("hidden")).toBe(true);
+
+        // The real assertion: if the JS's internal _activeTab wasn't synced from the
+        // DOM (i.e. it still thinks Search Results is active, the default), clicking
+        // the Search Results tab would be a no-op (tab === this._activeTab short-
+        // circuits _activateTab) and the AI panel would incorrectly stay visible.
+        document.querySelector('[data-cmp-hook-contentaisearch="tabSearchResults"]').click();
+
+        expect(panelResults.hasAttribute("hidden")).toBe(false);
+        expect(panelAi.hasAttribute("hidden")).toBe(true);
+        expect(document.cookie).toContain("cmp-contentaisearch-tab=search-results");
+    });
+
     test("submitting a query with AI Search Mode enabled calls both endpoints in parallel", () => {
         document.body.innerHTML = renderComponentHtml({});
         loadFreshScript();

--- a/content/test/jest/contentaisearch/contentaisearch-v2.test.js
+++ b/content/test/jest/contentaisearch/contentaisearch-v2.test.js
@@ -211,4 +211,38 @@ describe("contentaisearch.js v2 - tab switching", () => {
         expect(calledUrls.some((url) => url.indexOf(".search.json") !== -1)).toBe(true);
         expect(calledUrls.some((url) => url.indexOf(".gensearch.json") !== -1)).toBe(true);
     });
+
+    test("backspacing the query down to empty clears already-rendered results and summary", async () => {
+        document.body.innerHTML = renderComponentHtml({});
+        global.fetch = jest.fn((url) => {
+            const data = url.indexOf(".gensearch.json") !== -1
+                ? { result: "Adventures include hiking and skiing.", hits: [] }
+                : { results: [{ id: "1", data: { title: "Adventure" } }], hasMore: false, sourceCursors: {} };
+            return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(data) });
+        });
+        loadFreshScript();
+        const form = document.querySelector('[data-cmp-hook-contentaisearch="form"]');
+        const input = document.querySelector('[data-cmp-hook-contentaisearch="input"]');
+        const resultsSection = document.querySelector('[data-cmp-hook-contentaisearch="resultsSection"]');
+        const summary = document.querySelector('[data-cmp-hook-contentaisearch="summary"]');
+
+        input.value = "adventure";
+        form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+        // Let the fetch .then() chains settle, including _hideSummaryLoading's
+        // minimum-visible-time setTimeout.
+        jest.useFakeTimers();
+        await jest.runAllTimersAsync();
+        jest.useRealTimers();
+
+        expect(resultsSection.hasAttribute("hidden")).toBe(false);
+        expect(summary.hasAttribute("hidden")).toBe(false);
+
+        // Simulate the user backspacing the field to empty - no submit, no clear button.
+        input.value = "";
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+
+        expect(resultsSection.hasAttribute("hidden")).toBe(true);
+        expect(summary.hasAttribute("hidden")).toBe(true);
+        expect(document.querySelector('[data-cmp-hook-contentaisearch="results"]').innerHTML).toBe("");
+    });
 });

--- a/content/test/jest/contentaisearch/jest.config.js
+++ b/content/test/jest/contentaisearch/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+    testEnvironment: "jsdom",
+    testEnvironmentOptions: {
+        // AEM as a Cloud Service is HTTPS-only, and the cookie set by contentaisearch.js
+        // now carries the Secure attribute - jsdom's default http://localhost origin would
+        // silently drop such cookies, so the test origin is pinned to https here to match
+        // production reality.
+        url: "https://localhost/"
+    },
+    testMatch: ["**/*.test.js"]
+};


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | GRANITE-71475
| Patch: Bug Fix?          |
| Minor: New Feature?      | Yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (README + code comments)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

## Summary

Adds a new `v2` variant of the ContentAI Supported Search core component that
splits the single-panel layout into a tabbed **Search Results / AI Mode** UI,
addressing PM feedback on the v1 layout-shift-during-AI-answer-reveal problem
and the need to fully suppress AI answers when desired.

- New `ContentAISupportedSearchV2` model/impl, resourceType
  `core/wcm/components/contentaisearch/v2/contentaisearch`, independent of v1's
  impl (no inheritance), with `aiSearchModeEnabled` / `genSearchErrorRetryVisible`
  dialog toggles (both default `true`).
- Tabbed HTL (`role="tablist"`/`"tab"`/`"tabpanel"` ARIA pattern, keyboard nav,
  synchronous pre-paint script to avoid FOUC) with independent Search Results
  and AI Mode panels; tab selection persisted via cookie.
- Both `.search.json` and `.gensearch.json` requests fire in parallel on submit
  when AI Search Mode is enabled; AI Mode panel shows the full generative
  answer + sources immediately.
- Card/list result layouts, each with description text properly clamped
  (4 lines for cards, 2 for list rows) with a trailing ellipsis.
- Shared query servlets (`ContentAISearchResultsServlet`,
  `ContentAIGenSearchServlet`) extended to also resolve the v2 resourceType.

## Notable fixes folded into this PR (found during manual end-to-end testing
against a live AEM Cloud Service instance + Content AI backend, on top of the
original subagent-driven-development + code review passes)

- **AI Mode never actually fired `.gensearch.json`**: the JS read
  `data-cmp-ai-search-mode-enabled` via a `getAttribute() === "true"` string
  comparison, but Sightly renders boolean-typed attributes bare (present when
  true, omitted when false) - never as the literal string `"true"`. Switched to
  `hasAttribute()`, matching the convention already used elsewhere in this
  codebase (e.g. `data-cmp-data-layer-enabled`).
- **Result/summary description line-clamp silently never rendered**:
  `_populateItemNode` showed the description via a shared `toggleShow()` helper
  that sets an inline `style="display: block"`, which (being more specific than
  any external stylesheet rule) permanently clobbered the CSS's
  `display: -webkit-box` needed for `-webkit-line-clamp` to have any effect.
  Fixed by toggling `hidden` directly instead of through `toggleShow()`, plus an
  explicit `&[hidden] { display: none }` override (a bare `[hidden]` attribute
  alone doesn't hide an element that has a custom author-stylesheet `display`
  declared, regardless of specificity).
- Removed the word-by-word reveal animation on the AI Mode answer (now renders
  immediately) and the input-field loading spinner, per product feedback.
- Backspacing a query down to empty (without submitting or using the explicit
  clear button) now also clears stale results/summary.
- Dropped the dead i18n JSON pipeline that was never read client-side, added a
  missing `aria-label` on the tablist, and closed a JaCoCo coverage gap plus
  some RAT license-header gaps that only surface on a full reactor build.

All changes verified both via the Jest suite (`content/test/jest/contentaisearch`)
and manually end-to-end against a running AEM Cloud Service author instance with
a live Content AI backend (real search + gensearch responses).
