### PR TITLE
Update parsing and sanitization of HTML elements in content fragment list.

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/authoringutils/js/authoringMarkupUtils.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/authoringutils/js/authoringMarkupUtils.js
@@ -276,6 +276,26 @@
     }
 
     /**
+     * Parses datasource HTML, sanitizes the body subtree, and returns the sanitized first body child element
+     * for direct import into a live document. Returning a Node instead of serializing to a string avoids a
+     * second HTML parse under a different scripting context
+     *
+     * @param {String} markup - HTML document string from a datasource response
+     * @returns {Element|null} sanitized element to import into a live document, or null when absent
+     */
+    function sanitizeAuthoringEditorResponseMarkupNode(markup) {
+        var doc = parseMarkupDocument(String(markup == null ? "" : markup));
+        if (doc.body) {
+            sanitizeAuthoringMarkupSubtree(doc.body);
+        }
+        var body = doc.body;
+        if (!body || !body.firstElementChild) {
+            return null;
+        }
+        return body.firstElementChild;
+    }
+
+    /**
      * Parses datasource HTML into a document whose body subtree is normalised the same way as for
      * {@code sanitizeAuthoringEditorResponseMarkup}, without collapsing to the first child inner string.
      *
@@ -430,6 +450,7 @@
         stripAsciiControlsAndWhitespaceForSchemeCheck: stripAsciiControlsAndWhitespaceForSchemeCheck,
         buildPageImageThumbnailShellForEditor: buildPageImageThumbnailShellForEditor,
         sanitizeAuthoringEditorResponseMarkup: sanitizeAuthoringEditorResponseMarkup,
+        sanitizeAuthoringEditorResponseMarkupNode: sanitizeAuthoringEditorResponseMarkupNode,
         parseAndNormalizeAuthoringDatasourceMarkup: parseAndNormalizeAuthoringDatasourceMarkup,
         parseAuthoringMarkupStripEventHandlersOnly: parseAuthoringMarkupStripEventHandlersOnly
     };

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/clientlibs/editor/js/contentfragmentlist.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/clientlibs/editor/js/contentfragmentlist.js
@@ -203,6 +203,52 @@
         return getInnerHtmlFromDatasourceResponse(html);
     }
 
+    /**
+     * Resolves the sanitized element names container node for the editor from a datasource response string, for
+     * callers that import DOM nodes directly into the live document rather than re-parsing a serialized string.
+     *
+     * @param {String} html - response body
+     * @returns {Element|null} Sanitized element to import into the live document, or null when the toggle is
+     * disabled or the markup helper is unavailable.
+     */
+    function resolveElementNamesContainerNodeForEditor(html) {
+        if (!isContentFragmentListV1EditorMarkupHelpersEnabled()) {
+            return null;
+        }
+        var markupUtils = getAuthoringMarkupUtils();
+        if (markupUtils && typeof markupUtils.sanitizeAuthoringEditorResponseMarkupNode === "function") {
+            return markupUtils.sanitizeAuthoringEditorResponseMarkupNode(html);
+        }
+        return null;
+    }
+
+    /**
+     * Renders the element names datasource response markup into the given live container element, the way
+     * {@link ContentFragmentListController#_updateElementsHTML} does. Extracted so tests can exercise the exact
+     * production rendering path against a plain container, without a full dialog/controller instance.
+     *
+     * Imports the sanitized markup's child nodes directly into the live document rather than serializing to a
+     * string and reassigning via innerHTML, to avoid a second HTML parse under a different scripting context
+     * (see {@link resolveElementNamesContainerNodeForEditor}). Falls back to the legacy string-based path when
+     * the toggle is disabled or the node-returning helper is unavailable.
+     *
+     * @param {String} html - element names datasource response body
+     * @param {Element} container - live document element that the resolved markup will be rendered into
+     */
+    function renderElementNamesContainerForEditor(html, container) {
+        var sanitizedNode = resolveElementNamesContainerNodeForEditor(html);
+        if (sanitizedNode) {
+            container.innerHTML = "";
+            var childNode = sanitizedNode.firstChild;
+            while (childNode) {
+                container.appendChild(container.ownerDocument.importNode(childNode, true));
+                childNode = childNode.nextSibling;
+            }
+            return;
+        }
+        container.innerHTML = resolveElementNamesContainerInnerHtmlForEditor(html);
+    }
+
     // ui helper
     var ui = $(window).adaptTo("foundation-ui");
 
