### PR TITLE
feat: expose LinkHandler interface (#1818)

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/link/LinkHandler.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/link/LinkHandler.java
@@ -1,0 +1,69 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.commons.link;
+
+import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.annotation.versioning.ProviderType;
+
+import com.day.cq.dam.api.Asset;
+import com.day.cq.wcm.api.Page;
+
+/**
+ * Interface to get resolved {@link Link} instances directly.
+ *
+ * <p>This Sling Model can be injected into custom models using the {@code @Self} annotation
+ * to quickly obtain built links without manually invoking a builder.</p>
+ */
+@ProviderType
+public interface LinkHandler {
+
+    /**
+     * Returns a resolved link pointing to a page.
+     *
+     * @param page Target page of the link.
+     * @return {@link Link} pointing to the specified page.
+     */
+    @NotNull
+    Link<Page> getLink(@NotNull Page page);
+
+    /**
+     * Returns a resolved link defined by the resource properties.
+     *
+     * @param resource Resource to read the link properties from.
+     * @return {@link Link} built from the specified resource.
+     */
+    @NotNull
+    Link<Page> getLink(@NotNull Resource resource);
+
+    /**
+     * Returns a resolved link pointing to an asset.
+     *
+     * @param asset Target asset of the link.
+     * @return {@link Link} pointing to the specified asset.
+     */
+    @NotNull
+    Link<Asset> getLink(@NotNull Asset asset);
+
+    /**
+     * Returns a resolved link pointing to an URL or path.
+     *
+     * @param url URL string of the link.
+     * @return {@link Link} pointing to the specified URL.
+     */
+    @NotNull
+    Link<String> getLink(@NotNull String url);
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/link/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/link/package-info.java
@@ -16,7 +16,7 @@
 /**
  * Link handling.
  */
-@Version("1.2.0")
+@Version("1.3.0")
 package com.adobe.cq.wcm.core.components.commons.link;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkManagerImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/link/LinkManagerImpl.java
@@ -20,6 +20,8 @@ import java.util.Set;
 
 import javax.annotation.PostConstruct;
 
+import com.adobe.cq.wcm.core.components.commons.link.Link;
+import com.adobe.cq.wcm.core.components.commons.link.LinkHandler;
 import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -39,11 +41,9 @@ import com.day.cq.dam.api.Asset;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.designer.Style;
 
-import static com.adobe.cq.wcm.core.components.commons.link.Link.PN_LINK_URL;
-
 @Model(adaptables = SlingHttpServletRequest.class,
-        adapters = LinkManager.class)
-public class LinkManagerImpl implements LinkManager {
+    adapters = {LinkManager.class, LinkHandler.class})
+public class LinkManagerImpl implements LinkManager, LinkHandler {
 
     /**
      * List of allowed/supported values for link target.
@@ -93,6 +93,11 @@ public class LinkManagerImpl implements LinkManager {
      */
     private Boolean shadowingDisabled;
 
+    /**
+     * Constant for suppressing unchecked warnings in Link annotations.
+     */
+    public static final String SUPPRESS_WARNINGS_UNCHECKED = "unchecked";
+
     @PostConstruct
     private void initModel() {
         shadowingDisabled = PROP_DISABLE_SHADOWING_DEFAULT;
@@ -133,5 +138,29 @@ public class LinkManagerImpl implements LinkManager {
      */
     public static boolean isExternalLink(String url) {
         return StringUtils.isNotBlank(url) && !url.startsWith("/");
+    }
+
+    @Override
+    @SuppressWarnings(SUPPRESS_WARNINGS_UNCHECKED)
+    public @NotNull Link<Page> getLink(@NotNull Page page) {
+        return (Link<Page>) get(page).build();
+    }
+
+    @Override
+    @SuppressWarnings(SUPPRESS_WARNINGS_UNCHECKED)
+    public @NotNull Link<Page> getLink(@NotNull Resource resource) {
+        return (Link<Page>) get(resource).build();
+    }
+
+    @Override
+    @SuppressWarnings(SUPPRESS_WARNINGS_UNCHECKED)
+    public @NotNull Link<Asset> getLink(@NotNull Asset asset) {
+        return (Link<Asset>) get(asset).build();
+    }
+
+    @Override
+    @SuppressWarnings(SUPPRESS_WARNINGS_UNCHECKED)
+    public @NotNull Link<String> getLink(@NotNull String url) {
+        return (Link<String>) get(url).build();
     }
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkManagerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/link/LinkManagerImplTest.java
@@ -1,0 +1,101 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2026 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.link;
+
+import org.apache.sling.api.resource.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.adobe.cq.wcm.core.components.commons.link.Link;
+import com.adobe.cq.wcm.core.components.commons.link.LinkHandler;
+import com.adobe.cq.wcm.core.components.services.link.PathProcessor;
+import com.day.cq.dam.api.Asset;
+import com.day.cq.wcm.api.Page;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+
+@ExtendWith(AemContextExtension.class)
+class LinkManagerImplTest {
+
+    public final AemContext context = new AemContext();
+
+    @BeforeEach
+    void setUp() {
+        // Mock and register required OSGi PathProcessor service
+        PathProcessor pathProcessor = mock(PathProcessor.class);
+        when(pathProcessor.accepts(any(), any())).thenReturn(Boolean.TRUE);
+        when(pathProcessor.map(any(), any())).then(returnsFirstArg());
+        when(pathProcessor.sanitize(any(), any())).then(returnsFirstArg());
+        when(pathProcessor.externalize(any(), any())).then(returnsFirstArg());
+
+        context.registerService(PathProcessor.class, pathProcessor);
+
+        // Register the implementation model
+        context.addModelsForClasses(LinkManagerImpl.class);
+    }
+
+    @Test
+    void testGetLinkPageWithLinkHandler() {
+        Page page = context.create().page("/content/test-page");
+        LinkHandler linkHandler = context.request().adaptTo(LinkHandler.class);
+
+        assertNotNull(linkHandler);
+        Link<Page> link = linkHandler.getLink(page);
+        assertNotNull(link);
+        assertEquals("/content/test-page.html", link.getURL());
+    }
+
+    @Test
+    void testGetLinkResourceWithLinkHandler() {
+        context.create().page("/content/test-page");
+        Resource resource = context.currentResource("/content/test-page");
+        LinkHandler linkHandler = context.request().adaptTo(LinkHandler.class);
+
+        assertNotNull(linkHandler);
+        Link<Page> link = linkHandler.getLink(resource);
+        assertNotNull(link);
+    }
+
+    @Test
+    void testGetLinkAssetWithLinkHandler() {
+        Asset asset = context.create().asset("/content/dam/test-asset.png", 100, 100, "image/png");
+        LinkHandler linkHandler = context.request().adaptTo(LinkHandler.class);
+
+        assertNotNull(linkHandler);
+        Link<Asset> link = linkHandler.getLink(asset);
+        assertNotNull(link);
+        assertEquals("/content/dam/test-asset.png", link.getURL());
+    }
+
+    @Test
+    void testGetLinkUrlWithLinkHandler() {
+        LinkHandler linkHandler = context.request().adaptTo(LinkHandler.class);
+
+        assertNotNull(linkHandler);
+        Link<String> link = linkHandler.getLink("/content/test-url");
+        assertNotNull(link);
+        assertEquals("/content/test-url", link.getURL());
+    }
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                     | A <!--(Can use an emoji 👍 ) -->
| --------------------- | ---
| Fixed Issues?         | Fixes #1818
| Patch: Bug Fix?       |
| Minor: New Feature?   | Yes
| Major: Breaking Change? |
| Tests Added + Pass?   | Yes
| Documentation Provided | Yes (code comments and or markdown)
| Any Dependency Changes? |
| License               | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

## Description
Exposes the `LinkHandler` interface to the public API package (`com.adobe.cq.wcm.core.components.commons.link`).

This change allows custom Sling Models to inject and leverage the internal `LinkHandler` service directly for resolving component links in a standardized way.