### PR TITLE
fix(search): enable partial search matching by appending wildcard (#149)

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/SearchResultServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/SearchResultServlet.java
@@ -274,6 +274,7 @@ public final class SearchResultServlet extends SlingSafeMethodsServlet {
         }
         long resultsOffset = Optional.ofNullable(request.getParameter(PARAM_RESULTS_OFFSET)).map(Long::parseLong).orElse(0L);
         Map<String, String> predicatesMap = new HashMap<>();
+        fulltext = StringUtils.isNotBlank(fulltext) ? fulltext.trim() + "*" : fulltext;
         predicatesMap.put(FulltextPredicateEvaluator.FULLTEXT, fulltext);
         predicatesMap.put(PathPredicateEvaluator.PATH, searchComponent.getSearchRootPagePath());
         predicatesMap.put(TypePredicateEvaluator.TYPE, NameConstants.NT_PAGE);


### PR DESCRIPTION
…#149)

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                         | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #149
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

## Description
This PR enables partial match searching in the Quick Search component (`SearchResultServlet`) by appending a trailing wildcard (`*`) to the `fulltext` query parameter as requested in #149.

## Changes Made
- Updated `SearchResultServlet.java` to append `*` to the `PARAM_FULLTEXT` parameter when the input string is not blank.

---

### ⚠️ Technical Note / Alternative Approach
Appending a wildcard to global `fulltext` allows Lucene to match internal JCR properties (such as `cq:template` containing `content-page`). As a result, searching for short terms like `te` may yield results (e.g., `Form Hidden`) matching internal paths or technical properties rather than visible text.

If we wish to restrict partial matching exclusively to user-visible elements (e.g., `jcr:title`, `pageTitle`, `jcr:description`) to prevent technical metadata false positives, we could consider targeting specific properties via a predicate group instead.

I am open to adjusting this implementation based on feedback from the maintainers!
