### PR TITLE
[SITES-49050] [Core Components] Normalize VCF preview response markup before rendering

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     categories="[core.wcm.components.contentfragment.v1.authoring,cq.authoring.editor.hook]"
-    dependencies="[cq.authoring.editor.core]"/>
+    dependencies="[cq.authoring.editor.core,core.wcm.components.commons.editor.authoringutils]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/vcfRenderer.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/vcfRenderer.js
@@ -24,6 +24,56 @@
 
     var _observer = null;
 
+    var CT_SITES_49050 = "CT_SITES-49050";
+
+    /**
+     * Granite feature toggle CT_SITES-49050 gates markup normalization for the VCF preview response.
+     * When Granite or {@code Toggles} is unavailable, helpers are treated as enabled. When the toggle
+     * is explicitly disabled, behaviour matches earlier revisions.
+     *
+     * @returns {Boolean}
+     */
+    function isVcfAuthoringMarkupHelpersEnabled() {
+        if (typeof Granite === "undefined" || !Granite.Toggles || typeof Granite.Toggles.isEnabled !== "function") {
+            return true;
+        }
+        return Granite.Toggles.isEnabled(CT_SITES_49050) !== false;
+    }
+
+    /**
+     * @returns {Object|null} {@code CQ.CoreComponents.AuthoringEditorUtils.markup} when present
+     */
+    function getAuthoringMarkupUtils() {
+        if (window.CQ && window.CQ.CoreComponents && window.CQ.CoreComponents.AuthoringEditorUtils) {
+            return window.CQ.CoreComponents.AuthoringEditorUtils.markup;
+        }
+        return null;
+    }
+
+    /**
+     * Normalizes the VCF preview response markup before it is rendered in the editor, delegating to the
+     * shared authoring markup utility so the preview is inserted consistently with other authoring
+     * editor responses. Falls back to the raw markup when the toggle is disabled or the utility is
+     * unavailable.
+     *
+     * @param {String} html - response body for the VCF preview
+     * @returns {String} markup to assign to {@code innerHTML}
+     */
+    function resolveVcfPreviewMarkup(html) {
+        if (!isVcfAuthoringMarkupHelpersEnabled()) {
+            return html;
+        }
+        var markupUtils = getAuthoringMarkupUtils();
+        if (markupUtils && typeof markupUtils.parseAndNormalizeAuthoringDatasourceMarkup === "function") {
+            var doc = markupUtils.parseAndNormalizeAuthoringDatasourceMarkup(html);
+            if (doc && doc.body) {
+                return doc.body.innerHTML;
+            }
+            return "";
+        }
+        return html;
+    }
+
     function i18n(message) {
         if (typeof window !== "undefined" && window.Granite && window.Granite.I18n) {
             return window.Granite.I18n.get(message);
@@ -141,7 +191,7 @@
                 } else {
                     target.removeAttribute(ATTR_LOAD_FAILED);
                     target.removeAttribute(ATTR_NO_PREVIEW);
-                    target.innerHTML = html;
+                    target.innerHTML = resolveVcfPreviewMarkup(html);
                 }
                 target.removeAttribute(LOADING_ATTR);
             }

--- a/content/test/clientlibs/contentfragment/vcfRendererTest.js
+++ b/content/test/clientlibs/contentfragment/vcfRendererTest.js
@@ -125,6 +125,76 @@ describe("Test VCF renderer for", function() {
         }, 50);
     });
 
+    it("normalizes the VCF preview response markup before injecting", function(done) {
+        window.__vcfHandlerFired = false;
+        // CT_SITES-49050 gates markup normalization; force it enabled (mock default is off).
+        const savedIsEnabled = globalThis.Granite.Toggles.isEnabled;
+        globalThis.Granite.Toggles.isEnabled = function() {
+            return true;
+        };
+
+        const contentFrameDoc = document.createElement("div");
+        const vcfElement = document.createElement("div");
+        vcfElement.className = "cmp-contentfragment cmp-contentfragment--vcf";
+        vcfElement.dataset.cmpContentfragmentVcfUrl = "/cf/preview?" + FRAGMENT_UUID;
+        contentFrameDoc.appendChild(vcfElement);
+
+        Granite.author.ContentFrame.contentWindow = {
+            document: contentFrameDoc
+        };
+
+        const responseMarkup =
+            "<div class=\"cmp-contentfragment-vcf__preview\">visible preview" +
+                "<img src=\"x\" onerror=\"window.__vcfHandlerFired = true\">" +
+                "<script>window.__vcfHandlerFired = true;<\/script>" +
+            "</div>";
+
+        jQuery._ajaxHandler = function(options, resolve) {
+            resolve(responseMarkup);
+
+            setTimeout(function() {
+                globalThis.Granite.Toggles.isEnabled = savedIsEnabled;
+                expect(vcfElement.innerHTML).not.toContain("onerror");
+                expect(vcfElement.innerHTML.toLowerCase()).not.toContain("<script");
+                expect(vcfElement.innerHTML).toContain("visible preview");
+                expect(window.__vcfHandlerFired).toBe(false);
+                delete window.__vcfHandlerFired;
+                done();
+            }, 50);
+        };
+
+        channel.trigger("cq-editor-loaded");
+    });
+
+    it("returns the raw preview markup when markup helpers are disabled", function(done) {
+        const savedIsEnabled = globalThis.Granite.Toggles.isEnabled;
+        globalThis.Granite.Toggles.isEnabled = function(key) {
+            return key !== "CT_SITES-49050";
+        };
+
+        const contentFrameDoc = document.createElement("div");
+        const vcfElement = document.createElement("div");
+        vcfElement.className = "cmp-contentfragment cmp-contentfragment--vcf";
+        vcfElement.dataset.cmpContentfragmentVcfUrl = "/cf/preview?" + FRAGMENT_UUID;
+        contentFrameDoc.appendChild(vcfElement);
+
+        Granite.author.ContentFrame.contentWindow = {
+            document: contentFrameDoc
+        };
+
+        jQuery._ajaxHandler = function(options, resolve) {
+            resolve("<div>Legacy Preview</div>");
+
+            setTimeout(function() {
+                globalThis.Granite.Toggles.isEnabled = savedIsEnabled;
+                expect(vcfElement.innerHTML).toBe("<div>Legacy Preview</div>");
+                done();
+            }, 0);
+        };
+
+        channel.trigger("cq-editor-loaded");
+    });
+
     it("does not load element already being loaded", function(done) {
         const contentFrameDoc = document.createElement("div");
         const vcfElement = document.createElement("div");


### PR DESCRIPTION

Route the Visual Content Fragment preview response through the shared authoring markup utility before inserting it into the editor DOM, so the preview is handled consistently with other authoring editor responses. Add the authoringutils clientlib dependency so the helper is available in the authoring clientlib, and gate the behaviour behind feature toggle CT_SITES-49050.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-49050
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