@@ -395,7 +441,7 @@
      * @param {String} html - HTML document string from the element names datasource response (same shape as the $.get body).
      */
     ContentFragmentListController.prototype._updateElementsHTML = function(html) {
-        this.elementNamesContainer.innerHTML = resolveElementNamesContainerInnerHtmlForEditor(html);
+        renderElementNamesContainerForEditor(html, this.elementNamesContainer);
         this._updateElementNamesField();
     };
 
@@ -552,6 +598,8 @@
             isContentFragmentListV1EditorMarkupHelpersEnabled;
         cflEditorTestApiHost.__CONTENTFRAGMENTLIST_V1_EDITOR_TEST_API.resolveElementNamesContainerInnerHtmlForEditor =
             resolveElementNamesContainerInnerHtmlForEditor;
+        cflEditorTestApiHost.__CONTENTFRAGMENTLIST_V1_EDITOR_TEST_API.renderElementNamesContainerForEditor =
+            renderElementNamesContainerForEditor;
         cflEditorTestApiHost.__CONTENTFRAGMENTLIST_V1_EDITOR_TEST_API.getAuthoringMarkupUtils = getAuthoringMarkupUtils;
         cflEditorTestApiHost.__CONTENTFRAGMENTLIST_V1_EDITOR_TEST_API.isSameOriginDatasourcePath = isSameOriginDatasourcePath;
     }

--- a/content/test/clientlibs/contentfragmentlist/contentfragmentlistEditorTest.js
+++ b/content/test/clientlibs/contentfragmentlist/contentfragmentlistEditorTest.js
@@ -46,6 +46,7 @@ describe("Content Fragment List v1 editor contentfragmentlist.js (Karma-loaded)"
         it("exposes resolve, toggle, and datasource path helpers", function() {
             expect(api).toBeDefined();
             expect(typeof api.resolveElementNamesContainerInnerHtmlForEditor).toBe("function");
+            expect(typeof api.renderElementNamesContainerForEditor).toBe("function");
             expect(typeof api.isContentFragmentListV1EditorMarkupHelpersEnabled).toBe("function");
             expect(typeof api.getAuthoringMarkupUtils).toBe("function");
             expect(typeof api.isSameOriginDatasourcePath).toBe("function");
@@ -86,6 +87,23 @@ describe("Content Fragment List v1 editor contentfragmentlist.js (Karma-loaded)"
                 "<div><div data-granite-coral-multifield-name=\"./elementNames\"><img src=\"x\" onerror=\"alert(1)\"></div></div>";
             const inner = api.resolveElementNamesContainerInnerHtmlForEditor(doc);
             expect(inner.indexOf("onerror")).not.toBe(-1);
+        });
+    });
+
+    describe("renderElementNamesContainerForEditor", function() {
+        const mxssNoscriptPayload =
+            "<div class=\"cmp-cfl-js\"><noscript><!--</noscript><img src=x onerror=alert(1)>--></noscript></div>";
+
+        it("does not resurrect an onerror payload hidden behind a noscript scripting-context mismatch", function() {
+            contentfragmentlistEditorTestToggleOn();
+            const container = document.createElement("div");
+            document.body.appendChild(container);
+            try {
+                api.renderElementNamesContainerForEditor(mxssNoscriptPayload, container);
+                expect(container.querySelector("img[onerror]")).toBeNull();
+            } finally {
+                document.body.removeChild(container);
+            }
         });
     });
 


### PR DESCRIPTION


<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-48197
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
