### PR TITLE
[SITES-49051] [Core Components] Sanitize authored panel title before rendering in the panel selector

### DIFF
--- a/content/karma.conf.js
+++ b/content/karma.conf.js
@@ -35,6 +35,8 @@ module.exports = function(config) {
             'src/content/jcr_root/apps/core/wcm/components/image/v3/image/clientlibs/site/**/js/*.js',
             'src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/editAction.js',
             'src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/vcfRenderer.js',
+            'src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelselect/js/namespace.js',
+            'src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelselect/js/panelselect.js',
             'src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/authoringutils/js/*.js',
             'src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/htmlidvalidator/js/*.js',
             'src/content/jcr_root/apps/core/wcm/components/commons/v1/clientlibs/editor/checkboxTextfieldTuple/checkboxTextfieldTuple.js',

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelselect/js/panelselect.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelselect/js/panelselect.js
@@ -25,6 +25,37 @@
         indexMarker: ".cmp-panelselector__indexMarker"
     };
 
+    var CT_SITES_49051 = "CT_SITES-49051";
+
+    /**
+     * Granite feature toggle CT_SITES-49051 gates sanitization of the authored panel title before it is
+     * inserted into the selector markup. When Granite or {@code Toggles} is unavailable, sanitization is
+     * treated as enabled. When the toggle is explicitly disabled, behaviour matches earlier revisions.
+     *
+     * @returns {Boolean}
+     */
+    function isPanelTitleSanitizationEnabled() {
+        if (typeof Granite === "undefined" || !Granite.Toggles || typeof Granite.Toggles.isEnabled !== "function") {
+            return true;
+        }
+        return Granite.Toggles.isEnabled(CT_SITES_49051) !== false;
+    }
+
+    /**
+     * Encodes a string for safe insertion into an HTML context.
+     *
+     * @param {String} value - raw input value
+     * @returns {String} the HTML-encoded value
+     */
+    function encodeHtml(value) {
+        return String(value)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#x27;");
+    }
+
     /**
      * @typedef {Object} PanelSelectorConfig Represents a Panel Selector configuration object
      * @property {Granite.author.Editable} editable The [Editable]{@link Granite.author.Editable} against which to create the panel selector
@@ -406,7 +437,8 @@
             }
 
             if (subTitle) {
-                title = title + ": <span class='foundation-layout-util-subtletext'>" + subTitle + "</span>";
+                var safeSubTitle = isPanelTitleSanitizationEnabled() ? encodeHtml(subTitle) : subTitle;
+                title = title + ": <span class='foundation-layout-util-subtletext'>" + safeSubTitle + "</span>";
             }
 
             return title;

--- a/content/test/clientlibs/commons/editor/panelselectTest.js
+++ b/content/test/clientlibs/commons/editor/panelselectTest.js
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright 2026 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+describe("Panel Selector getTitle", function() {
+
+    const PN_PANEL_TITLE = "cq:panelTitle";
+    let getTitle;
+    let savedIsEnabled;
+
+    beforeAll(function() {
+        getTitle = CQ.CoreComponents.PanelSelector.prototype.getTitle;
+    });
+
+    beforeEach(function() {
+        savedIsEnabled = Granite.Toggles.isEnabled;
+    });
+
+    afterEach(function() {
+        Granite.Toggles.isEnabled = savedIsEnabled;
+    });
+
+    it("encodes the authored panel title before building the selector markup", function() {
+        // CT_SITES-49051 gates the sanitization; force it enabled (mock default is off).
+        Granite.Toggles.isEnabled = function() {
+            return true;
+        };
+
+        const item = {};
+        item[PN_PANEL_TITLE] = "</span><img src=\"x\" onerror=\"window.__panelHandlerFired = true\">";
+
+        const title = getTitle({ displayName: "Accordion" }, item, 1);
+
+        expect(title).not.toContain("<img");
+        expect(title).not.toContain("<span class='foundation-layout-util-subtletext'></span>");
+        expect(title).toContain("&lt;");
+
+        // Rendering the title as markup must not create an executable image element.
+        window.__panelHandlerFired = false;
+        const host = document.createElement("div");
+        host.innerHTML = title;
+        expect(host.querySelector("img")).toBeNull();
+        expect(window.__panelHandlerFired).toBe(false);
+        delete window.__panelHandlerFired;
+    });
+
+    it("returns the raw authored title when sanitization is disabled", function() {
+        Granite.Toggles.isEnabled = function(key) {
+            return key !== "CT_SITES-49051";
+        };
+
+        const item = {};
+        item[PN_PANEL_TITLE] = "<b>My Panel</b>";
+
+        const title = getTitle({ displayName: "Accordion" }, item, 1);
+
+        expect(title).toContain("<b>My Panel</b>");
+    });
+
+});

--- a/content/test/mocks.js
+++ b/content/test/mocks.js
@@ -441,6 +441,22 @@ Granite = {
                     }
                 }
             }
+        },
+        ui: {
+            ToolbarAction: function (config) {
+                Object.assign(this, config);
+            }
+        },
+        editableHelper: {
+            getEditableDisplayableName: function (editable) {
+                return (editable && editable.displayName) || "Panel";
+            }
+        },
+        EditorFrame: {
+            editableToolbar: {
+                registerAction: function () {
+                }
+            }
         }
     },
     Toggles: {
@@ -457,6 +473,9 @@ Granite = {
     I18n: {
         get: function(message) {
             return message;
+        },
+        getVar: function(value) {
+            return value;
         }
     }
 };


### PR DESCRIPTION
Encode the authored panel title (cq:panelTitle) before it is concatenated into the panel selector markup, so authored input is rendered as text rather than interpreted as markup. Gated behind feature toggle CT_SITES-49051 with a fallback to previous behaviour when the toggle is disabled.

Add a Karma unit test for the sanitized and fallback code paths, wiring the panel selector clientlib and the required authoring mocks into the test setup.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **main** branch and make sure to check you have incorporated or merged the latest changes!

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | SITES-49051
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
